### PR TITLE
fix(egopulse): 生産コードの panic 根絶 — default_state_root Result化

### DIFF
--- a/egopulse/src/agent_loop/session.rs
+++ b/egopulse/src/agent_loop/session.rs
@@ -438,7 +438,7 @@ mod tests {
     fn build_state_with_provider(data_dir: String, llm: Box<dyn LlmProvider>) -> AppState {
         use crate::channel_adapter::ChannelRegistry;
         let config = test_config(data_dir.clone());
-        let skills = Arc::new(SkillManager::from_skills_dir(config.skills_dir()));
+        let skills = Arc::new(SkillManager::from_skills_dir(config.skills_dir().expect("skills_dir")));
         AppState {
             db: Arc::new(Database::new(&data_dir).expect("db")),
             config: config.clone(),

--- a/egopulse/src/agent_loop/session.rs
+++ b/egopulse/src/agent_loop/session.rs
@@ -438,7 +438,9 @@ mod tests {
     fn build_state_with_provider(data_dir: String, llm: Box<dyn LlmProvider>) -> AppState {
         use crate::channel_adapter::ChannelRegistry;
         let config = test_config(data_dir.clone());
-        let skills = Arc::new(SkillManager::from_skills_dir(config.skills_dir().expect("skills_dir")));
+        let skills = Arc::new(SkillManager::from_skills_dir(
+            config.skills_dir().expect("skills_dir"),
+        ));
         AppState {
             db: Arc::new(Database::new(&data_dir).expect("db")),
             config: config.clone(),

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -1209,7 +1209,7 @@ mod tests {
         use crate::channel_adapter::ChannelRegistry;
         let data_dir = config.data_dir.clone();
         let db = Arc::new(Database::new(&data_dir).expect("db"));
-        let skills = Arc::new(SkillManager::from_skills_dir(config.skills_dir()));
+        let skills = Arc::new(SkillManager::from_skills_dir(config.skills_dir().expect("skills_dir")));
         AppState {
             db,
             config: config.clone(),
@@ -1252,7 +1252,7 @@ mod tests {
             dir.path().to_str().expect("utf8").to_string(),
             Box::new(provider.clone()),
         );
-        let workspace = state.config.workspace_dir();
+        let workspace = state.config.workspace_dir().expect("workspace_dir");
         let note_path = workspace.join(&relative_path);
         std::fs::create_dir_all(note_path.parent().expect("note parent")).expect("workspace");
         std::fs::write(&note_path, "hello from tool").expect("notes");
@@ -1414,7 +1414,7 @@ mod tests {
                 ]),
             }),
         );
-        let workspace = state.config.workspace_dir();
+        let workspace = state.config.workspace_dir().expect("workspace_dir");
         let file_path = workspace.join(&relative_path);
         std::fs::create_dir_all(file_path.parent().expect("file parent")).expect("workspace");
         std::fs::write(&file_path, "content").expect("a.txt");

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -1209,7 +1209,9 @@ mod tests {
         use crate::channel_adapter::ChannelRegistry;
         let data_dir = config.data_dir.clone();
         let db = Arc::new(Database::new(&data_dir).expect("db"));
-        let skills = Arc::new(SkillManager::from_skills_dir(config.skills_dir().expect("skills_dir")));
+        let skills = Arc::new(SkillManager::from_skills_dir(
+            config.skills_dir().expect("skills_dir"),
+        ));
         AppState {
             db,
             config: config.clone(),

--- a/egopulse/src/config.rs
+++ b/egopulse/src/config.rs
@@ -328,7 +328,7 @@ impl Config {
 
     /// Locate the default config file, or fail when absent.
     pub fn resolve_config_path() -> Result<Option<PathBuf>, ConfigError> {
-        let candidate = default_config_path();
+        let candidate = default_config_path()?;
         if candidate.exists() {
             return Ok(Some(candidate));
         }
@@ -370,12 +370,12 @@ impl Config {
     }
 
     /// Directory containing skill definitions.
-    pub fn skills_dir(&self) -> PathBuf {
-        default_workspace_dir().join("skills")
+    pub fn skills_dir(&self) -> Result<PathBuf, ConfigError> {
+        default_workspace_dir().map(|dir| dir.join("skills"))
     }
 
     /// Workspace directory for agent file operations.
-    pub fn workspace_dir(&self) -> PathBuf {
+    pub fn workspace_dir(&self) -> Result<PathBuf, ConfigError> {
         default_workspace_dir()
     }
 
@@ -397,25 +397,25 @@ impl Config {
 }
 
 /// Default config file path: `~/.egopulse/egopulse.config.yaml`.
-pub fn default_config_path() -> PathBuf {
-    default_state_root().join("egopulse.config.yaml")
+pub fn default_config_path() -> Result<PathBuf, ConfigError> {
+    default_state_root().map(|root| root.join("egopulse.config.yaml"))
 }
 
 /// Default state root directory: `~/.egopulse`.
-pub fn default_state_root() -> PathBuf {
+pub fn default_state_root() -> Result<PathBuf, ConfigError> {
     dirs::home_dir()
-        .unwrap_or_else(|| panic!("failed to resolve OS home directory for EgoPulse state root"))
-        .join(".egopulse")
+        .map(|home| home.join(".egopulse"))
+        .ok_or(ConfigError::HomeDirectoryUnresolved)
 }
 
 /// Default data directory: `~/.egopulse/data`.
-pub fn default_data_dir() -> PathBuf {
-    default_state_root().join("data")
+pub fn default_data_dir() -> Result<PathBuf, ConfigError> {
+    default_state_root().map(|root| root.join("data"))
 }
 
 /// Default workspace directory: `~/.egopulse/workspace`.
-pub fn default_workspace_dir() -> PathBuf {
-    default_state_root().join("workspace")
+pub fn default_workspace_dir() -> Result<PathBuf, ConfigError> {
+    default_state_root().map(|root| root.join("workspace"))
 }
 
 fn normalize_channels(
@@ -593,7 +593,7 @@ fn build_config(
 
     let default_model = normalize_string(file_default_model);
 
-    let data_dir = default_data_dir().to_string_lossy().into_owned();
+    let data_dir = default_data_dir()?.to_string_lossy().into_owned();
 
     let log_level = first_non_empty([env_var("EGOPULSE_LOG_LEVEL"), file_log_level])
         .unwrap_or_else(|| "info".to_string());
@@ -1095,9 +1095,9 @@ channels:
 
         assert_eq!(config.default_provider, "openai");
         assert_eq!(config.global_provider().label, "OpenAI");
-        assert_eq!(PathBuf::from(&config.data_dir), default_data_dir());
-        assert_eq!(config.workspace_dir(), default_workspace_dir());
-        assert_eq!(config.skills_dir(), default_workspace_dir().join("skills"));
+        assert_eq!(PathBuf::from(&config.data_dir), default_data_dir().unwrap());
+        assert_eq!(config.workspace_dir().unwrap(), default_workspace_dir().unwrap());
+        assert_eq!(config.skills_dir().unwrap(), default_workspace_dir().unwrap().join("skills"));
         assert!(config.web_enabled());
         assert_eq!(config.web_auth_token(), Some("web-secret"));
 

--- a/egopulse/src/config.rs
+++ b/egopulse/src/config.rs
@@ -1085,6 +1085,14 @@ channels:
 
     #[test]
     #[serial]
+    fn home_directory_unresolved_error_displays_correctly() {
+        let error = ConfigError::HomeDirectoryUnresolved;
+        let message = error.to_string();
+        assert!(message.contains("home_directory_unresolved"));
+    }
+
+    #[test]
+    #[serial]
     fn loads_provider_based_config() {
         let env = EnvGuard::new();
         let temp_dir = tempfile::tempdir().expect("tempdir");
@@ -1096,8 +1104,14 @@ channels:
         assert_eq!(config.default_provider, "openai");
         assert_eq!(config.global_provider().label, "OpenAI");
         assert_eq!(PathBuf::from(&config.data_dir), default_data_dir().unwrap());
-        assert_eq!(config.workspace_dir().unwrap(), default_workspace_dir().unwrap());
-        assert_eq!(config.skills_dir().unwrap(), default_workspace_dir().unwrap().join("skills"));
+        assert_eq!(
+            config.workspace_dir().unwrap(),
+            default_workspace_dir().unwrap()
+        );
+        assert_eq!(
+            config.skills_dir().unwrap(),
+            default_workspace_dir().unwrap().join("skills")
+        );
         assert!(config.web_enabled());
         assert_eq!(config.web_auth_token(), Some("web-secret"));
 

--- a/egopulse/src/error.rs
+++ b/egopulse/src/error.rs
@@ -71,6 +71,9 @@ pub enum ConfigError {
     InvalidCompactionConfig(String),
     #[error("no_active_channels: no enabled channel has a valid bot_token configured")]
     NoActiveChannels,
+    /// OS のホームディレクトリが解決できなかった。
+    #[error("home_directory_unresolved: OS home directory could not be resolved")]
+    HomeDirectoryUnresolved,
 }
 
 /// TUI (Terminal User Interface) rendering and event errors.

--- a/egopulse/src/gateway.rs
+++ b/egopulse/src/gateway.rs
@@ -55,7 +55,7 @@ pub fn resolve_cli_config_path(path: &std::path::Path) -> PathBuf {
 }
 
 fn runtime_default_config_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|home| home.join(".egopulse").join("egopulse.config.yaml"))
+    crate::config::default_config_path().ok()
 }
 
 fn escape_systemd_exec_arg(value: &str) -> String {

--- a/egopulse/src/main.rs
+++ b/egopulse/src/main.rs
@@ -103,7 +103,7 @@ async fn run_with_config(cli: &Cli) -> Result<(), EgoPulseError> {
                     return Ok(());
                 }
                 return Err(EgoPulseError::Config(ConfigError::AutoConfigNotFound {
-                    searched_paths: vec![default_config_path()],
+                    searched_paths: vec![default_config_path()?],
                 }));
             }
             Err(e) => return Err(EgoPulseError::Config(e)),

--- a/egopulse/src/mcp.rs
+++ b/egopulse/src/mcp.rs
@@ -22,7 +22,7 @@ use rmcp::transport::{
 };
 
 use crate::config::default_state_root;
-use crate::error::McpError;
+use crate::error::{ConfigError, McpError};
 use crate::llm::ToolDefinition;
 
 const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 60;
@@ -85,18 +85,18 @@ impl ConnectedServer {
     }
 }
 
-pub fn mcp_config_paths(workspace_dir: &Path) -> Vec<PathBuf> {
-    let state_root = default_state_root();
-    vec![
+pub fn mcp_config_paths(workspace_dir: &Path) -> Result<Vec<PathBuf>, ConfigError> {
+    let state_root = default_state_root()?;
+    Ok(vec![
         state_root.join("mcp.json"),
         state_root.join("mcp.d"),
         workspace_dir.join("mcp.json"),
         workspace_dir.join("mcp.d"),
-    ]
+    ])
 }
 
-pub fn load_and_merge_mcp_configs(workspace_dir: &Path) -> HashMap<String, McpServerConfig> {
-    let paths = mcp_config_paths(workspace_dir);
+pub fn load_and_merge_mcp_configs(workspace_dir: &Path) -> Result<HashMap<String, McpServerConfig>, ConfigError> {
+    let paths = mcp_config_paths(workspace_dir)?;
     let mut merged: HashMap<String, McpServerConfig> = HashMap::new();
 
     for path in &paths {
@@ -135,7 +135,7 @@ pub fn load_and_merge_mcp_configs(workspace_dir: &Path) -> HashMap<String, McpSe
         }
     }
 
-    merged
+    Ok(merged)
 }
 
 fn read_mcp_config_file(path: &Path) -> Result<McpConfigFile, McpError> {
@@ -181,8 +181,8 @@ fn sha2_short(input: &str) -> String {
 }
 
 impl McpManager {
-    pub async fn new(workspace_dir: &Path) -> Self {
-        let configs = load_and_merge_mcp_configs(workspace_dir);
+    pub async fn new(workspace_dir: &Path) -> Result<Self, ConfigError> {
+        let configs = load_and_merge_mcp_configs(workspace_dir)?;
         let mut servers = Vec::new();
 
         for (name, config) in &configs {
@@ -231,7 +231,7 @@ impl McpManager {
             total = configs.len(),
             "MCP initialization complete"
         );
-        Self { servers }
+        Ok(Self { servers })
     }
 
     pub fn all_tool_definitions(&self) -> Vec<ToolDefinition> {
@@ -531,7 +531,7 @@ mod tests {
     #[test]
     fn config_paths_include_global_and_workspace() {
         let workspace = Path::new("/tmp/test-workspace");
-        let paths = mcp_config_paths(workspace);
+        let paths = mcp_config_paths(workspace).unwrap();
         assert_eq!(paths.len(), 4);
         assert!(paths[0].ends_with("mcp.json"));
         assert!(paths[1].ends_with("mcp.d"));
@@ -581,7 +581,7 @@ mod tests {
             std::env::set_var("HOME", dir.path());
         }
 
-        let configs = load_and_merge_mcp_configs(&workspace);
+        let configs = load_and_merge_mcp_configs(&workspace).expect("load_and_merge_mcp_configs");
         assert_eq!(configs.len(), 2);
         assert!(configs.contains_key("shared"));
         assert!(configs.contains_key("local"));
@@ -614,7 +614,7 @@ mod tests {
             std::env::set_var("HOME", dir.path());
         }
 
-        let configs = load_and_merge_mcp_configs(&workspace);
+        let configs = load_and_merge_mcp_configs(&workspace).expect("load_and_merge_mcp_configs");
         assert!(configs.is_empty());
 
         match original_home {
@@ -645,7 +645,7 @@ mod tests {
             std::env::set_var("HOME", dir.path());
         }
 
-        let configs = load_and_merge_mcp_configs(&workspace);
+        let configs = load_and_merge_mcp_configs(&workspace).expect("load_and_merge_mcp_configs");
         assert_eq!(configs.len(), 1);
         assert!(configs.contains_key("good"));
 

--- a/egopulse/src/mcp.rs
+++ b/egopulse/src/mcp.rs
@@ -95,7 +95,9 @@ pub fn mcp_config_paths(workspace_dir: &Path) -> Result<Vec<PathBuf>, ConfigErro
     ])
 }
 
-pub fn load_and_merge_mcp_configs(workspace_dir: &Path) -> Result<HashMap<String, McpServerConfig>, ConfigError> {
+pub fn load_and_merge_mcp_configs(
+    workspace_dir: &Path,
+) -> Result<HashMap<String, McpServerConfig>, ConfigError> {
     let paths = mcp_config_paths(workspace_dir)?;
     let mut merged: HashMap<String, McpServerConfig> = HashMap::new();
 

--- a/egopulse/src/runtime.rs
+++ b/egopulse/src/runtime.rs
@@ -94,7 +94,7 @@ pub async fn build_app_state_with_path(
 ) -> Result<AppState, EgoPulseError> {
     let db = Arc::new(Database::new(&config.data_dir)?);
     let assets = Arc::new(AssetStore::new(&config.data_dir)?);
-    let skills = Arc::new(SkillManager::from_skills_dir(config.skills_dir()));
+    let skills = Arc::new(SkillManager::from_skills_dir(config.skills_dir()?));
 
     let mut channels = ChannelRegistry::new();
     channels.register(Arc::new(WebAdapter));
@@ -117,7 +117,8 @@ pub async fn build_app_state_with_path(
     let channels = Arc::new(channels);
     let mut tools = ToolRegistry::new(&config, Arc::clone(&skills));
 
-    let mcp_manager = crate::mcp::McpManager::new(&config.workspace_dir()).await;
+    let workspace_dir = config.workspace_dir()?;
+    let mcp_manager = crate::mcp::McpManager::new(&workspace_dir).await?;
     let mcp_arc = Arc::new(tokio::sync::RwLock::new(mcp_manager));
     tools.set_mcp_manager(mcp_arc);
 

--- a/egopulse/src/setup.rs
+++ b/egopulse/src/setup.rs
@@ -413,8 +413,11 @@ struct SetupApp {
 }
 
 impl SetupApp {
-    fn new(config_path: Option<PathBuf>) -> Self {
-        let config_path = config_path.unwrap_or_else(default_config_path);
+    fn new(config_path: Option<PathBuf>) -> Result<Self, String> {
+        let config_path = match config_path {
+            Some(path) => path,
+            None => default_config_path().map_err(|e| e.to_string())?,
+        };
         let (existing, original_yaml) = Self::load_existing_config(&config_path);
         let provider_id = existing
             .get("PROVIDER")
@@ -529,7 +532,7 @@ impl SetupApp {
         // Hide channel-specific fields when channel is disabled
         Self::update_field_visibility(&mut fields);
 
-        Self {
+        Ok(Self {
             fields,
             selected: 0,
             mode: SetupMode::Navigate,
@@ -539,7 +542,7 @@ impl SetupApp {
             completion_summary: Vec::new(),
             config_path,
             original_yaml,
-        }
+        })
     }
 
     fn update_field_visibility(fields: &mut [Field]) {
@@ -945,9 +948,9 @@ impl SetupApp {
             fs::create_dir_all(config_dir)
                 .map_err(|e| format!("Failed to create config directory: {e}"))?;
         }
-        fs::create_dir_all(default_data_dir())
+        fs::create_dir_all(default_data_dir().map_err(|e| e.to_string())?)
             .map_err(|e| format!("Failed to create data directory: {e}"))?;
-        fs::create_dir_all(default_workspace_dir())
+        fs::create_dir_all(default_workspace_dir().map_err(|e| e.to_string())?)
             .map_err(|e| format!("Failed to create workspace directory: {e}"))?;
 
         if config_path.exists() {
@@ -1031,7 +1034,7 @@ impl SetupApp {
             default_provider: provider_id.clone(),
             default_model: Some(model.clone()),
             providers,
-            data_dir: default_data_dir().to_string_lossy().into_owned(),
+            data_dir: default_data_dir().map_err(|e| e.to_string())?.to_string_lossy().into_owned(),
             log_level: "info".to_string(),
             compaction_timeout_secs: 180,
             max_history_messages: 50,
@@ -1578,7 +1581,7 @@ fn draw_selector_popup(frame: &mut ratatui::Frame<'_>, state: &SelectorState, ar
 
 /// Runs the interactive setup wizard and writes the resulting configuration file.
 pub async fn run_setup_wizard(config_path: Option<PathBuf>) -> Result<(), String> {
-    let mut app = SetupApp::new(config_path);
+    let mut app = SetupApp::new(config_path)?;
     let terminal = init_terminal()?;
 
     run_loop(terminal, &mut app).await
@@ -1938,7 +1941,7 @@ api_key: sk-legacy
     fn setup_mode_navigate_default() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let config_path = temp_dir.path().join("egopulse.config.yaml");
-        let app = SetupApp::new(Some(config_path));
+        let app = SetupApp::new(Some(config_path)).expect("setup app");
         assert!(matches!(app.mode, SetupMode::Navigate));
     }
 

--- a/egopulse/src/setup.rs
+++ b/egopulse/src/setup.rs
@@ -1034,7 +1034,10 @@ impl SetupApp {
             default_provider: provider_id.clone(),
             default_model: Some(model.clone()),
             providers,
-            data_dir: default_data_dir().map_err(|e| e.to_string())?.to_string_lossy().into_owned(),
+            data_dir: default_data_dir()
+                .map_err(|e| e.to_string())?
+                .to_string_lossy()
+                .into_owned(),
             log_level: "info".to_string(),
             compaction_timeout_secs: 180,
             max_history_messages: 50,

--- a/egopulse/src/tools.rs
+++ b/egopulse/src/tools.rs
@@ -117,7 +117,16 @@ pub struct ToolRegistry {
 impl ToolRegistry {
     /// Instantiate all built-in tools scoped to the configured workspace.
     pub fn new(config: &Config, skill_manager: Arc<SkillManager>) -> Self {
-        let workspace_dir = config.workspace_dir();
+        let workspace_dir = match config.workspace_dir() {
+            Ok(dir) => dir,
+            Err(error) => {
+                tracing::warn!("failed to resolve workspace dir: {error}");
+                return Self {
+                    tools: vec![Box::new(ActivateSkillTool::new(skill_manager))],
+                    mcp_manager: None,
+                };
+            }
+        };
         if let Err(error) = std::fs::create_dir_all(&workspace_dir) {
             tracing::warn!(
                 workspace_dir = %workspace_dir.display(),
@@ -2046,7 +2055,7 @@ mod tests {
     fn test_registry(config: &Config) -> ToolRegistry {
         ToolRegistry::new(
             config,
-            Arc::new(SkillManager::from_skills_dir(config.skills_dir())),
+            Arc::new(SkillManager::from_skills_dir(config.skills_dir().expect("skills_dir"))),
         )
     }
 
@@ -2056,7 +2065,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let _home = HomeGuard::set(dir.path());
         let config = test_config(dir.path().to_str().expect("utf8"));
-        let workspace = config.workspace_dir();
+        let workspace = config.workspace_dir().expect("workspace_dir");
         std::fs::create_dir_all(&workspace).expect("workspace");
         std::fs::write(workspace.join("notes.txt"), "hello\nworld").expect("write file");
         let registry = test_registry(&config);
@@ -2074,7 +2083,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let _home = HomeGuard::set(dir.path());
         let config = test_config(dir.path().to_str().expect("utf8"));
-        let workspace = config.workspace_dir();
+        let workspace = config.workspace_dir().expect("workspace_dir");
         std::fs::create_dir_all(&workspace).expect("workspace");
         std::fs::write(
             workspace.join("pixel.png"),
@@ -2108,7 +2117,7 @@ mod tests {
         let config = test_config(dir.path().to_str().expect("utf8"));
         let registry = test_registry(&config);
 
-        std::fs::create_dir_all(config.workspace_dir().join("src")).expect("create src dir");
+        std::fs::create_dir_all(config.workspace_dir().expect("workspace_dir").join("src")).expect("create src dir");
 
         let result = registry
             .execute(
@@ -2120,7 +2129,7 @@ mod tests {
         assert!(!result.is_error);
         assert!(result.content.contains("Successfully wrote 11 bytes"));
         assert_eq!(
-            std::fs::read_to_string(config.workspace_dir().join("src/demo.txt")).expect("read"),
+            std::fs::read_to_string(config.workspace_dir().expect("workspace_dir").join("src/demo.txt")).expect("read"),
             "hello world"
         );
     }
@@ -2131,7 +2140,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let _home = HomeGuard::set(dir.path());
         let config = test_config(dir.path().to_str().expect("utf8"));
-        let workspace = config.workspace_dir();
+        let workspace = config.workspace_dir().expect("workspace_dir");
         std::fs::create_dir_all(&workspace).expect("workspace");
         std::fs::write(workspace.join("notes.txt"), "alpha\nbeta\ngamma\n").expect("write");
         let registry = test_registry(&config);
@@ -2174,7 +2183,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let _home = HomeGuard::set(dir.path());
         let config = test_config(dir.path().to_str().expect("utf8"));
-        let workspace = config.workspace_dir();
+        let workspace = config.workspace_dir().expect("workspace_dir");
         std::fs::create_dir_all(workspace.join("nested")).expect("nested");
         std::fs::write(workspace.join("a.txt"), "a").expect("a");
         std::fs::write(workspace.join(".hidden"), "b").expect("hidden");
@@ -2192,7 +2201,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let _home = HomeGuard::set(dir.path());
         let config = test_config(dir.path().to_str().expect("utf8"));
-        let workspace = config.workspace_dir();
+        let workspace = config.workspace_dir().expect("workspace_dir");
         std::fs::create_dir_all(workspace.join("src")).expect("src");
         std::fs::write(workspace.join("src/lib.rs"), "pub fn demo() {}").expect("lib");
         let registry = test_registry(&config);
@@ -2210,7 +2219,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let _home = HomeGuard::set(dir.path());
         let config = test_config(dir.path().to_str().expect("utf8"));
-        let workspace = config.workspace_dir();
+        let workspace = config.workspace_dir().expect("workspace_dir");
         std::fs::create_dir_all(workspace.join("src")).expect("src");
         std::fs::write(workspace.join("src/lib.rs"), "pub fn demo() {}\n").expect("lib");
         let registry = test_registry(&config);
@@ -2228,7 +2237,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let _home = HomeGuard::set(dir.path());
         let config = test_config(dir.path().to_str().expect("utf8"));
-        let workspace = config.workspace_dir();
+        let workspace = config.workspace_dir().expect("workspace_dir");
         std::fs::create_dir_all(&workspace).expect("workspace");
         std::fs::write(workspace.join("notes.txt"), "hello").expect("notes");
         let registry = test_registry(&config);
@@ -2259,7 +2268,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let _home = HomeGuard::set(dir.path());
         let config = test_config(dir.path().to_str().expect("utf8"));
-        let skills_dir = config.skills_dir();
+        let skills_dir = config.skills_dir().expect("skills_dir");
         std::fs::create_dir_all(skills_dir.join("pdf")).expect("skill dir");
         std::fs::write(
             skills_dir.join("pdf").join("SKILL.md"),

--- a/egopulse/src/tools.rs
+++ b/egopulse/src/tools.rs
@@ -2055,7 +2055,9 @@ mod tests {
     fn test_registry(config: &Config) -> ToolRegistry {
         ToolRegistry::new(
             config,
-            Arc::new(SkillManager::from_skills_dir(config.skills_dir().expect("skills_dir"))),
+            Arc::new(SkillManager::from_skills_dir(
+                config.skills_dir().expect("skills_dir"),
+            )),
         )
     }
 
@@ -2117,7 +2119,8 @@ mod tests {
         let config = test_config(dir.path().to_str().expect("utf8"));
         let registry = test_registry(&config);
 
-        std::fs::create_dir_all(config.workspace_dir().expect("workspace_dir").join("src")).expect("create src dir");
+        std::fs::create_dir_all(config.workspace_dir().expect("workspace_dir").join("src"))
+            .expect("create src dir");
 
         let result = registry
             .execute(
@@ -2129,7 +2132,13 @@ mod tests {
         assert!(!result.is_error);
         assert!(result.content.contains("Successfully wrote 11 bytes"));
         assert_eq!(
-            std::fs::read_to_string(config.workspace_dir().expect("workspace_dir").join("src/demo.txt")).expect("read"),
+            std::fs::read_to_string(
+                config
+                    .workspace_dir()
+                    .expect("workspace_dir")
+                    .join("src/demo.txt")
+            )
+            .expect("read"),
             "hello world"
         );
     }

--- a/egopulse/src/web/config.rs
+++ b/egopulse/src/web/config.rs
@@ -95,7 +95,7 @@ pub(super) struct ConfigUpdateRequest {
 pub(super) async fn api_get_config(
     State(state): State<WebState>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let path = config_path_for_save(&state);
+    let path = config_path_for_save(&state).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let display = match Config::load_allow_missing_api_key(Some(&path)) {
         Ok(config) => Some(config),
         Err(ConfigError::ConfigNotFound { .. }) => None,
@@ -105,8 +105,8 @@ pub(super) async fn api_get_config(
     Ok(Json(serde_json::json!({
         "ok": true,
         "config": match display.as_ref() {
-            Some(display) => payload_from_config(display, &path),
-            None => default_payload(&path),
+            Some(display) => payload_from_config(display, &path).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+            None => default_payload(&path).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
         },
     })))
 }
@@ -133,7 +133,7 @@ pub(super) async fn api_put_config(
         ));
     }
 
-    let path = config_path_for_save(&state);
+    let path = config_path_for_save(&state).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
 
     let mut config = match Config::load_allow_missing_api_key(Some(&path)) {
         Ok(config) => config,
@@ -188,7 +188,7 @@ pub(super) async fn api_put_config(
 
     Ok(Json(serde_json::json!({
         "ok": true,
-        "config": payload_from_config(&display, &path),
+        "config": payload_from_config(&display, &path).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
     })))
 }
 
@@ -345,15 +345,15 @@ fn apply_channel_overrides(
     Ok(())
 }
 
-fn default_payload(path: &std::path::Path) -> ConfigPayload {
-    ConfigPayload {
+fn default_payload(path: &std::path::Path) -> Result<ConfigPayload, ConfigError> {
+    Ok(ConfigPayload {
         default_provider: String::new(),
         default_model: None,
         effective_model: String::new(),
-        data_dir: crate::config::default_data_dir()
+        data_dir: crate::config::default_data_dir()?
             .to_string_lossy()
             .into_owned(),
-        workspace_dir: crate::config::default_workspace_dir()
+        workspace_dir: crate::config::default_workspace_dir()?
             .to_string_lossy()
             .into_owned(),
         web_enabled: false,
@@ -364,17 +364,17 @@ fn default_payload(path: &std::path::Path) -> ConfigPayload {
         config_path: path.display().to_string(),
         providers: Vec::new(),
         channel_overrides: HashMap::new(),
+    })
+}
+
+fn config_path_for_save(state: &WebState) -> Result<PathBuf, ConfigError> {
+    match &state.config_path {
+        Some(path) => Ok(path.clone()),
+        None => default_config_path(),
     }
 }
 
-fn config_path_for_save(state: &WebState) -> PathBuf {
-    state
-        .config_path
-        .clone()
-        .unwrap_or_else(default_config_path)
-}
-
-fn payload_from_config(config: &Config, path: &std::path::Path) -> ConfigPayload {
+fn payload_from_config(config: &Config, path: &std::path::Path) -> Result<ConfigPayload, ConfigError> {
     let resolved = config.resolve_global_llm();
 
     let providers = config
@@ -407,12 +407,12 @@ fn payload_from_config(config: &Config, path: &std::path::Path) -> ConfigPayload
         })
         .collect();
 
-    ConfigPayload {
+    Ok(ConfigPayload {
         default_provider: resolved.provider,
         default_model: config.default_model.clone(),
         effective_model: resolved.model,
         data_dir: config.data_dir.clone(),
-        workspace_dir: crate::config::default_workspace_dir()
+        workspace_dir: crate::config::default_workspace_dir()?
             .to_string_lossy()
             .into_owned(),
         web_enabled: config.web_enabled(),
@@ -423,7 +423,7 @@ fn payload_from_config(config: &Config, path: &std::path::Path) -> ConfigPayload
         config_path: path.display().to_string(),
         providers,
         channel_overrides,
-    }
+    })
 }
 
 fn infer_provider_label(provider: &str) -> String {

--- a/egopulse/src/web/config.rs
+++ b/egopulse/src/web/config.rs
@@ -95,7 +95,8 @@ pub(super) struct ConfigUpdateRequest {
 pub(super) async fn api_get_config(
     State(state): State<WebState>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let path = config_path_for_save(&state).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let path = config_path_for_save(&state)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let display = match Config::load_allow_missing_api_key(Some(&path)) {
         Ok(config) => Some(config),
         Err(ConfigError::ConfigNotFound { .. }) => None,
@@ -133,7 +134,8 @@ pub(super) async fn api_put_config(
         ));
     }
 
-    let path = config_path_for_save(&state).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+    let path = config_path_for_save(&state)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let mut config = match Config::load_allow_missing_api_key(Some(&path)) {
         Ok(config) => config,
@@ -374,7 +376,10 @@ fn config_path_for_save(state: &WebState) -> Result<PathBuf, ConfigError> {
     }
 }
 
-fn payload_from_config(config: &Config, path: &std::path::Path) -> Result<ConfigPayload, ConfigError> {
+fn payload_from_config(
+    config: &Config,
+    path: &std::path::Path,
+) -> Result<ConfigPayload, ConfigError> {
     let resolved = config.resolve_global_llm();
 
     let providers = config


### PR DESCRIPTION
## 概要

Issue endo-ly/egopulse#8 の妥当性検証と修正。調査の結果、Issue が主張する「~20箇所の unwrap/panic」は既に大部分が解消済みであり、**生産コードに残存する実質的な panic は1箇所のみ**（`config::default_state_root`）であることを確認しました。

## 変更内容

### 根本原因
`default_state_root()` が `dirs::home_dir()` の解決失敗時に `panic!` でアプリケーション全体をクラッシュさせていた。コンテナ環境等で `HOME` が未設定の場合、起動時にユーザーへのエラー表示なしに異常終了する。

### 修正方針
`default_state_root()` → `Result<PathBuf, ConfigError>` に変更し、エラーを呼び出しチェーン経由で `main()` まで伝播させる。`main()` は既に `Result<(), EgoPulseError>` を返すため、最終的にユーザーフレンドリーなエラーメッセージとして表示される。

### 変更ファイル（11ファイル）
| ファイル | 変更 |
|---|---|
| `error.rs` | `ConfigError::HomeDirectoryUnresolved` 変種を追加 |
| `config.rs` | `default_state_root/config_path/data_dir/workspace_dir` → Result化、`skills_dir/workspace_dir` → Result化 |
| `mcp.rs` | `mcp_config_paths/load_and_merge_mcp_configs` → Result化、`McpManager::new` → Result化 |
| `runtime.rs` | Result伝播の追従 |
| `setup.rs` | `SetupApp::new` → Result化、save() の追従 |
| `main.rs` | Result伝播の追従 |
| `gateway.rs` | `runtime_default_config_path` を `default_config_path().ok()` に統一 |
| `web/config.rs` | `default_payload/config_path_for_save/payload_from_config` → Result化 |
| `tools.rs` | `ToolRegistry::new` で graceful degradation（エラー時は最小ツールセット） |
| `agent_loop/session.rs`, `agent_loop/turn.rs` | テストコードの追従 |

## 検証

- ✅ `cargo check -p egopulse` — 通過
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` — 警告なし
- ✅ `cargo test -p egopulse` — 123/123 テスト通過

## Issue endo-ly/egopulse#8 に対する所見

Issue の「対象箇所」に挙げられた行番号の大部分は、以前のリファクタリングで既に安全なイディオム（`.unwrap_or_default()`、`.map_err()` 等）に置き換えられていました。Issue 作成時点のコードとは乖離があります。残存する正当な用法（`main.rs` の `unreachable!`、`llm.rs` の `LazyLock<Regex>::expect`）は変更していません。

Close endo-ly/egopulse#8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * 設定・セットアップ処理のエラーハンドリングが全体的に強化され、設定パスやホームディレクトリ未解決時のエラー検出が早期化しました。
* **バグ修正 / 挙動変更**
  * Web APIの設定関連エンドポイントが設定解決エラーを適切にHTTP 500で返すようになりました。
  * 初期化処理やツール登録で不整合なパスを検出した際に安全にフォールバックまたはエラーを返すようになりました。
* **テスト**
  * テストコードが新しいエラーハンドリングに合わせて更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->