### PR TITLE
refactor(egopulse): WebUI設定保存方式のリファクタリング

### DIFF
--- a/egopulse/egopulse.config.example.yaml
+++ b/egopulse/egopulse.config.example.yaml
@@ -1,4 +1,5 @@
 default_provider: openai
+default_model: gpt-4o-mini
 
 providers:
   openai:

--- a/egopulse/src/agent_loop/session.rs
+++ b/egopulse/src/agent_loop/session.rs
@@ -397,7 +397,7 @@ mod tests {
     fn test_config(data_dir: String) -> Config {
         Config {
             default_provider: "openai".to_string(),
-            default_model: "gpt-4o-mini".to_string(),
+            default_model: Some("gpt-4o-mini".to_string()),
             providers: std::collections::HashMap::from([(
                 "openai".to_string(),
                 ProviderConfig {

--- a/egopulse/src/agent_loop/session.rs
+++ b/egopulse/src/agent_loop/session.rs
@@ -397,6 +397,7 @@ mod tests {
     fn test_config(data_dir: String) -> Config {
         Config {
             default_provider: "openai".to_string(),
+            default_model: "gpt-4o-mini".to_string(),
             providers: std::collections::HashMap::from([(
                 "openai".to_string(),
                 ProviderConfig {

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -1139,7 +1139,7 @@ mod tests {
     fn test_config(data_dir: String) -> Config {
         Config {
             default_provider: "openai".to_string(),
-            default_model: "gpt-4o-mini".to_string(),
+            default_model: Some("gpt-4o-mini".to_string()),
             providers: std::collections::HashMap::from([(
                 "openai".to_string(),
                 ProviderConfig {

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -1139,6 +1139,7 @@ mod tests {
     fn test_config(data_dir: String) -> Config {
         Config {
             default_provider: "openai".to_string(),
+            default_model: "gpt-4o-mini".to_string(),
             providers: std::collections::HashMap::from([(
                 "openai".to_string(),
                 ProviderConfig {

--- a/egopulse/src/config.rs
+++ b/egopulse/src/config.rs
@@ -26,10 +26,14 @@ pub struct ChannelConfig {
     pub model: Option<String>,
     /// Web: browser/client authentication token.
     pub auth_token: Option<String>,
+    #[serde(skip)]
+    pub file_auth_token: Option<String>,
     /// Web: allowed Origin values for WebSocket connections.
     pub allowed_origins: Option<Vec<String>>,
     /// Discord / Telegram 共通: bot token
     pub bot_token: Option<String>,
+    #[serde(skip)]
+    pub file_bot_token: Option<String>,
     /// Telegram: bot username (group メンション検知用)
     pub bot_username: Option<String>,
     /// Telegram: DM 許可ユーザー ID (空 = 全員許可)
@@ -164,8 +168,8 @@ struct FileConfig {
 #[derive(Clone)]
 pub struct Config {
     pub default_provider: String,
-    /// Resolved global default model (YAML `default_model` or provider's `default_model`).
-    pub default_model: String,
+    /// Optional global model override (YAML `default_model`).
+    pub default_model: Option<String>,
     pub providers: HashMap<String, ProviderConfig>,
     pub data_dir: String,
     pub log_level: String,
@@ -220,7 +224,10 @@ impl Config {
             label: provider.label.clone(),
             base_url: provider.base_url.clone(),
             api_key: provider.api_key.clone(),
-            model: self.default_model.clone(),
+            model: self
+                .default_model
+                .clone()
+                .unwrap_or_else(|| provider.default_model.clone()),
         }
     }
 
@@ -246,7 +253,11 @@ impl Config {
             .channels
             .get(&channel_key)
             .and_then(|config| config.model.clone())
-            .unwrap_or_else(|| self.default_model.clone());
+            .unwrap_or_else(|| {
+                self.default_model
+                    .clone()
+                    .unwrap_or_else(|| provider.default_model.clone())
+            });
 
         Ok(ResolvedLlmConfig {
             provider: provider_name,
@@ -416,6 +427,8 @@ fn normalize_channels(
         if key.is_empty() {
             continue;
         }
+        config.file_auth_token = normalize_string(config.auth_token.clone());
+        config.file_bot_token = normalize_string(config.bot_token.clone());
         config.provider = normalize_string(config.provider);
         config.model = normalize_string(config.model);
         normalized.insert(key, config);
@@ -578,13 +591,7 @@ fn build_config(
         });
     }
 
-    let default_model = normalize_string(file_default_model).unwrap_or_else(|| {
-        providers
-            .get(&default_provider)
-            .expect("validated above")
-            .default_model
-            .clone()
-    });
+    let default_model = normalize_string(file_default_model);
 
     let data_dir = default_data_dir().to_string_lossy().into_owned();
 
@@ -775,7 +782,8 @@ fn is_local_url(value: &str) -> bool {
 #[derive(Serialize)]
 struct SerializableConfig {
     default_provider: String,
-    default_model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_model: Option<String>,
     data_dir: String,
     log_level: String,
     compaction_timeout_secs: u64,
@@ -857,9 +865,9 @@ impl From<&Config> for SerializableConfig {
                         host: c.host.clone(),
                         provider: c.provider.clone(),
                         model: c.model.clone(),
-                        auth_token: c.auth_token.clone(),
+                        auth_token: c.file_auth_token.clone(),
                         allowed_origins: c.allowed_origins.clone(),
-                        bot_token: c.bot_token.clone(),
+                        bot_token: c.file_bot_token.clone(),
                         bot_username: c.bot_username.clone(),
                         allowed_user_ids: c.allowed_user_ids.clone(),
                         allowed_channels: c.allowed_channels.clone(),
@@ -1240,8 +1248,8 @@ channels:
 
         let config = Config::load(Some(&file_path)).expect("load config");
 
-        // config.default_model takes the YAML-level value
-        assert_eq!(config.default_model, "gpt-5");
+        // config.default_model preserves the YAML-level override as Some
+        assert_eq!(config.default_model, Some("gpt-5".to_string()));
 
         // resolve_global_llm uses config.default_model
         let global = config.resolve_global_llm();
@@ -1275,7 +1283,7 @@ channels:
 
         let config = Config::load(Some(&file_path)).expect("load config");
 
-        assert_eq!(config.default_model, "gpt-4o-mini");
+        assert_eq!(config.default_model, None);
         let global = config.resolve_global_llm();
         assert_eq!(global.model, "gpt-4o-mini");
     }

--- a/egopulse/src/config.rs
+++ b/egopulse/src/config.rs
@@ -776,6 +776,12 @@ fn is_local_url(value: &str) -> bool {
 struct SerializableConfig {
     default_provider: String,
     default_model: String,
+    data_dir: String,
+    log_level: String,
+    compaction_timeout_secs: u64,
+    max_history_messages: usize,
+    max_session_messages: usize,
+    compact_keep_recent: usize,
     providers: HashMap<String, SerializableProvider>,
     channels: HashMap<String, SerializableChannel>,
 }
@@ -865,6 +871,12 @@ impl From<&Config> for SerializableConfig {
         Self {
             default_provider: config.default_provider.clone(),
             default_model: config.default_model.clone(),
+            data_dir: config.data_dir.clone(),
+            log_level: config.log_level.clone(),
+            compaction_timeout_secs: config.compaction_timeout_secs,
+            max_history_messages: config.max_history_messages,
+            max_session_messages: config.max_session_messages,
+            compact_keep_recent: config.compact_keep_recent,
             providers,
             channels,
         }
@@ -930,7 +942,10 @@ fn write_atomically(path: &Path, content: &str) -> Result<(), EgoPulseError> {
         .map_err(|error| EgoPulseError::Internal(error.to_string()))?;
     drop(temp_file);
 
-    fs::rename(&temp_path, path).map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+    if let Err(error) = fs::rename(&temp_path, path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(EgoPulseError::Internal(error.to_string()));
+    }
 
     if let Ok(dir) = OpenOptions::new().read(true).open(parent) {
         let _ = dir.sync_all();

--- a/egopulse/src/config.rs
+++ b/egopulse/src/config.rs
@@ -1,13 +1,18 @@
 use std::collections::HashMap;
 use std::env;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
 
-use secrecy::SecretString;
-use serde::Deserialize;
+use fs2::FileExt;
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::error::ConfigError;
+use crate::error::{ConfigError, EgoPulseError};
+
+static CONFIG_WRITE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 /// Per-channel configuration (web, discord, telegram).
 #[derive(Clone, Deserialize, Default)]
@@ -144,6 +149,8 @@ struct FileProviderConfig {
 #[derive(Debug, Deserialize, Default)]
 struct FileConfig {
     default_provider: Option<String>,
+    /// グローバルでのモデル選択（YAMLトップレベル）。未指定時は default_provider の default_model にフォールバック。
+    default_model: Option<String>,
     providers: Option<HashMap<String, FileProviderConfig>>,
     log_level: Option<String>,
     compaction_timeout_secs: Option<u64>,
@@ -157,6 +164,8 @@ struct FileConfig {
 #[derive(Clone)]
 pub struct Config {
     pub default_provider: String,
+    /// Resolved global default model (YAML `default_model` or provider's `default_model`).
+    pub default_model: String,
     pub providers: HashMap<String, ProviderConfig>,
     pub data_dir: String,
     pub log_level: String,
@@ -171,6 +180,7 @@ impl std::fmt::Debug for Config {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Config")
             .field("default_provider", &self.default_provider)
+            .field("default_model", &self.default_model)
             .field("providers", &self.providers)
             .field("data_dir", &self.data_dir)
             .field("log_level", &self.log_level)
@@ -210,7 +220,7 @@ impl Config {
             label: provider.label.clone(),
             base_url: provider.base_url.clone(),
             api_key: provider.api_key.clone(),
-            model: provider.default_model.clone(),
+            model: self.default_model.clone(),
         }
     }
 
@@ -236,7 +246,7 @@ impl Config {
             .channels
             .get(&channel_key)
             .and_then(|config| config.model.clone())
-            .unwrap_or_else(|| provider.default_model.clone());
+            .unwrap_or_else(|| self.default_model.clone());
 
         Ok(ResolvedLlmConfig {
             provider: provider_name,
@@ -356,6 +366,22 @@ impl Config {
     /// Workspace directory for agent file operations.
     pub fn workspace_dir(&self) -> PathBuf {
         default_workspace_dir()
+    }
+
+    /// Atomically writes the current config to a YAML file.
+    ///
+    /// Uses the global `CONFIG_WRITE_LOCK` for in-process mutual exclusion and an
+    /// file-level lock (`fs2`) for cross-process safety. The write is atomic via
+    /// temp-file + rename.
+    pub fn save_yaml(&self, path: &Path) -> Result<(), EgoPulseError> {
+        let _guard = CONFIG_WRITE_LOCK
+            .lock()
+            .map_err(|_| EgoPulseError::Internal("config write lock poisoned".to_string()))?;
+        let _lock_file = acquire_config_lock(path)?;
+
+        let yaml = serde_yml::to_string(&SerializableConfig::from(self))
+            .map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+        write_atomically(path, &yaml)
     }
 }
 
@@ -530,6 +556,7 @@ fn build_config(
     };
     let FileConfig {
         default_provider: file_default_provider,
+        default_model: file_default_model,
         providers: file_providers,
         log_level: file_log_level,
         compaction_timeout_secs: file_compaction_timeout_secs,
@@ -550,6 +577,14 @@ fn build_config(
             provider: default_provider,
         });
     }
+
+    let default_model = normalize_string(file_default_model).unwrap_or_else(|| {
+        providers
+            .get(&default_provider)
+            .expect("validated above")
+            .default_model
+            .clone()
+    });
 
     let data_dir = default_data_dir().to_string_lossy().into_owned();
 
@@ -573,6 +608,7 @@ fn build_config(
 
     let config = Config {
         default_provider,
+        default_model,
         providers,
         data_dir,
         log_level,
@@ -732,6 +768,175 @@ fn is_local_url(value: &str) -> bool {
         url.host_str(),
         Some("localhost") | Some("127.0.0.1") | Some("0.0.0.0") | Some("::1")
     )
+}
+
+// --- Serialization helpers for save_yaml ---
+
+#[derive(Serialize)]
+struct SerializableConfig {
+    default_provider: String,
+    default_model: String,
+    providers: HashMap<String, SerializableProvider>,
+    channels: HashMap<String, SerializableChannel>,
+}
+
+#[derive(Serialize)]
+struct SerializableProvider {
+    label: String,
+    base_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    api_key: Option<String>,
+    default_model: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    models: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct SerializableChannel {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auth_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_origins: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bot_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bot_username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_user_ids: Option<Vec<i64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_channels: Option<Vec<u64>>,
+}
+
+impl From<&Config> for SerializableConfig {
+    fn from(config: &Config) -> Self {
+        let providers = config
+            .providers
+            .iter()
+            .map(|(id, p)| {
+                (
+                    id.clone(),
+                    SerializableProvider {
+                        label: p.label.clone(),
+                        base_url: p.base_url.clone(),
+                        api_key: p
+                            .api_key
+                            .as_ref()
+                            .map(|s| ExposeSecret::expose_secret(s).to_string()),
+                        default_model: p.default_model.clone(),
+                        models: p.models.clone(),
+                    },
+                )
+            })
+            .collect();
+
+        let channels = config
+            .channels
+            .iter()
+            .map(|(id, c)| {
+                (
+                    id.clone(),
+                    SerializableChannel {
+                        enabled: c.enabled,
+                        port: c.port,
+                        host: c.host.clone(),
+                        provider: c.provider.clone(),
+                        model: c.model.clone(),
+                        auth_token: c.auth_token.clone(),
+                        allowed_origins: c.allowed_origins.clone(),
+                        bot_token: c.bot_token.clone(),
+                        bot_username: c.bot_username.clone(),
+                        allowed_user_ids: c.allowed_user_ids.clone(),
+                        allowed_channels: c.allowed_channels.clone(),
+                    },
+                )
+            })
+            .collect();
+
+        Self {
+            default_provider: config.default_provider.clone(),
+            default_model: config.default_model.clone(),
+            providers,
+            channels,
+        }
+    }
+}
+
+fn acquire_config_lock(path: &Path) -> Result<File, EgoPulseError> {
+    let lock_path = {
+        let parent = path
+            .parent()
+            .ok_or_else(|| EgoPulseError::Internal("config path has no parent".to_string()))?;
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("egopulse.config.yaml");
+        parent.join(format!(".{file_name}.lock"))
+    };
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+    }
+
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+    lock_file
+        .lock_exclusive()
+        .map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+    Ok(lock_file)
+}
+
+fn write_atomically(path: &Path, content: &str) -> Result<(), EgoPulseError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| EgoPulseError::Internal("config path has no parent".to_string()))?;
+    fs::create_dir_all(parent).map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+
+    let temp_path = parent.join(format!(
+        ".{}.tmp-{}-{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("egopulse.config.yaml"),
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+
+    let mut temp_file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temp_path)
+        .map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+    temp_file
+        .write_all(content.as_bytes())
+        .map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+    temp_file
+        .flush()
+        .map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+    temp_file
+        .sync_all()
+        .map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+    drop(temp_file);
+
+    fs::rename(&temp_path, path).map_err(|error| EgoPulseError::Internal(error.to_string()))?;
+
+    if let Ok(dir) = OpenOptions::new().read(true).open(parent) {
+        let _ = dir.sync_all();
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -994,5 +1199,120 @@ channels:
         let config =
             Config::load_allow_missing_api_key(Some(&file_path)).expect("allow missing key");
         assert!(config.web_llm().expect("resolved").api_key.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn default_model_in_yaml_overrides_provider_default() {
+        let env = EnvGuard::new();
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        env.set("HOME", temp_dir.path());
+        let file_path = write_config(
+            &temp_dir,
+            r#"default_provider: openai
+default_model: gpt-5
+providers:
+  openai:
+    label: OpenAI
+    base_url: https://api.openai.com/v1
+    api_key: sk-openai
+    default_model: gpt-4o-mini
+channels:
+  web:
+    enabled: true
+    auth_token: web-secret"#,
+        );
+
+        let config = Config::load(Some(&file_path)).expect("load config");
+
+        // config.default_model takes the YAML-level value
+        assert_eq!(config.default_model, "gpt-5");
+
+        // resolve_global_llm uses config.default_model
+        let global = config.resolve_global_llm();
+        assert_eq!(global.model, "gpt-5");
+
+        // channel without model override also falls back to config.default_model
+        let web_llm = config.web_llm().expect("web llm");
+        assert_eq!(web_llm.model, "gpt-5");
+    }
+
+    #[test]
+    #[serial]
+    fn default_model_falls_back_to_provider_default() {
+        let env = EnvGuard::new();
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        env.set("HOME", temp_dir.path());
+        let file_path = write_config(
+            &temp_dir,
+            r#"default_provider: openai
+providers:
+  openai:
+    label: OpenAI
+    base_url: https://api.openai.com/v1
+    api_key: sk-openai
+    default_model: gpt-4o-mini
+channels:
+  web:
+    enabled: true
+    auth_token: web-secret"#,
+        );
+
+        let config = Config::load(Some(&file_path)).expect("load config");
+
+        assert_eq!(config.default_model, "gpt-4o-mini");
+        let global = config.resolve_global_llm();
+        assert_eq!(global.model, "gpt-4o-mini");
+    }
+
+    #[test]
+    #[serial]
+    fn model_resolution_chain_channel_overrides_global() {
+        let env = EnvGuard::new();
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        env.set("HOME", temp_dir.path());
+        let file_path = write_config(
+            &temp_dir,
+            r#"default_provider: openai
+default_model: gpt-5
+providers:
+  openai:
+    label: OpenAI
+    base_url: https://api.openai.com/v1
+    api_key: sk-openai
+    default_model: gpt-4o-mini
+  local:
+    label: Local
+    base_url: http://127.0.0.1:1234/v1
+    default_model: qwen2.5
+channels:
+  web:
+    enabled: true
+    auth_token: web-secret
+    model: gpt-4o
+  discord:
+    enabled: false
+    provider: local
+    model: qwen2.5-coder"#,
+        );
+
+        let config = Config::load(Some(&file_path)).expect("load config");
+
+        // channel.model > config.default_model
+        let web_llm = config.web_llm().expect("web llm");
+        assert_eq!(web_llm.model, "gpt-4o");
+
+        // channel.model > config.default_model (different provider)
+        let discord_llm = config
+            .resolve_llm_for_channel("discord")
+            .expect("discord llm");
+        assert_eq!(discord_llm.model, "qwen2.5-coder");
+        assert_eq!(discord_llm.provider, "local");
+
+        // channel without model → config.default_model (not provider.default_model)
+        let telegram_llm = config
+            .resolve_llm_for_channel("telegram")
+            .expect("telegram llm");
+        assert_eq!(telegram_llm.model, "gpt-5");
     }
 }

--- a/egopulse/src/config_store.rs
+++ b/egopulse/src/config_store.rs
@@ -1,4 +1,9 @@
 //! 設定 YAML の排他更新と安全な永続化を扱うモジュール。
+//!
+//! このモジュールは旧式の `serde_yml::Value` ベースの操作を提供する。
+//! 新規の保存処理では `Config::save_yaml()` を使用すること。
+
+#![allow(dead_code)]
 
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;

--- a/egopulse/src/llm_profile.rs
+++ b/egopulse/src/llm_profile.rs
@@ -111,11 +111,7 @@ async fn handle_provider_command(
     let mut config = Config::load_allow_missing_api_key(Some(path))?;
     if scope == GLOBAL_SCOPE {
         config.default_provider = value.to_string();
-        config.default_model = config
-            .providers
-            .get(value)
-            .map(|p| p.default_model.clone())
-            .unwrap_or_default();
+        config.default_model = None;
     } else {
         let channel = config.channels.entry(scope.clone()).or_default();
         channel.provider = Some(value.to_string());
@@ -149,13 +145,12 @@ async fn handle_model_command(
     let value = first_non_scope_arg(&parts[1..]).unwrap_or_default();
     if value == "reset" {
         if scope == GLOBAL_SCOPE {
-            let provider = config.global_provider();
             let mut config = Config::load_allow_missing_api_key(Some(config_path(state)?))?;
-            config.default_model = provider.default_model.clone();
+            config.default_model = None;
             config.save_yaml(config_path(state)?)?;
             return Ok(format!(
                 "scope={scope} model reset -> {}",
-                provider.default_model
+                config.global_provider().default_model
             ));
         }
         let path = config_path(state)?;
@@ -172,7 +167,7 @@ async fn handle_model_command(
     let path = config_path(state)?;
     let mut config = Config::load_allow_missing_api_key(Some(path))?;
     if scope == GLOBAL_SCOPE {
-        config.default_model = value.to_string();
+        config.default_model = Some(value.to_string());
         if let Some(provider) = config.providers.get_mut(&config.default_provider) {
             if !provider.models.iter().any(|m| m == value) {
                 provider.models.push(value.to_string());

--- a/egopulse/src/llm_profile.rs
+++ b/egopulse/src/llm_profile.rs
@@ -2,11 +2,8 @@
 
 use std::path::Path;
 
-use serde_yml::{Mapping, Value};
-
 use crate::agent_loop::SurfaceContext;
 use crate::config::Config;
-use crate::config_store::update_yaml;
 use crate::error::EgoPulseError;
 use crate::runtime::AppState;
 
@@ -93,7 +90,12 @@ async fn handle_provider_command(
             return Ok("global scope uses default_provider and cannot reset".to_string());
         }
         let path = config_path(state)?;
-        save_scope_provider(path, &scope, None)?;
+        let mut config = Config::load_allow_missing_api_key(Some(path))?;
+        if let Some(channel) = config.channels.get_mut(&scope) {
+            channel.provider = None;
+            channel.model = None;
+        }
+        config.save_yaml(path)?;
         let updated = Config::load_allow_missing_api_key(Some(path))?;
         let resolved = resolved_for_scope(&updated, &scope)?;
         return Ok(format!(
@@ -106,7 +108,20 @@ async fn handle_provider_command(
         return Ok(format!("unknown provider: {value}"));
     }
     let path = config_path(state)?;
-    save_scope_provider(path, &scope, Some(value))?;
+    let mut config = Config::load_allow_missing_api_key(Some(path))?;
+    if scope == GLOBAL_SCOPE {
+        config.default_provider = value.to_string();
+        config.default_model = config
+            .providers
+            .get(value)
+            .map(|p| p.default_model.clone())
+            .unwrap_or_default();
+    } else {
+        let channel = config.channels.entry(scope.clone()).or_default();
+        channel.provider = Some(value.to_string());
+        channel.model = None;
+    }
+    config.save_yaml(path)?;
     let updated = Config::load_allow_missing_api_key(Some(path))?;
     let resolved = resolved_for_scope(&updated, &scope)?;
     Ok(format!(
@@ -134,19 +149,40 @@ async fn handle_model_command(
     let value = first_non_scope_arg(&parts[1..]).unwrap_or_default();
     if value == "reset" {
         if scope == GLOBAL_SCOPE {
-            return Ok(
-                "global scope model is stored on the provider default and cannot reset".to_string(),
-            );
+            let provider = config.global_provider();
+            let mut config = Config::load_allow_missing_api_key(Some(config_path(state)?))?;
+            config.default_model = provider.default_model.clone();
+            config.save_yaml(config_path(state)?)?;
+            return Ok(format!(
+                "scope={scope} model reset -> {}",
+                provider.default_model
+            ));
         }
         let path = config_path(state)?;
-        save_scope_model(path, &scope, None, &resolved.provider)?;
+        let mut config = Config::load_allow_missing_api_key(Some(path))?;
+        if let Some(channel) = config.channels.get_mut(&scope) {
+            channel.model = None;
+        }
+        config.save_yaml(path)?;
         let updated = Config::load_allow_missing_api_key(Some(path))?;
         let effective = resolved_for_scope(&updated, &scope)?;
         return Ok(format!("scope={scope} model reset -> {}", effective.model));
     }
 
     let path = config_path(state)?;
-    save_scope_model(path, &scope, Some(value), &resolved.provider)?;
+    let mut config = Config::load_allow_missing_api_key(Some(path))?;
+    if scope == GLOBAL_SCOPE {
+        config.default_model = value.to_string();
+        if let Some(provider) = config.providers.get_mut(&config.default_provider) {
+            if !provider.models.iter().any(|m| m == value) {
+                provider.models.push(value.to_string());
+            }
+        }
+    } else {
+        let channel = config.channels.entry(scope.clone()).or_default();
+        channel.model = Some(value.to_string());
+    }
+    config.save_yaml(path)?;
     let updated = Config::load_allow_missing_api_key(Some(path))?;
     let effective = resolved_for_scope(&updated, &scope)?;
     Ok(format!(
@@ -217,138 +253,5 @@ fn resolved_for_scope(
     match scope {
         GLOBAL_SCOPE => Ok(config.resolve_global_llm()),
         channel => Ok(config.resolve_llm_for_channel(channel)?),
-    }
-}
-
-fn save_scope_provider(
-    path: &Path,
-    scope: &str,
-    provider: Option<&str>,
-) -> Result<(), EgoPulseError> {
-    update_yaml(path, |root| {
-        if scope == GLOBAL_SCOPE {
-            let provider = provider
-                .ok_or_else(|| EgoPulseError::Internal("provider is required".to_string()))?;
-            set_string(root, "default_provider", provider);
-        } else {
-            let channel = ensure_channel_mapping(root, scope);
-            match provider {
-                Some(provider) => {
-                    channel.insert(
-                        Value::String("provider".to_string()),
-                        Value::String(provider.to_string()),
-                    );
-                }
-                None => {
-                    channel.remove(Value::String("provider".to_string()));
-                }
-            }
-            channel.remove(Value::String("model".to_string()));
-        }
-        Ok(())
-    })
-}
-
-fn save_scope_model(
-    path: &Path,
-    scope: &str,
-    model: Option<&str>,
-    provider: &str,
-) -> Result<(), EgoPulseError> {
-    update_yaml(path, |root| {
-        if scope == GLOBAL_SCOPE {
-            let model =
-                model.ok_or_else(|| EgoPulseError::Internal("model is required".to_string()))?;
-            let provider_mapping = ensure_provider_mapping(root, provider);
-            provider_mapping.insert(
-                Value::String("default_model".to_string()),
-                Value::String(model.to_string()),
-            );
-            let mut models = provider_mapping
-                .get(Value::String("models".to_string()))
-                .and_then(value_as_string_vec)
-                .unwrap_or_default();
-            if !models.iter().any(|candidate| candidate == model) {
-                models.push(model.to_string());
-            }
-            provider_mapping.insert(
-                Value::String("models".to_string()),
-                serde_yml::to_value(models)
-                    .map_err(|error| EgoPulseError::Internal(error.to_string()))?,
-            );
-        } else {
-            let channel = ensure_channel_mapping(root, scope);
-            match model {
-                Some(model) => {
-                    channel.insert(
-                        Value::String("model".to_string()),
-                        Value::String(model.to_string()),
-                    );
-                }
-                None => {
-                    channel.remove(Value::String("model".to_string()));
-                }
-            }
-        }
-        Ok(())
-    })
-}
-
-fn ensure_provider_mapping<'a>(root: &'a mut Value, provider: &str) -> &'a mut Mapping {
-    let providers = ensure_mapping(entry_mut(root, "providers"));
-    ensure_mapping(
-        providers
-            .entry(Value::String(provider.to_string()))
-            .or_insert(Value::Mapping(Mapping::new())),
-    )
-}
-
-fn ensure_channel_mapping<'a>(root: &'a mut Value, channel: &str) -> &'a mut Mapping {
-    let channels = ensure_mapping(entry_mut(root, "channels"));
-    ensure_mapping(
-        channels
-            .entry(Value::String(channel.to_string()))
-            .or_insert(Value::Mapping(Mapping::new())),
-    )
-}
-
-fn set_string(root: &mut Value, key: &str, value: &str) {
-    let mapping = ensure_mapping(root);
-    mapping.insert(
-        Value::String(key.to_string()),
-        Value::String(value.to_string()),
-    );
-}
-
-fn entry_mut<'a>(root: &'a mut Value, key: &str) -> &'a mut Value {
-    ensure_mapping(root)
-        .entry(Value::String(key.to_string()))
-        .or_insert(Value::Mapping(Mapping::new()))
-}
-
-fn ensure_mapping(value: &mut Value) -> &mut Mapping {
-    if !matches!(value, Value::Mapping(_)) {
-        *value = Value::Mapping(Mapping::new());
-    }
-    match value {
-        Value::Mapping(mapping) => mapping,
-        _ => unreachable!(),
-    }
-}
-
-fn value_as_string_vec(value: &Value) -> Option<Vec<String>> {
-    match value {
-        Value::Sequence(values) => Some(
-            values
-                .iter()
-                .filter_map(|value| match value {
-                    Value::String(value) => {
-                        Some(value.trim().to_string()).filter(|value| !value.is_empty())
-                    }
-                    _ => None,
-                })
-                .collect::<Vec<_>>(),
-        ),
-        _ => None,
     }
 }

--- a/egopulse/src/tools.rs
+++ b/egopulse/src/tools.rs
@@ -2007,7 +2007,7 @@ mod tests {
     fn test_config(data_dir: &str) -> Config {
         Config {
             default_provider: "local".to_string(),
-            default_model: "gpt-4o-mini".to_string(),
+            default_model: Some("gpt-4o-mini".to_string()),
             providers: std::collections::HashMap::from([(
                 "local".to_string(),
                 ProviderConfig {

--- a/egopulse/src/tools.rs
+++ b/egopulse/src/tools.rs
@@ -2007,6 +2007,7 @@ mod tests {
     fn test_config(data_dir: &str) -> Config {
         Config {
             default_provider: "local".to_string(),
+            default_model: "gpt-4o-mini".to_string(),
             providers: std::collections::HashMap::from([(
                 "local".to_string(),
                 ProviderConfig {

--- a/egopulse/src/web/auth.rs
+++ b/egopulse/src/web/auth.rs
@@ -173,7 +173,7 @@ mod tests {
     fn config_with_web(auth_token: Option<&str>, allowed_origins: Option<Vec<String>>) -> Config {
         Config {
             default_provider: "local".to_string(),
-            default_model: "gpt-4o-mini".to_string(),
+            default_model: Some("gpt-4o-mini".to_string()),
             providers: std::collections::HashMap::from([(
                 "local".to_string(),
                 ProviderConfig {

--- a/egopulse/src/web/auth.rs
+++ b/egopulse/src/web/auth.rs
@@ -173,6 +173,7 @@ mod tests {
     fn config_with_web(auth_token: Option<&str>, allowed_origins: Option<Vec<String>>) -> Config {
         Config {
             default_provider: "local".to_string(),
+            default_model: "gpt-4o-mini".to_string(),
             providers: std::collections::HashMap::from([(
                 "local".to_string(),
                 ProviderConfig {

--- a/egopulse/src/web/config.rs
+++ b/egopulse/src/web/config.rs
@@ -151,24 +151,12 @@ pub(super) async fn api_put_config(
         Err(error) => return Err((StatusCode::BAD_REQUEST, error.to_string())),
     };
 
-    let selected_provider_default_model = config
-        .providers
-        .get(default_provider)
-        .map(|provider| provider.default_model.clone())
-        .ok_or_else(|| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("unknown provider: {default_provider}"),
-            )
-        })?;
-
     config.default_provider = default_provider.to_string();
-    config.default_model =
-        if config.default_model.is_none() && default_model == selected_provider_default_model {
-            None
-        } else {
-            Some(default_model.to_string())
-        };
+    config.default_model = if default_model.is_empty() {
+        None
+    } else {
+        Some(default_model.to_string())
+    };
 
     let web_enabled = request.web_enabled;
     let web_host = request.web_host.trim().to_string();
@@ -186,7 +174,8 @@ pub(super) async fn api_put_config(
     }
 
     if let Some(overrides) = request.channel_overrides {
-        apply_channel_overrides(&mut config, overrides);
+        apply_channel_overrides(&mut config, overrides)
+            .map_err(|error| (StatusCode::BAD_REQUEST, error.to_string()))?;
     }
 
     config
@@ -259,7 +248,7 @@ fn apply_provider_updates(config: &mut Config, updates: HashMap<String, Provider
                 _ => continue,
             };
 
-            let models = update
+            let mut models = update
                 .models
                 .unwrap_or_default()
                 .into_iter()
@@ -272,6 +261,10 @@ fn apply_provider_updates(config: &mut Config, updates: HashMap<String, Provider
                     }
                 })
                 .collect::<Vec<_>>();
+
+            if !models.contains(&default_model) {
+                models.push(default_model.clone());
+            }
 
             let mut api_key = None;
             apply_api_key_update(&mut api_key, update.api_key);
@@ -307,24 +300,32 @@ fn apply_api_key_update(current: &mut Option<SecretString>, raw_update: Option<S
 fn apply_channel_overrides(
     config: &mut Config,
     overrides: HashMap<String, ChannelOverrideUpdatePayload>,
-) {
+) -> Result<(), ConfigError> {
     for (channel, update) in overrides {
         let key = channel.trim().to_ascii_lowercase();
         if key.is_empty() || key == "web" {
             continue;
         }
 
-        let entry = config.channels.entry(key).or_default();
+        let entry = config.channels.entry(key.clone()).or_default();
 
-        match update.provider {
-            Some(provider) if !provider.trim().is_empty() => {
-                entry.provider = Some(provider.trim().to_string());
+        let provider_name = match update.provider {
+            Some(provider) => {
+                let trimmed = provider.trim();
+                let channel_name = key.clone();
+                if trimmed.is_empty() {
+                    None
+                } else if config.providers.contains_key(trimmed) {
+                    Some(trimmed.to_string())
+                } else {
+                    return Err(ConfigError::InvalidProviderReference {
+                        provider: format!("{} for channel {}", trimmed, channel_name),
+                    });
+                }
             }
-            Some(_) => {
-                entry.provider = None;
-            }
-            None => {}
-        }
+            None => entry.provider.clone(),
+        };
+        entry.provider = provider_name;
 
         match update.model {
             Some(model) if !model.trim().is_empty() => {
@@ -336,6 +337,7 @@ fn apply_channel_overrides(
             None => {}
         }
     }
+    Ok(())
 }
 
 fn default_payload(path: &std::path::Path) -> ConfigPayload {

--- a/egopulse/src/web/config.rs
+++ b/egopulse/src/web/config.rs
@@ -151,8 +151,24 @@ pub(super) async fn api_put_config(
         Err(error) => return Err((StatusCode::BAD_REQUEST, error.to_string())),
     };
 
+    let selected_provider_default_model = config
+        .providers
+        .get(default_provider)
+        .map(|provider| provider.default_model.clone())
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("unknown provider: {default_provider}"),
+            )
+        })?;
+
     config.default_provider = default_provider.to_string();
-    config.default_model = default_model.to_string();
+    config.default_model =
+        if config.default_model.is_none() && default_model == selected_provider_default_model {
+            None
+        } else {
+            Some(default_model.to_string())
+        };
 
     let web_enabled = request.web_enabled;
     let web_host = request.web_host.trim().to_string();

--- a/egopulse/src/web/config.rs
+++ b/egopulse/src/web/config.rs
@@ -186,10 +186,7 @@ pub(super) async fn api_put_config(
     })))
 }
 
-fn apply_provider_updates(
-    config: &mut Config,
-    updates: HashMap<String, ProviderUpdatePayload>,
-) {
+fn apply_provider_updates(config: &mut Config, updates: HashMap<String, ProviderUpdatePayload>) {
     for (id, update) in updates {
         let id = id.trim().to_ascii_lowercase();
         if id.is_empty() {
@@ -277,10 +274,7 @@ fn apply_provider_updates(
     }
 }
 
-fn apply_api_key_update(
-    current: &mut Option<SecretString>,
-    raw_update: Option<String>,
-) {
+fn apply_api_key_update(current: &mut Option<SecretString>, raw_update: Option<String>) {
     let Some(value) = raw_update else { return };
     let trimmed = value.trim();
     if trimmed.is_empty() {

--- a/egopulse/src/web/config.rs
+++ b/egopulse/src/web/config.rs
@@ -38,7 +38,8 @@ struct ChannelOverridePayload {
 #[serde(rename_all = "snake_case")]
 struct ConfigPayload {
     default_provider: String,
-    default_model: String,
+    default_model: Option<String>,
+    effective_model: String,
     data_dir: String,
     workspace_dir: String,
     web_enabled: bool,
@@ -79,7 +80,8 @@ struct ChannelOverrideUpdatePayload {
 #[serde(rename_all = "snake_case")]
 pub(super) struct ConfigUpdateRequest {
     default_provider: String,
-    default_model: String,
+    #[serde(default)]
+    default_model: Option<String>,
     #[serde(default)]
     providers: Option<HashMap<String, ProviderUpdatePayload>>,
     web_enabled: bool,
@@ -115,17 +117,10 @@ pub(super) async fn api_put_config(
     Json(request): Json<ConfigUpdateRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let default_provider = request.default_provider.trim();
-    let default_model = request.default_model.trim();
     if default_provider.is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,
             "default_provider is required".to_string(),
-        ));
-    }
-    if default_model.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "default_model is required".to_string(),
         ));
     }
     if request.web_host.trim().is_empty() {
@@ -151,20 +146,26 @@ pub(super) async fn api_put_config(
         Err(error) => return Err((StatusCode::BAD_REQUEST, error.to_string())),
     };
 
-    config.default_provider = default_provider.to_string();
-    config.default_model = if default_model.is_empty() {
-        None
-    } else {
-        Some(default_model.to_string())
-    };
-
-    let web_enabled = request.web_enabled;
-    let web_host = request.web_host.trim().to_string();
-    let web_port = request.web_port;
+    config.default_model = request.default_model.as_ref().and_then(|m| {
+        let trimmed = m.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    });
 
     if let Some(provider_updates) = request.providers {
         apply_provider_updates(&mut config, provider_updates);
     }
+
+    if config.providers.contains_key(default_provider) {
+        config.default_provider = default_provider.to_string();
+    }
+
+    let web_enabled = request.web_enabled;
+    let web_host = request.web_host.trim().to_string();
+    let web_port = request.web_port;
 
     {
         let web = config.channels.entry("web".to_string()).or_default();
@@ -218,6 +219,7 @@ fn apply_provider_updates(config: &mut Config, updates: HashMap<String, Provider
                 }
             }
             if let Some(models) = update.models {
+                let final_default = existing.default_model.clone();
                 existing.models = models
                     .into_iter()
                     .filter_map(|m| {
@@ -229,6 +231,9 @@ fn apply_provider_updates(config: &mut Config, updates: HashMap<String, Provider
                         }
                     })
                     .collect();
+                if !existing.models.contains(&final_default) {
+                    existing.models.push(final_default);
+                }
             }
             apply_api_key_update(&mut existing.api_key, update.api_key);
         } else {
@@ -343,7 +348,8 @@ fn apply_channel_overrides(
 fn default_payload(path: &std::path::Path) -> ConfigPayload {
     ConfigPayload {
         default_provider: String::new(),
-        default_model: String::new(),
+        default_model: None,
+        effective_model: String::new(),
         data_dir: crate::config::default_data_dir()
             .to_string_lossy()
             .into_owned(),
@@ -403,7 +409,8 @@ fn payload_from_config(config: &Config, path: &std::path::Path) -> ConfigPayload
 
     ConfigPayload {
         default_provider: resolved.provider,
-        default_model: resolved.model,
+        default_model: config.default_model.clone(),
+        effective_model: resolved.model,
         data_dir: config.data_dir.clone(),
         workspace_dir: crate::config::default_workspace_dir()
             .to_string_lossy()

--- a/egopulse/src/web/config.rs
+++ b/egopulse/src/web/config.rs
@@ -1,23 +1,20 @@
 //! Web 設定 API を扱うモジュール。
 //!
-//! provider / model / scope を中心とした設定の参照と YAML 保存を HTTP として公開する。
+//! グローバル設定（provider/model）とチャネル別overrideの参照・保存をHTTPとして公開する。
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use axum::Json;
-use axum::extract::{Query, State};
+use axum::extract::State;
 use axum::http::StatusCode;
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
-use serde_yml::{Mapping, Value};
 
-use crate::config::{Config, default_config_path};
-use crate::config_store::update_yaml;
+use crate::config::{Config, ProviderConfig, default_config_path};
 use crate::error::ConfigError;
 
 use super::WebState;
-
-const GLOBAL_SCOPE: &str = "global";
-const SUPPORTED_SCOPES: &[&str] = &[GLOBAL_SCOPE, "web", "discord", "telegram"];
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -32,11 +29,16 @@ struct ProviderPayload {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
+struct ChannelOverridePayload {
+    provider: Option<String>,
+    model: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
 struct ConfigPayload {
-    scope: String,
-    provider: String,
-    model: String,
-    base_url: String,
+    default_provider: String,
+    default_model: String,
     data_dir: String,
     workspace_dir: String,
     web_enabled: bool,
@@ -45,37 +47,51 @@ struct ConfigPayload {
     web_auth_enabled: bool,
     has_api_key: bool,
     config_path: String,
-    scopes: Vec<String>,
     providers: Vec<ProviderPayload>,
+    channel_overrides: HashMap<String, ChannelOverridePayload>,
 }
 
 #[derive(Debug, Deserialize)]
-/// Accepts mutable config values from the browser client.
-pub(super) struct ConfigUpdateRequest {
-    scope: String,
-    provider: String,
-    model: String,
+#[serde(rename_all = "snake_case")]
+struct ProviderUpdatePayload {
+    #[serde(default)]
+    label: Option<String>,
     #[serde(default)]
     base_url: Option<String>,
+    #[serde(default)]
+    api_key: Option<String>,
+    #[serde(default)]
+    default_model: Option<String>,
+    #[serde(default)]
+    models: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct ChannelOverrideUpdatePayload {
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) struct ConfigUpdateRequest {
+    default_provider: String,
+    default_model: String,
+    #[serde(default)]
+    providers: Option<HashMap<String, ProviderUpdatePayload>>,
     web_enabled: bool,
     web_host: String,
     web_port: u16,
     #[serde(default)]
-    api_key: Option<String>,
-    #[serde(default)]
-    clear_api_key: bool,
-}
-
-#[derive(Debug, Deserialize)]
-pub(super) struct ConfigQuery {
-    #[serde(default)]
-    scope: Option<String>,
+    channel_overrides: Option<HashMap<String, ChannelOverrideUpdatePayload>>,
 }
 
 /// Returns the persisted configuration visible to the web UI.
 pub(super) async fn api_get_config(
     State(state): State<WebState>,
-    Query(query): Query<ConfigQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let path = config_path_for_save(&state);
     let display = match Config::load_allow_missing_api_key(Some(&path)) {
@@ -83,18 +99,12 @@ pub(super) async fn api_get_config(
         Err(ConfigError::ConfigNotFound { .. }) => None,
         Err(error) => return Err((StatusCode::INTERNAL_SERVER_ERROR, error.to_string())),
     };
-    let scope = query
-        .scope
-        .as_deref()
-        .map(normalize_scope)
-        .transpose()?
-        .unwrap_or_else(|| GLOBAL_SCOPE.to_string());
 
     Ok(Json(serde_json::json!({
         "ok": true,
         "config": match display.as_ref() {
-            Some(display) => payload_from_config(display, &path, &scope)?,
-            None => default_payload(&path, &scope),
+            Some(display) => payload_from_config(display, &path),
+            None => default_payload(&path),
         },
     })))
 }
@@ -104,14 +114,19 @@ pub(super) async fn api_put_config(
     State(state): State<WebState>,
     Json(request): Json<ConfigUpdateRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let scope = normalize_scope(&request.scope)?;
-    let provider = request.provider.trim();
-    let model = request.model.trim();
-    if provider.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "provider is required".to_string()));
+    let default_provider = request.default_provider.trim();
+    let default_model = request.default_model.trim();
+    if default_provider.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "default_provider is required".to_string(),
+        ));
     }
-    if model.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "model is required".to_string()));
+    if default_model.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "default_model is required".to_string(),
+        ));
     }
     if request.web_host.trim().is_empty() {
         return Err((StatusCode::BAD_REQUEST, "web_host is required".to_string()));
@@ -124,80 +139,199 @@ pub(super) async fn api_put_config(
     }
 
     let path = config_path_for_save(&state);
-    let current_config = match Config::load_allow_missing_api_key(Some(&path)) {
-        Ok(config) => Some(config),
-        Err(ConfigError::ConfigNotFound { .. }) => None,
+
+    let mut config = match Config::load_allow_missing_api_key(Some(&path)) {
+        Ok(config) => config,
+        Err(ConfigError::ConfigNotFound { .. }) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "config file not found; run 'egopulse setup' first".to_string(),
+            ));
+        }
         Err(error) => return Err((StatusCode::BAD_REQUEST, error.to_string())),
     };
-    update_yaml(&path, |root| {
-        if scope == GLOBAL_SCOPE {
-            upsert_provider(
-                root,
-                provider,
-                model,
-                request
-                    .base_url
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty()),
-                normalized_api_key_update(request.api_key.as_deref(), request.clear_api_key),
-            )
-            .map_err(|(_, error)| crate::error::EgoPulseError::Internal(error))?;
-            set_string(root, "default_provider", provider);
-        } else {
-            if current_config
-                .as_ref()
-                .is_none_or(|config| !config.providers.contains_key(provider))
-            {
-                return Err(crate::error::EgoPulseError::Internal(format!(
-                    "unknown provider for scope {scope}: {provider}"
-                )));
-            }
-            let channel = ensure_channel_mapping(root, &scope);
-            channel.insert(
-                Value::String("provider".to_string()),
-                Value::String(provider.to_string()),
-            );
-            channel.insert(
-                Value::String("model".to_string()),
-                Value::String(model.to_string()),
-            );
-        }
 
-        let web = ensure_channel_mapping(root, "web");
-        web.insert(
-            Value::String("enabled".to_string()),
-            Value::Bool(request.web_enabled),
-        );
-        web.insert(
-            Value::String("host".to_string()),
-            Value::String(request.web_host.trim().to_string()),
-        );
-        web.insert(
-            Value::String("port".to_string()),
-            serde_yml::to_value(request.web_port)
-                .map_err(|error| crate::error::EgoPulseError::Internal(error.to_string()))?,
-        );
+    config.default_provider = default_provider.to_string();
+    config.default_model = default_model.to_string();
 
-        Ok(())
-    })
-    .map_err(internal_error)?;
+    let web_enabled = request.web_enabled;
+    let web_host = request.web_host.trim().to_string();
+    let web_port = request.web_port;
+
+    if let Some(provider_updates) = request.providers {
+        apply_provider_updates(&mut config, provider_updates);
+    }
+
+    {
+        let web = config.channels.entry("web".to_string()).or_default();
+        web.enabled = Some(web_enabled);
+        web.host = Some(web_host);
+        web.port = Some(web_port);
+    }
+
+    if let Some(overrides) = request.channel_overrides {
+        apply_channel_overrides(&mut config, overrides);
+    }
+
+    config
+        .save_yaml(&path)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
 
     let display = Config::load_allow_missing_api_key(Some(&path))
-        .map_err(|error| (StatusCode::BAD_REQUEST, error.to_string()))?;
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
 
     Ok(Json(serde_json::json!({
         "ok": true,
-        "config": payload_from_config(&display, &path, &scope)?,
+        "config": payload_from_config(&display, &path),
     })))
 }
 
-fn default_payload(path: &std::path::Path, scope: &str) -> ConfigPayload {
+fn apply_provider_updates(
+    config: &mut Config,
+    updates: HashMap<String, ProviderUpdatePayload>,
+) {
+    for (id, update) in updates {
+        let id = id.trim().to_ascii_lowercase();
+        if id.is_empty() {
+            continue;
+        }
+
+        if let Some(existing) = config.providers.get_mut(&id) {
+            if let Some(label) = update.label {
+                let trimmed = label.trim();
+                if !trimmed.is_empty() {
+                    existing.label = trimmed.to_string();
+                }
+            }
+            if let Some(base_url) = update.base_url {
+                let trimmed = base_url.trim();
+                if !trimmed.is_empty() {
+                    existing.base_url = trimmed.to_string();
+                }
+            }
+            if let Some(model) = update.default_model {
+                let trimmed = model.trim();
+                if !trimmed.is_empty() {
+                    existing.default_model = trimmed.to_string();
+                }
+            }
+            if let Some(models) = update.models {
+                existing.models = models
+                    .into_iter()
+                    .filter_map(|m| {
+                        let trimmed = m.trim();
+                        if trimmed.is_empty() {
+                            None
+                        } else {
+                            Some(trimmed.to_string())
+                        }
+                    })
+                    .collect();
+            }
+            apply_api_key_update(&mut existing.api_key, update.api_key);
+        } else {
+            let label = update
+                .label
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+                .unwrap_or_else(|| infer_provider_label(&id));
+
+            let base_url = match update.base_url {
+                Some(url) if !url.trim().is_empty() => url.trim().to_string(),
+                _ => continue,
+            };
+
+            let default_model = match update.default_model {
+                Some(model) if !model.trim().is_empty() => model.trim().to_string(),
+                _ => continue,
+            };
+
+            let models = update
+                .models
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|m| {
+                    let trimmed = m.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            let mut api_key = None;
+            apply_api_key_update(&mut api_key, update.api_key);
+
+            config.providers.insert(
+                id,
+                ProviderConfig {
+                    label,
+                    base_url,
+                    api_key,
+                    default_model,
+                    models,
+                },
+            );
+        }
+    }
+}
+
+fn apply_api_key_update(
+    current: &mut Option<SecretString>,
+    raw_update: Option<String>,
+) {
+    let Some(value) = raw_update else { return };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        // empty string → keep existing
+        return;
+    }
+    if trimmed == "*CLEAR*" {
+        *current = None;
+    } else {
+        *current = Some(SecretString::new(trimmed.to_string().into_boxed_str()));
+    }
+}
+
+fn apply_channel_overrides(
+    config: &mut Config,
+    overrides: HashMap<String, ChannelOverrideUpdatePayload>,
+) {
+    for (channel, update) in overrides {
+        let key = channel.trim().to_ascii_lowercase();
+        if key.is_empty() || key == "web" {
+            continue;
+        }
+
+        let entry = config.channels.entry(key).or_default();
+
+        match update.provider {
+            Some(provider) if !provider.trim().is_empty() => {
+                entry.provider = Some(provider.trim().to_string());
+            }
+            Some(_) => {
+                entry.provider = None;
+            }
+            None => {}
+        }
+
+        match update.model {
+            Some(model) if !model.trim().is_empty() => {
+                entry.model = Some(model.trim().to_string());
+            }
+            Some(_) => {
+                entry.model = None;
+            }
+            None => {}
+        }
+    }
+}
+
+fn default_payload(path: &std::path::Path) -> ConfigPayload {
     ConfigPayload {
-        scope: scope.to_string(),
-        provider: String::new(),
-        model: String::new(),
-        base_url: String::new(),
+        default_provider: String::new(),
+        default_model: String::new(),
         data_dir: crate::config::default_data_dir()
             .to_string_lossy()
             .into_owned(),
@@ -210,11 +344,8 @@ fn default_payload(path: &std::path::Path, scope: &str) -> ConfigPayload {
         web_auth_enabled: false,
         has_api_key: false,
         config_path: path.display().to_string(),
-        scopes: SUPPORTED_SCOPES
-            .iter()
-            .map(|scope| (*scope).to_string())
-            .collect(),
         providers: Vec::new(),
+        channel_overrides: HashMap::new(),
     }
 }
 
@@ -225,17 +356,8 @@ fn config_path_for_save(state: &WebState) -> PathBuf {
         .unwrap_or_else(default_config_path)
 }
 
-fn payload_from_config(
-    config: &Config,
-    path: &std::path::Path,
-    scope: &str,
-) -> Result<ConfigPayload, (StatusCode, String)> {
-    let resolved = match scope {
-        GLOBAL_SCOPE => config.resolve_global_llm(),
-        channel => config
-            .resolve_llm_for_channel(channel)
-            .map_err(internal_error)?,
-    };
+fn payload_from_config(config: &Config, path: &std::path::Path) -> ConfigPayload {
+    let resolved = config.resolve_global_llm();
 
     let providers = config
         .providers
@@ -250,11 +372,26 @@ fn payload_from_config(
         })
         .collect::<Vec<_>>();
 
-    Ok(ConfigPayload {
-        scope: scope.to_string(),
-        provider: resolved.provider,
-        model: resolved.model,
-        base_url: resolved.base_url,
+    let channel_overrides = config
+        .channels
+        .iter()
+        .filter_map(|(id, channel)| {
+            if id == "web" {
+                return None;
+            }
+            Some((
+                id.clone(),
+                ChannelOverridePayload {
+                    provider: channel.provider.clone(),
+                    model: channel.model.clone(),
+                },
+            ))
+        })
+        .collect();
+
+    ConfigPayload {
+        default_provider: resolved.provider,
+        default_model: resolved.model,
         data_dir: config.data_dir.clone(),
         workspace_dir: crate::config::default_workspace_dir()
             .to_string_lossy()
@@ -265,112 +402,9 @@ fn payload_from_config(
         web_auth_enabled: config.web_auth_token().is_some(),
         has_api_key: resolved.api_key.is_some(),
         config_path: path.display().to_string(),
-        scopes: SUPPORTED_SCOPES
-            .iter()
-            .map(|scope| (*scope).to_string())
-            .collect(),
         providers,
-    })
-}
-
-fn normalize_scope(scope: &str) -> Result<String, (StatusCode, String)> {
-    let normalized = scope.trim().to_ascii_lowercase();
-    if SUPPORTED_SCOPES
-        .iter()
-        .any(|candidate| *candidate == normalized)
-    {
-        return Ok(normalized);
+        channel_overrides,
     }
-    Err((StatusCode::BAD_REQUEST, "invalid scope".to_string()))
-}
-
-fn upsert_provider(
-    root: &mut Value,
-    provider: &str,
-    model: &str,
-    base_url: Option<&str>,
-    api_key_update: ApiKeyUpdate<'_>,
-) -> Result<(), (StatusCode, String)> {
-    let providers = ensure_mapping(entry_mut(root, "providers"));
-    let provider_value = providers
-        .entry(Value::String(provider.to_string()))
-        .or_insert(Value::Mapping(Mapping::new()));
-    let provider_mapping = ensure_mapping(provider_value);
-
-    let current_base_url = provider_mapping
-        .get(Value::String("base_url".to_string()))
-        .and_then(value_as_trimmed_str);
-    let effective_base_url = base_url.or(current_base_url.as_deref()).ok_or((
-        StatusCode::BAD_REQUEST,
-        "base_url is required when creating a provider".to_string(),
-    ))?;
-
-    if !provider_mapping.contains_key(Value::String("label".to_string())) {
-        provider_mapping.insert(
-            Value::String("label".to_string()),
-            Value::String(infer_provider_label(provider).to_string()),
-        );
-    }
-    provider_mapping.insert(
-        Value::String("base_url".to_string()),
-        Value::String(effective_base_url.to_string()),
-    );
-    provider_mapping.insert(
-        Value::String("default_model".to_string()),
-        Value::String(model.to_string()),
-    );
-
-    let mut models = provider_mapping
-        .get(Value::String("models".to_string()))
-        .and_then(value_as_string_vec)
-        .unwrap_or_default();
-    if !models.iter().any(|candidate| candidate == model) {
-        models.push(model.to_string());
-    }
-    provider_mapping.insert(
-        Value::String("models".to_string()),
-        serde_yml::to_value(models).map_err(internal_error)?,
-    );
-
-    match api_key_update {
-        ApiKeyUpdate::Replace(value) => {
-            provider_mapping.insert(
-                Value::String("api_key".to_string()),
-                Value::String(value.to_string()),
-            );
-        }
-        ApiKeyUpdate::Clear => {
-            provider_mapping.remove(Value::String("api_key".to_string()));
-        }
-        ApiKeyUpdate::NoChange => {}
-    }
-
-    Ok(())
-}
-
-enum ApiKeyUpdate<'a> {
-    NoChange,
-    Replace(&'a str),
-    Clear,
-}
-
-fn normalized_api_key_update(api_key: Option<&str>, clear_api_key: bool) -> ApiKeyUpdate<'_> {
-    if clear_api_key {
-        return ApiKeyUpdate::Clear;
-    }
-    match api_key.map(str::trim) {
-        Some(value) if !value.is_empty() => ApiKeyUpdate::Replace(value),
-        _ => ApiKeyUpdate::NoChange,
-    }
-}
-
-fn ensure_channel_mapping<'a>(root: &'a mut Value, channel: &str) -> &'a mut Mapping {
-    let channels = ensure_mapping(entry_mut(root, "channels"));
-    ensure_mapping(
-        channels
-            .entry(Value::String(channel.to_string()))
-            .or_insert(Value::Mapping(Mapping::new())),
-    )
 }
 
 fn infer_provider_label(provider: &str) -> String {
@@ -381,58 +415,4 @@ fn infer_provider_label(provider: &str) -> String {
         "custom" => "Custom OpenAI-compatible".to_string(),
         other => other.to_string(),
     }
-}
-
-fn value_as_trimmed_str(value: &Value) -> Option<String> {
-    match value {
-        Value::String(value) => {
-            let trimmed = value.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            }
-        }
-        _ => None,
-    }
-}
-
-fn value_as_string_vec(value: &Value) -> Option<Vec<String>> {
-    match value {
-        Value::Sequence(values) => Some(
-            values
-                .iter()
-                .filter_map(value_as_trimmed_str)
-                .collect::<Vec<_>>(),
-        ),
-        _ => None,
-    }
-}
-
-fn set_string(root: &mut Value, key: &str, value: &str) {
-    let mapping = ensure_mapping(root);
-    mapping.insert(
-        Value::String(key.to_string()),
-        Value::String(value.to_string()),
-    );
-}
-
-fn entry_mut<'a>(root: &'a mut Value, key: &str) -> &'a mut Value {
-    ensure_mapping(root)
-        .entry(Value::String(key.to_string()))
-        .or_insert(Value::Mapping(Mapping::new()))
-}
-
-fn ensure_mapping(value: &mut Value) -> &mut Mapping {
-    if !matches!(value, Value::Mapping(_)) {
-        *value = Value::Mapping(Mapping::new());
-    }
-    match value {
-        Value::Mapping(mapping) => mapping,
-        _ => unreachable!(),
-    }
-}
-
-fn internal_error(error: impl std::fmt::Display) -> (StatusCode, String) {
-    (StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
 }

--- a/egopulse/web/src/main.tsx
+++ b/egopulse/web/src/main.tsx
@@ -53,7 +53,7 @@ type ProviderUpdate = {
   base_url: string;
   default_model: string;
   models: string[];
-  api_key: string;
+  api_key?: string;
 };
 
 type HealthPayload = {
@@ -286,6 +286,18 @@ function App() {
   const selectedProvider = useMemo(() => {
     return config?.providers.find((item) => item.id === config.default_provider) || null;
   }, [config]);
+
+  useEffect(() => {
+    setConfigApiKey("");
+    setConfig((current) =>
+      current
+        ? {
+            ...current,
+            has_api_key: selectedProvider?.has_api_key || false,
+          }
+        : current,
+    );
+  }, [selectedProvider?.id]);
 
   useEffect(() => {
     messageEndRef.current?.scrollIntoView({ block: "end" });
@@ -681,14 +693,18 @@ function App() {
         base_url: provider.base_url,
         default_model: provider.default_model,
         models: provider.models,
-        api_key: "",
       };
     }
 
     const activeProviderId = config.default_provider;
     const activeProvider = providersPayload[activeProviderId];
     if (activeProvider) {
-      activeProvider.api_key = configApiKey || "";
+      const apiKey = configApiKey.trim();
+      if (apiKey === "*CLEAR*") {
+        activeProvider.api_key = apiKey;
+      } else if (apiKey) {
+        activeProvider.api_key = apiKey;
+      }
     }
 
     const payload = {
@@ -882,6 +898,7 @@ function App() {
                       ...config,
                       default_provider: providerId,
                       default_model: provider?.default_model || config.default_model,
+                      has_api_key: provider?.has_api_key || false,
                     });
                   }}
                 >
@@ -914,13 +931,13 @@ function App() {
                     type="password"
                     value={configApiKey}
                     placeholder={
-                      selectedProvider?.has_api_key || config.has_api_key
+                      selectedProvider?.has_api_key
                         ? "Configured. Enter to replace."
                         : "Enter API key"
                     }
                     onChange={(event) => setConfigApiKey(event.target.value)}
                   />
-                  {selectedProvider?.has_api_key || config.has_api_key ? (
+                  {selectedProvider?.has_api_key ? (
                     <button
                       type="button"
                       className="secondary-button api-key-clear"

--- a/egopulse/web/src/main.tsx
+++ b/egopulse/web/src/main.tsx
@@ -19,11 +19,23 @@ type MessageItem = {
   timestamp: string;
 };
 
-type ConfigPayload = {
-  scope: string;
-  provider: string;
-  model: string;
+type ProviderInfo = {
+  id: string;
+  label: string;
   base_url: string;
+  default_model: string;
+  models: string[];
+  has_api_key: boolean;
+};
+
+type ChannelOverride = {
+  provider?: string;
+  model?: string;
+};
+
+type ConfigPayload = {
+  default_provider: string;
+  default_model: string;
   data_dir: string;
   workspace_dir: string;
   web_enabled: boolean;
@@ -32,15 +44,16 @@ type ConfigPayload = {
   web_auth_enabled: boolean;
   has_api_key: boolean;
   config_path: string;
-  scopes: string[];
-  providers: Array<{
-    id: string;
-    label: string;
-    base_url: string;
-    default_model: string;
-    models: string[];
-    has_api_key: boolean;
-  }>;
+  providers: ProviderInfo[];
+  channel_overrides: Record<string, ChannelOverride>;
+};
+
+type ProviderUpdate = {
+  label: string;
+  base_url: string;
+  default_model: string;
+  models: string[];
+  api_key: string;
 };
 
 type HealthPayload = {
@@ -271,7 +284,7 @@ function App() {
   }, [selectedSession, sessions]);
 
   const selectedProvider = useMemo(() => {
-    return config?.providers.find((item) => item.id === config.provider) || null;
+    return config?.providers.find((item) => item.id === config.default_provider) || null;
   }, [config]);
 
   useEffect(() => {
@@ -321,10 +334,9 @@ function App() {
     setHealth({ version: payload.version });
   }
 
-  async function refreshConfig(scope?: string) {
-    const query = scope ? `?scope=${encodeURIComponent(scope)}` : "";
+  async function refreshConfig() {
     const payload = await api<{ ok: boolean; config: ConfigPayload }>(
-      `/api/config${query}`,
+      "/api/config",
       authTokenRef.current,
     );
     setConfig(payload.config);
@@ -662,15 +674,31 @@ function App() {
     event.preventDefault();
     if (!config) return;
 
+    const providersPayload: Record<string, ProviderUpdate> = {};
+    for (const provider of config.providers) {
+      providersPayload[provider.id] = {
+        label: provider.label,
+        base_url: provider.base_url,
+        default_model: provider.default_model,
+        models: provider.models,
+        api_key: "",
+      };
+    }
+
+    const activeProviderId = config.default_provider;
+    const activeProvider = providersPayload[activeProviderId];
+    if (activeProvider) {
+      activeProvider.api_key = configApiKey || "";
+    }
+
     const payload = {
-      scope: config.scope,
-      provider: config.provider,
-      model: config.model,
-      base_url: config.base_url,
+      default_provider: config.default_provider,
+      default_model: config.default_model,
+      providers: providersPayload,
       web_enabled: config.web_enabled,
       web_host: config.web_host,
       web_port: config.web_port,
-      api_key: configApiKey,
+      channel_overrides: config.channel_overrides,
     };
 
     try {
@@ -686,7 +714,7 @@ function App() {
       setConfigApiKey("");
       setStatus({
         tone: "ok",
-        text: "Config saved. Next turns use the new LLM settings.",
+        text: "Config saved. Changes take effect on the next turn.",
       });
       setShowSettings(false);
     } catch (error) {
@@ -839,36 +867,11 @@ function App() {
             </div>
 
             <form className="config-form" onSubmit={handleSaveConfig}>
-              <label>
-                <span>Apply To</span>
-                <select
-                  value={config.scope}
-                  onChange={(event) => {
-                    const nextScope = event.target.value;
-                    void withAuthHandling(async () => {
-                      await refreshConfig(nextScope);
-                    }).catch((error) => {
-                      setStatus({
-                        tone: "error",
-                        text:
-                          error instanceof Error
-                            ? error.message
-                            : "Failed to load scoped config",
-                      });
-                    });
-                  }}
-                >
-                  {config.scopes.map((scope) => (
-                    <option key={scope} value={scope}>
-                      {scope}
-                    </option>
-                  ))}
-                </select>
-              </label>
+              <div className="config-section-title">Default LLM</div>
               <label>
                 <span>Provider</span>
                 <select
-                  value={config.provider}
+                  value={config.default_provider}
                   onChange={(event) => {
                     const providerId = event.target.value;
                     const provider = config.providers.find(
@@ -876,9 +879,8 @@ function App() {
                     );
                     setConfig({
                       ...config,
-                      provider: providerId,
-                      model: provider?.default_model || config.model,
-                      base_url: provider?.base_url || config.base_url,
+                      default_provider: providerId,
+                      default_model: provider?.default_model || config.default_model,
                     });
                   }}
                 >
@@ -893,9 +895,9 @@ function App() {
                 <span>Model</span>
                 <input
                   list="provider-models"
-                  value={config.model}
+                  value={config.default_model}
                   onChange={(event) =>
-                    setConfig({ ...config, model: event.target.value })
+                    setConfig({ ...config, default_model: event.target.value })
                   }
                 />
                 <datalist id="provider-models">
@@ -905,30 +907,44 @@ function App() {
                 </datalist>
               </label>
               <label>
-                <span>Base URL</span>
-                <input
-                  value={config.base_url}
-                  onChange={(event) =>
-                    setConfig({ ...config, base_url: event.target.value })
-                  }
-                />
-              </label>
-              <label>
                 <span>API Key</span>
+                <div className="api-key-row">
+                  <input
+                    type="password"
+                    value={configApiKey}
+                    placeholder={
+                      selectedProvider?.has_api_key || config.has_api_key
+                        ? "Configured. Enter to replace."
+                        : "Enter API key"
+                    }
+                    onChange={(event) => setConfigApiKey(event.target.value)}
+                  />
+                  {selectedProvider?.has_api_key || config.has_api_key ? (
+                    <button
+                      type="button"
+                      className="secondary-button api-key-clear"
+                      onClick={() => setConfigApiKey("*CLEAR*")}
+                    >
+                      Clear
+                    </button>
+                  ) : null}
+                </div>
+              </label>
+
+              <div className="config-section-title">Web Server</div>
+              <label className="checkbox-row">
                 <input
-                  type="password"
-                  value={configApiKey}
-                  placeholder={
-                    selectedProvider?.has_api_key || config.has_api_key
-                      ? "Configured. Enter to replace."
-                      : "Enter API key"
+                  type="checkbox"
+                  checked={config.web_enabled}
+                  onChange={(event) =>
+                    setConfig({ ...config, web_enabled: event.target.checked })
                   }
-                  onChange={(event) => setConfigApiKey(event.target.value)}
                 />
+                <span>Enable</span>
               </label>
               <div className="grid-two">
                 <label>
-                  <span>Web Host</span>
+                  <span>Host</span>
                   <input
                     value={config.web_host}
                     onChange={(event) =>
@@ -937,7 +953,7 @@ function App() {
                   />
                 </label>
                 <label>
-                  <span>Web Port</span>
+                  <span>Port</span>
                   <input
                     type="number"
                     value={config.web_port}
@@ -955,19 +971,102 @@ function App() {
                   />
                 </label>
               </div>
-              <label className="checkbox-row">
-                <input
-                  type="checkbox"
-                  checked={config.web_enabled}
-                  onChange={(event) =>
-                    setConfig({ ...config, web_enabled: event.target.checked })
-                  }
-                />
-                <span>Enable web channel</span>
-              </label>
+
+              <div className="config-section-title">Providers</div>
+              <div className="provider-list">
+                {config.providers.map((provider) => (
+                  <div key={provider.id} className="provider-card">
+                    <div className="provider-card-header">
+                      <strong>{provider.label}</strong>
+                      <code className="provider-id">{provider.id}</code>
+                    </div>
+                    <div className="provider-card-body">
+                      <span className="provider-detail">
+                        <span className="provider-detail-label">base_url</span>
+                        <span className="provider-detail-value">{provider.base_url}</span>
+                      </span>
+                      <span className="provider-detail">
+                        <span className="provider-detail-label">default</span>
+                        <span className="provider-detail-value">{provider.default_model}</span>
+                      </span>
+                      {provider.models.length > 0 && (
+                        <span className="provider-detail">
+                          <span className="provider-detail-label">models</span>
+                          <span className="provider-detail-value">{provider.models.join(", ")}</span>
+                        </span>
+                      )}
+                      <span className="provider-detail">
+                        <span className="provider-detail-label">api_key</span>
+                        <span className={`provider-detail-value ${provider.has_api_key ? "status-ok" : "status-none"}`}>
+                          {provider.has_api_key ? "configured" : "not set"}
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div className="config-section-title">Channel Overrides</div>
+              {(["discord", "telegram"] as const).map((channel) => {
+                const override = config.channel_overrides[channel] || {};
+                return (
+                  <div key={channel} className="channel-override-row">
+                    <span className="channel-override-label">{channel}</span>
+                    <div className="grid-two">
+                      <label>
+                        <span>Provider</span>
+                        <select
+                          value={override.provider || ""}
+                          onChange={(event) => {
+                            const value = event.target.value;
+                            setConfig({
+                              ...config,
+                              channel_overrides: {
+                                ...config.channel_overrides,
+                                [channel]: {
+                                  ...override,
+                                  provider: value || undefined,
+                                },
+                              },
+                            });
+                          }}
+                        >
+                          <option value="">---</option>
+                          {config.providers.map((p) => (
+                            <option key={p.id} value={p.id}>
+                              {p.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label>
+                        <span>Model</span>
+                        <input
+                          value={override.model || ""}
+                          placeholder="Use default"
+                          onChange={(event) => {
+                            const value = event.target.value;
+                            setConfig({
+                              ...config,
+                              channel_overrides: {
+                                ...config.channel_overrides,
+                                [channel]: {
+                                  ...override,
+                                  model: value || undefined,
+                                },
+                              },
+                            });
+                          }}
+                        />
+                      </label>
+                    </div>
+                  </div>
+                );
+              })}
+
               <div className="config-footer">
                 <span>
-                  Changes are persisted immediately and used on the next turn.
+                  Changes take effect on the next turn.
                 </span>
                 <button className="primary-button" type="submit">
                   Save

--- a/egopulse/web/src/main.tsx
+++ b/egopulse/web/src/main.tsx
@@ -877,6 +877,7 @@ function App() {
                     const provider = config.providers.find(
                       (item) => item.id === providerId,
                     );
+                    setConfigApiKey("");
                     setConfig({
                       ...config,
                       default_provider: providerId,
@@ -1019,6 +1020,9 @@ function App() {
                           value={override.provider || ""}
                           onChange={(event) => {
                             const value = event.target.value;
+                            const provider = config.providers.find(
+                              (item) => item.id === value,
+                            );
                             setConfig({
                               ...config,
                               channel_overrides: {
@@ -1026,6 +1030,7 @@ function App() {
                                 [channel]: {
                                   ...override,
                                   provider: value || undefined,
+                                  model: provider?.default_model || undefined,
                                 },
                               },
                             });

--- a/egopulse/web/src/styles.css
+++ b/egopulse/web/src/styles.css
@@ -433,7 +433,119 @@ button {
   }
 
   .grid-two,
-  .config-footer {
+.config-form select {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: rgba(8, 14, 30, 0.86);
+  color: var(--text);
+  padding: 14px 16px;
+}
+
+.config-section-title {
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 8px;
+  margin-bottom: 14px;
+  margin-top: 6px;
+}
+
+.api-key-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.api-key-row input {
+  flex: 1;
+}
+
+.api-key-clear {
+  flex-shrink: 0;
+  padding: 10px 12px;
+  font-size: 0.85rem;
+}
+
+.provider-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.provider-card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: rgba(8, 16, 32, 0.8);
+}
+
+.provider-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.provider-card-header strong {
+  font-size: 0.95rem;
+}
+
+.provider-id {
+  font-size: 0.75rem;
+  color: var(--muted);
+  background: var(--panel-2);
+  padding: 2px 8px;
+  border-radius: 6px;
+}
+
+.provider-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.provider-detail {
+  display: flex;
+  gap: 8px;
+  font-size: 0.82rem;
+}
+
+.provider-detail-label {
+  color: var(--muted);
+  min-width: 64px;
+}
+
+.provider-detail-value {
+  color: var(--text);
+  word-break: break-all;
+}
+
+.provider-detail-value.status-ok {
+  color: var(--accent);
+}
+
+.provider-detail-value.status-none {
+  color: var(--danger);
+}
+
+.channel-override-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.channel-override-label {
+  color: var(--accent-2);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.config-footer {
     grid-template-columns: 1fr;
     display: grid;
   }

--- a/egopulse/web/src/styles.css
+++ b/egopulse/web/src/styles.css
@@ -410,29 +410,6 @@ button {
   font-size: 0.88rem;
 }
 
-@media (max-width: 960px) {
-  .app-shell {
-    grid-template-columns: 1fr;
-  }
-
-  .sidebar {
-    border-right: 0;
-    border-bottom: 1px solid var(--border);
-  }
-
-  .main-panel {
-    min-height: auto;
-  }
-
-  .composer {
-    grid-template-columns: 1fr;
-  }
-
-  .bubble {
-    max-width: 100%;
-  }
-
-  .grid-two,
 .config-form select {
   width: 100%;
   border: 1px solid var(--border);
@@ -545,8 +522,34 @@ button {
   letter-spacing: 0.04em;
 }
 
-.config-footer {
+@media (max-width: 960px) {
+  .app-shell {
     grid-template-columns: 1fr;
-    display: grid;
+  }
+
+  .sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .main-panel {
+    min-height: auto;
+  }
+
+  .composer {
+    grid-template-columns: 1fr;
+  }
+
+  .bubble {
+    max-width: 100%;
+  }
+
+  .grid-two {
+    grid-template-columns: 1fr;
+  }
+
+  .config-footer {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary

- Config構造体に `default_model` を追加し、グローバルでのモデル選択をProvider定義から分離
- `update_yaml()`（serde_yml::Value部分操作）を廃止し、`Config::save_yaml()`（構造体全体保存）に統一
- Scope概念（global/web/discord/telegram）を廃止し、グローバル設定 + チャネル別overrideのフラット構造に変更
- WebUI Settings画面をセクション構成（Default LLM / Web Server / Providers / Channel Overrides）に刷新

## 設計方針

microclawのConfig保存方式（Config struct → serde_yaml::to_string → write）に合わせつつ、EgoPulseのホットリロード機構は維持。

### 解決チェーン
```
channel.model → config.default_model → provider.default_model
```

Provider定義は「メニュー」として不変に扱い、モデル選択結果は `config.default_model` / `channel.model` に保存する設計。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `src/config.rs` | `default_model` フィールド追加、`Config::save_yaml()` 実装、解決チェーン更新 |
| `src/web/config.rs` | API endpoint全面書き直し（scope廃止、Config struct経由の保存） |
| `src/llm_profile.rs` | CLI `/provider` `/model` を `Config::save_yaml()` に移行 |
| `src/config_store.rs` | `update_yaml()` を `#![allow(dead_code)]` に |
| `web/src/main.tsx` | Settings画面のセクション構成化 |
| `web/src/styles.css` | セクション/Providerカード/Channel Overrideのスタイル追加 |

## 検証

- `cargo test -p egopulse`: 115 passed ✅
- `cargo clippy`: clean ✅
- `npm run build`: success ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * グローバルのデフォルトモデル設定を追加（チャネルごとのオーバーライド対応）。
  * Web UI に「Default LLM」「Providers」「Channel Overrides」パネルを追加。

* **改善**
  * 設定の保存を型安全かつ原子操作で行う新しいフローに移行。
  * Web API とフロントエンドの設定入出力を新仕様に合わせて再設計、APIキーの取り扱いを改善。
  * 設定保存後のメッセージを「Changes take effect on the next turn.」に更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->