### PR TITLE
fix(frontend): auto-blur input when sidebar opens on mobile

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -3,10 +3,11 @@
  * 自動拡張するテキストエリアと送信ボタン
  */
 
-import { useState, KeyboardEvent } from 'react';
+import { useState, useRef, useEffect, KeyboardEvent } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import { Capacitor } from '@capacitor/core';
 import { Button } from '@/components/ui/button';
+import { useChatStore } from '@/lib/store';
 
 interface ChatInputProps {
   onSendMessage: (message: string) => void;
@@ -15,6 +16,15 @@ interface ChatInputProps {
 
 export function ChatInput({ onSendMessage, disabled = false }: ChatInputProps) {
   const [input, setInput] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const sidebarOpen = useChatStore((state) => state.sidebarOpen);
+
+  // サイドバーが開いたときに入力欄のフォーカスを外す
+  useEffect(() => {
+    if (sidebarOpen && textareaRef.current) {
+      textareaRef.current.blur();
+    }
+  }, [sidebarOpen]);
 
   const handleSubmit = () => {
     if (!input.trim() || disabled) return;
@@ -37,6 +47,7 @@ export function ChatInput({ onSendMessage, disabled = false }: ChatInputProps) {
     <div className="border-t bg-background p-4">
       <div className="mx-auto flex max-w-3xl gap-2">
         <TextareaAutosize
+          ref={textareaRef}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/frontend/src/components/chat/__tests__/ChatInput.test.tsx
+++ b/frontend/src/components/chat/__tests__/ChatInput.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * ChatInputコンポーネントのテスト
+ * 入力、送信、サイドバー連携を検証
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatInput } from '../ChatInput';
+
+// useChatStoreをモック
+vi.mock('@/lib/store', () => ({
+  useChatStore: vi.fn(),
+}));
+
+// Capacitorをモック
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => false),
+  },
+}));
+
+import { useChatStore } from '@/lib/store';
+import { Capacitor } from '@capacitor/core';
+
+describe('ChatInput', () => {
+  const mockOnSendMessage = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // デフォルトではサイドバーは閉じている
+    // useChatStoreはセレクター関数を受け取るため、適切にモックする
+    (useChatStore as unknown as ReturnType<typeof vi.fn>).mockImplementation((selector) =>
+      selector({ sidebarOpen: false })
+    );
+  });
+
+  // 基本的なレンダリング
+  it('renders input field and submit button', () => {
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    expect(textarea).toBeInTheDocument();
+
+    const submitButton = screen.getByRole('button', { name: '送信' });
+    expect(submitButton).toBeInTheDocument();
+  });
+
+  // メッセージ入力
+  it('allows typing in the textarea', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    await user.type(textarea, 'Hello, world!');
+
+    expect(textarea).toHaveValue('Hello, world!');
+  });
+
+  // 送信ボタンクリックでメッセージ送信
+  it('sends message when submit button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    const submitButton = screen.getByRole('button', { name: '送信' });
+
+    await user.type(textarea, 'Test message');
+    await user.click(submitButton);
+
+    expect(mockOnSendMessage).toHaveBeenCalledWith('Test message');
+    expect(textarea).toHaveValue('');
+  });
+
+  // 空白のみのメッセージは送信しない
+  it('does not send message with only whitespace', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    const submitButton = screen.getByRole('button', { name: '送信' });
+
+    await user.type(textarea, '   ');
+    await user.click(submitButton);
+
+    expect(mockOnSendMessage).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue('   ');
+  });
+
+  // disabledプロパティが機能する
+  it('disables input and button when disabled prop is true', () => {
+    render(<ChatInput onSendMessage={mockOnSendMessage} disabled={true} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    const submitButton = screen.getByRole('button', { name: '送信' });
+
+    expect(textarea).toBeDisabled();
+    expect(submitButton).toBeDisabled();
+  });
+
+  // デスクトップ環境でEnterキーで送信
+  it('sends message on Enter key press (desktop)', async () => {
+    (Capacitor.isNativePlatform as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const user = userEvent.setup();
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    await user.type(textarea, 'Test message');
+    await user.keyboard('{Enter}');
+
+    expect(mockOnSendMessage).toHaveBeenCalledWith('Test message');
+    expect(textarea).toHaveValue('');
+  });
+
+  // デスクトップ環境でShift+Enterで改行
+  it('adds newline on Shift+Enter (desktop)', async () => {
+    (Capacitor.isNativePlatform as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const user = userEvent.setup();
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    await user.type(textarea, 'First line{Shift>}{Enter}{/Shift}Second line');
+
+    expect(textarea).toHaveValue('First line\nSecond line');
+    expect(mockOnSendMessage).not.toHaveBeenCalled();
+  });
+
+  // モバイル環境でEnterキーは改行のみ
+  it('does not send on Enter key press in mobile environment', async () => {
+    (Capacitor.isNativePlatform as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const user = userEvent.setup();
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    await user.type(textarea, 'Test{Enter}message');
+
+    // モバイルではEnterで送信せず、改行が入る
+    expect(mockOnSendMessage).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue('Test\nmessage');
+  });
+
+  // サイドバーが開いたときにフォーカスが外れる（今回の新機能）
+  it('blurs textarea when sidebar is opened', async () => {
+    let sidebarOpen = false;
+    (useChatStore as unknown as ReturnType<typeof vi.fn>).mockImplementation((selector) =>
+      selector({ sidebarOpen })
+    );
+
+    const { rerender } = render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...') as HTMLTextAreaElement;
+
+    // テキストエリアにフォーカスを当てる
+    textarea.focus();
+    expect(textarea).toHaveFocus();
+
+    // サイドバーを開く
+    sidebarOpen = true;
+    (useChatStore as unknown as ReturnType<typeof vi.fn>).mockImplementation((selector) =>
+      selector({ sidebarOpen })
+    );
+    rerender(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    // フォーカスが外れることを確認
+    await waitFor(() => {
+      expect(textarea).not.toHaveFocus();
+    });
+  });
+
+  // サイドバーが閉じている状態ではフォーカスは維持される
+  it('maintains focus when sidebar remains closed', () => {
+    (useChatStore as unknown as ReturnType<typeof vi.fn>).mockImplementation((selector) =>
+      selector({ sidebarOpen: false })
+    );
+
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...') as HTMLTextAreaElement;
+
+    // テキストエリアにフォーカスを当てる
+    textarea.focus();
+    expect(textarea).toHaveFocus();
+
+    // サイドバーは閉じたままなので、フォーカスは維持される
+    expect(textarea).toHaveFocus();
+  });
+
+  // 前後の空白をトリムして送信
+  it('trims whitespace before sending message', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    const submitButton = screen.getByRole('button', { name: '送信' });
+
+    await user.type(textarea, '  Test message  ');
+    await user.click(submitButton);
+
+    expect(mockOnSendMessage).toHaveBeenCalledWith('Test message');
+  });
+
+  // 送信後に入力欄がクリアされる
+  it('clears input after successful submission', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    const submitButton = screen.getByRole('button', { name: '送信' });
+
+    await user.type(textarea, 'Test message');
+    expect(textarea).toHaveValue('Test message');
+
+    await user.click(submitButton);
+    expect(textarea).toHaveValue('');
+  });
+
+  // 空の入力では送信ボタンが無効
+  it('disables submit button when input is empty', () => {
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const submitButton = screen.getByRole('button', { name: '送信' });
+    expect(submitButton).toBeDisabled();
+  });
+
+  // テキスト入力後は送信ボタンが有効
+  it('enables submit button when input has text', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput onSendMessage={mockOnSendMessage} />);
+
+    const textarea = screen.getByPlaceholderText('メッセージを入力...');
+    const submitButton = screen.getByRole('button', { name: '送信' });
+
+    expect(submitButton).toBeDisabled();
+
+    await user.type(textarea, 'Test');
+    expect(submitButton).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
モバイルでメッセージ入力中にサイドバーを開くと、入力欄が残ったままになる問題を修正。
ChatGPTのモバイルアプリのように、サイドバーを開くと入力中状態が自動で解除されるようにした。

## Changes
- `ChatInput.tsx`: useEffectを追加し、sidebarOpenを監視してサイドバーが開いたときにtextarea.blur()を実行
- `ChatInput.test.tsx`: 14件の包括的なテストケースを追加
  - 基本的なレンダリング、入力、送信機能のテスト
  - サイドバー開閉時のフォーカス制御のテスト
  - モバイル/デスクトップ環境での動作テスト

## Test Results
- ✅ All tests passed: 73/73
- ✅ Lint: No errors
- ✅ CodeRabbit review: Passed

## Test plan
- [x] ユニットテスト追加・実行済み
- [ ] モバイル実機での動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * サイドバーが開いた時のチャット入力フィールドのフォーカス動作を改善しました。

* **テスト**
  * チャット入力機能の包括的なテストカバレッジを追加しました。デスクトップとモバイルでの動作、テキスト入力、メッセージ送信、サイドバー操作など各種シナリオに対応しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->