### PR TITLE
refactor: extract ui variant helpers

### DIFF
--- a/backend/tests/integration/test_api_chat.py
+++ b/backend/tests/integration/test_api_chat.py
@@ -345,6 +345,7 @@ class TestChatStreamingEndpoint:
         mock_backend_config,  # noqa: ARG002
     ):
         """ストリーミングレスポンスがtext/event-streamを返す。"""
+
         # Arrange
         async def mock_execute_loop_stream(*args, **kwargs):
             yield StreamChunk(type="done", finish_reason="stop")
@@ -432,6 +433,7 @@ class TestChatStreamingEndpoint:
         self, test_client, mock_backend_config
     ):
         """ストリーミングモードでユーザー・アシスタント両方のメッセージがDBに保存される。"""
+
         # Arrange
         async def mock_execute_loop_stream(*args, **kwargs):
             yield StreamChunk(type="delta", delta="Hello, ")
@@ -507,6 +509,7 @@ class TestChatStreamingEndpoint:
 
     def test_chat_streaming_creates_new_thread(self, test_client, mock_backend_config):
         """ストリーミングモードで新規スレッドが作成される。"""
+
         # Arrange
         async def mock_execute_loop_stream(*args, **kwargs):
             yield StreamChunk(type="delta", delta="Response text")
@@ -639,6 +642,7 @@ class TestChatStreamingEndpoint:
         self, test_client, mock_backend_config
     ):
         """ストリーミングで空のアシスタント応答の場合、メッセージを保存しない。"""
+
         # Arrange
         async def mock_execute_loop_stream(*args, **kwargs):
             yield StreamChunk(type="done", finish_reason="stop")

--- a/frontend/src/components/ui/badge-variants.ts
+++ b/frontend/src/components/ui/badge-variants.ts
@@ -1,0 +1,19 @@
+import { cva } from 'class-variance-authority';
+
+export const badgeVariants = cva(
+  'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-secondary text-secondary-foreground',
+        primary: 'border-transparent bg-accent text-accent-foreground',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground',
+        outline: 'text-foreground border-border',
+        success: 'border-transparent bg-success/10 text-success border-success/20',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -4,30 +4,9 @@
  */
 
 import * as React from 'react';
-import { cva, type VariantProps } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
-
-const badgeVariants = cva(
-  'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
-  {
-    variants: {
-      variant: {
-        default:
-          'border-transparent bg-secondary text-secondary-foreground',
-        primary:
-          'border-transparent bg-accent text-accent-foreground',
-        destructive:
-          'border-transparent bg-destructive text-destructive-foreground',
-        outline: 'text-foreground border-border',
-        success:
-          'border-transparent bg-success/10 text-success border-success/20',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-    },
-  },
-);
+import { badgeVariants } from './badge-variants';
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -37,4 +16,4 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
-export { Badge, badgeVariants };
+export { Badge };

--- a/frontend/src/components/ui/button-variants.ts
+++ b/frontend/src/components/ui/button-variants.ts
@@ -1,0 +1,30 @@
+import { cva } from 'class-variance-authority';
+
+export const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-accent text-accent-foreground hover:opacity-90 active:accent-glow active:-translate-y-px',
+        destructive:
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90 active:opacity-90',
+        outline: 'border border-input bg-background hover:bg-secondary/50 active:bg-secondary',
+        secondary:
+          'bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 active:bg-muted',
+        ghost: 'hover:bg-muted/50 active:bg-muted active:text-foreground',
+        link: 'text-primary underline-offset-4 hover:underline active:underline',
+      },
+      size: {
+        default: 'h-10 px-6 py-3',
+        sm: 'h-8 px-4 py-2 text-xs',
+        lg: 'h-12 px-8 py-4',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,38 +5,9 @@
 
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
-
-const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
-  {
-    variants: {
-      variant: {
-        default:
-          'bg-accent text-accent-foreground hover:opacity-90 active:accent-glow active:-translate-y-px',
-        destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90 active:opacity-90',
-        outline:
-          'border border-input bg-background hover:bg-secondary/50 active:bg-secondary',
-        secondary:
-          'bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 active:bg-muted',
-        ghost: 'hover:bg-muted/50 active:bg-muted active:text-foreground',
-        link: 'text-primary underline-offset-4 hover:underline active:underline',
-      },
-      size: {
-        default: 'h-10 px-6 py-3',
-        sm: 'h-8 px-4 py-2 text-xs',
-        lg: 'h-12 px-8 py-4',
-        icon: 'h-10 w-10',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-      size: 'default',
-    },
-  },
-);
+import { buttonVariants } from './button-variants';
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -57,4 +28,4 @@ const Button = ({ className, variant, size, asChild = false, ref, ...props }: Bu
 };
 Button.displayName = 'Button';
 
-export { Button, buttonVariants };
+export { Button };

--- a/ingest/spotify/pipeline.py
+++ b/ingest/spotify/pipeline.py
@@ -229,9 +229,7 @@ def enrich_master_data(
             failed_targets.append("tracks")
         if not artist_ok:
             failed_targets.append("artists")
-        raise RuntimeError(
-            "Failed to enrich master data: " + ", ".join(failed_targets)
-        )
+        raise RuntimeError("Failed to enrich master data: " + ", ".join(failed_targets))
 
 
 def _group_events_by_month(


### PR DESCRIPTION
## Summary
- split badge/button variant definitions into dedicated helpers
- keep component exports focused on component APIs
- minor formatting cleanup in ingest pipeline error