### PR TITLE
feat(egopulse): add slash commands for session management

### DIFF
--- a/egopulse/src/agent_loop/compaction.rs
+++ b/egopulse/src/agent_loop/compaction.rs
@@ -20,83 +20,9 @@ pub(crate) async fn maybe_compact_messages(
         return Ok(messages.to_vec());
     }
 
-    archive_conversation(&state.config.data_dir, &context.channel, chat_id, messages).await;
-
-    let keep_recent = state.config.compact_keep_recent.min(messages.len());
-    if keep_recent == messages.len() {
-        return Ok(messages.to_vec());
-    }
-
-    let split_at = messages.len() - keep_recent;
-    let old_messages = &messages[..split_at];
-    let recent_messages = &messages[split_at..];
-
-    let mut summary_input = String::new();
-    for message in old_messages {
-        let role = &message.role;
-        let text = message_to_text(message);
-        summary_input.push_str(&format!("[{role}]: {text}\n\n"));
-    }
-    summary_input = truncate_compaction_summary_input(summary_input);
-
-    let summarize_prompt = "Summarize the following conversation concisely, preserving key facts, decisions, tool results, and context needed to continue the conversation. Be brief but thorough.";
-    let summarize_messages = vec![Message::text(
-        "user",
-        format!("{summarize_prompt}\n\n---\n\n{summary_input}"),
-    )];
-    let timeout_secs = state.config.compaction_timeout_secs;
-    let summary_result = tokio::time::timeout(
-        std::time::Duration::from_secs(timeout_secs),
-        llm.send_message("You are a helpful summarizer.", summarize_messages, None),
-    )
-    .await;
-
-    let summary = match summary_result {
-        Ok(Ok(response)) => strip_thinking(&response.content),
-        Ok(Err(error)) => {
-            warn!("compaction summarization failed: {error}; falling back to recent messages");
-            return Ok(recent_messages.to_vec());
-        }
-        Err(_) => {
-            warn!(
-                "compaction summarization timed out after {timeout_secs}s for {}:{}; falling back to recent messages",
-                context.channel, chat_id
-            );
-            return Ok(recent_messages.to_vec());
-        }
-    };
-    if summary.trim().is_empty() {
-        warn!("compaction summarization returned empty text; falling back to recent messages");
-        return Ok(recent_messages.to_vec());
-    }
-
-    let mut compacted = vec![Message::text(
-        "user",
-        format!("[Conversation Summary]\n{summary}"),
-    )];
-    if !matches!(recent_messages.first(), Some(message) if message.role == "assistant") {
-        compacted.push(Message::text(
-            "assistant",
-            "Understood, I have the conversation context. How can I help?",
-        ));
-    }
-
-    for message in recent_messages {
-        append_compacted_message(&mut compacted, message);
-    }
-
-    if matches!(compacted.last(), Some(last) if last.role == "assistant") {
-        compacted.pop();
-    }
-
-    Ok(compacted)
+    summarize_and_compact(state, context, chat_id, messages, llm, "compaction").await
 }
 
-/// メッセージ数に関わらず必ず圧縮を実行する。
-///
-/// `maybe_compact_messages` と同一の要約・圧縮ロジックだが、閾値判定をスキップする。
-/// 空セッションの場合は空ベクタを返し、メッセージ数が `compact_keep_recent` 以下の場合は
-/// アーカイブだけ行ってメッセージをそのまま返す。
 pub async fn force_compact(
     state: &AppState,
     context: &SurfaceContext,
@@ -108,6 +34,17 @@ pub async fn force_compact(
         return Ok(Vec::new());
     }
 
+    summarize_and_compact(state, context, chat_id, messages, llm, "force_compact").await
+}
+
+async fn summarize_and_compact(
+    state: &AppState,
+    context: &SurfaceContext,
+    chat_id: i64,
+    messages: &[Message],
+    llm: &std::sync::Arc<dyn crate::llm::LlmProvider>,
+    label: &str,
+) -> Result<Vec<Message>, EgoPulseError> {
     archive_conversation(&state.config.data_dir, &context.channel, chat_id, messages).await;
 
     let keep_recent = state.config.compact_keep_recent.min(messages.len());
@@ -142,19 +79,19 @@ pub async fn force_compact(
     let summary = match summary_result {
         Ok(Ok(response)) => strip_thinking(&response.content),
         Ok(Err(error)) => {
-            warn!("force_compact summarization failed: {error}; falling back to recent messages");
+            warn!("{label} summarization failed: {error}; falling back to recent messages");
             return Ok(recent_messages.to_vec());
         }
         Err(_) => {
             warn!(
-                "force_compact summarization timed out after {timeout_secs}s for {}:{}; falling back to recent messages",
+                "{label} summarization timed out after {timeout_secs}s for {}:{}; falling back to recent messages",
                 context.channel, chat_id
             );
             return Ok(recent_messages.to_vec());
         }
     };
     if summary.trim().is_empty() {
-        warn!("force_compact summarization returned empty text; falling back to recent messages");
+        warn!("{label} summarization returned empty text; falling back to recent messages");
         return Ok(recent_messages.to_vec());
     }
 

--- a/egopulse/src/agent_loop/compaction.rs
+++ b/egopulse/src/agent_loop/compaction.rs
@@ -92,6 +92,94 @@ pub(crate) async fn maybe_compact_messages(
     Ok(compacted)
 }
 
+/// メッセージ数に関わらず必ず圧縮を実行する。
+///
+/// `maybe_compact_messages` と同一の要約・圧縮ロジックだが、閾値判定をスキップする。
+/// 空セッションの場合は空ベクタを返し、メッセージ数が `compact_keep_recent` 以下の場合は
+/// アーカイブだけ行ってメッセージをそのまま返す。
+pub async fn force_compact(
+    state: &AppState,
+    context: &SurfaceContext,
+    chat_id: i64,
+    messages: &[Message],
+    llm: &std::sync::Arc<dyn crate::llm::LlmProvider>,
+) -> Result<Vec<Message>, EgoPulseError> {
+    if messages.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    archive_conversation(&state.config.data_dir, &context.channel, chat_id, messages).await;
+
+    let keep_recent = state.config.compact_keep_recent.min(messages.len());
+    if keep_recent == messages.len() {
+        return Ok(messages.to_vec());
+    }
+
+    let split_at = messages.len() - keep_recent;
+    let old_messages = &messages[..split_at];
+    let recent_messages = &messages[split_at..];
+
+    let mut summary_input = String::new();
+    for message in old_messages {
+        let role = &message.role;
+        let text = message_to_text(message);
+        summary_input.push_str(&format!("[{role}]: {text}\n\n"));
+    }
+    summary_input = truncate_compaction_summary_input(summary_input);
+
+    let summarize_prompt = "Summarize the following conversation concisely, preserving key facts, decisions, tool results, and context needed to continue the conversation. Be brief but thorough.";
+    let summarize_messages = vec![Message::text(
+        "user",
+        format!("{summarize_prompt}\n\n---\n\n{summary_input}"),
+    )];
+    let timeout_secs = state.config.compaction_timeout_secs;
+    let summary_result = tokio::time::timeout(
+        std::time::Duration::from_secs(timeout_secs),
+        llm.send_message("You are a helpful summarizer.", summarize_messages, None),
+    )
+    .await;
+
+    let summary = match summary_result {
+        Ok(Ok(response)) => strip_thinking(&response.content),
+        Ok(Err(error)) => {
+            warn!("force_compact summarization failed: {error}; falling back to recent messages");
+            return Ok(recent_messages.to_vec());
+        }
+        Err(_) => {
+            warn!(
+                "force_compact summarization timed out after {timeout_secs}s for {}:{}; falling back to recent messages",
+                context.channel, chat_id
+            );
+            return Ok(recent_messages.to_vec());
+        }
+    };
+    if summary.trim().is_empty() {
+        warn!("force_compact summarization returned empty text; falling back to recent messages");
+        return Ok(recent_messages.to_vec());
+    }
+
+    let mut compacted = vec![Message::text(
+        "user",
+        format!("[Conversation Summary]\n{summary}"),
+    )];
+    if !matches!(recent_messages.first(), Some(message) if message.role == "assistant") {
+        compacted.push(Message::text(
+            "assistant",
+            "Understood, I have the conversation context. How can I help?",
+        ));
+    }
+
+    for message in recent_messages {
+        append_compacted_message(&mut compacted, message);
+    }
+
+    if matches!(compacted.last(), Some(last) if last.role == "assistant") {
+        compacted.pop();
+    }
+
+    Ok(compacted)
+}
+
 pub(crate) async fn archive_conversation(
     data_dir: &str,
     channel: &str,
@@ -434,5 +522,116 @@ mod tests {
                 .as_text_lossy(),
             "final answer"
         );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn force_compact_runs_regardless_of_threshold() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::new(
+            vec![Ok(MessagesResponse {
+                content: "summary text".to_string(),
+                tool_calls: Vec::new(),
+            })],
+            vec![0],
+        );
+        let config =
+            test_config_with_compaction(dir.path().to_str().expect("utf8").to_string(), 40, 1);
+        let state = build_state(config, Box::new(provider.clone()));
+        let context = cli_context("force-compact-threshold");
+        let llm = state.global_llm().expect("llm");
+        let messages = vec![
+            Message::text("user", "msg-1"),
+            Message::text("assistant", "reply-1"),
+        ];
+
+        let result = force_compact(&state, &context, 1, &messages, &llm)
+            .await
+            .expect("force_compact");
+
+        assert_eq!(provider.seen_systems().len(), 1);
+        assert_eq!(provider.seen_systems()[0], "You are a helpful summarizer.");
+        assert!(
+            result
+                .first()
+                .is_some_and(|m| m.content.as_text_lossy().contains("[Conversation Summary]"))
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn force_compact_preserves_recent_messages() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::new(
+            vec![Ok(MessagesResponse {
+                content: "summary text".to_string(),
+                tool_calls: Vec::new(),
+            })],
+            vec![0],
+        );
+        let config =
+            test_config_with_compaction(dir.path().to_str().expect("utf8").to_string(), 40, 2);
+        let state = build_state(config, Box::new(provider.clone()));
+        let context = cli_context("force-compact-recent");
+        let llm = state.global_llm().expect("llm");
+        let messages = vec![
+            Message::text("user", "old-1"),
+            Message::text("assistant", "old-2"),
+            Message::text("user", "old-3"),
+            Message::text("assistant", "old-4"),
+            Message::text("user", "kept-a"),
+            Message::text("assistant", "kept-b"),
+            Message::text("user", "kept-c"),
+        ];
+
+        let result = force_compact(&state, &context, 1, &messages, &llm)
+            .await
+            .expect("force_compact");
+
+        let text: Vec<String> = result.iter().map(|m| m.content.as_text_lossy()).collect();
+        assert!(text.iter().any(|t| t.contains("kept-b")));
+        assert!(text.iter().any(|t| t.contains("kept-c")));
+        assert!(text.iter().any(|t| t.contains("kept-c")));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn force_compact_produces_archive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().to_str().expect("utf8").to_string();
+        let provider = RecordingProvider::new(
+            vec![Ok(MessagesResponse {
+                content: "summary text".to_string(),
+                tool_calls: Vec::new(),
+            })],
+            vec![0],
+        );
+        let config = test_config_with_compaction(data_dir.clone(), 40, 1);
+        let state = build_state(config, Box::new(provider.clone()));
+        let context = cli_context("force-compact-archive");
+        let llm = state.global_llm().expect("llm");
+        let chat_id: i64 = 42;
+        let messages = vec![
+            Message::text("user", "msg-1"),
+            Message::text("assistant", "reply-1"),
+        ];
+
+        force_compact(&state, &context, chat_id, &messages, &llm)
+            .await
+            .expect("force_compact");
+
+        let archive_dir = dir
+            .path()
+            .join("groups")
+            .join("cli")
+            .join(chat_id.to_string())
+            .join("conversations");
+        let archives = std::fs::read_dir(&archive_dir)
+            .expect("archive dir")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("archive entries");
+        assert_eq!(archives.len(), 1);
+        let body = std::fs::read_to_string(archives[0].path()).expect("archive body");
+        assert!(body.contains("msg-1"));
     }
 }

--- a/egopulse/src/agent_loop/compaction.rs
+++ b/egopulse/src/agent_loop/compaction.rs
@@ -591,7 +591,6 @@ mod tests {
         let text: Vec<String> = result.iter().map(|m| m.content.as_text_lossy()).collect();
         assert!(text.iter().any(|t| t.contains("kept-b")));
         assert!(text.iter().any(|t| t.contains("kept-c")));
-        assert!(text.iter().any(|t| t.contains("kept-c")));
     }
 
     #[tokio::test]

--- a/egopulse/src/channels/cli.rs
+++ b/egopulse/src/channels/cli.rs
@@ -3,10 +3,10 @@
 //! 標準入出力を使った永続化チャットセッションを提供し、入力ごとに agent loop を実行する。
 
 use std::io::{self, BufRead, Write};
+use std::sync::Arc;
 
 use crate::agent_loop::{SurfaceContext, process_turn};
 use crate::error::EgoPulseError;
-use crate::llm_profile;
 use crate::runtime::AppState;
 
 /// Runs an interactive CLI chat loop for the given persistent session.
@@ -39,20 +39,33 @@ pub async fn run_chat(state: &AppState, session: &str) -> Result<(), EgoPulseErr
             break;
         }
 
-        match llm_profile::handle_command(state, &context, trimmed).await {
-            Ok(Some(response)) => {
+        if crate::slash_commands::is_slash_command(trimmed) {
+            let slash_chat_id = crate::storage::call_blocking(Arc::clone(&state.db), {
+                let channel = context.channel.clone();
+                let thread = context.surface_thread.clone();
+                let chat_type = context.chat_type.clone();
+                move |db| {
+                    db.resolve_or_create_chat_id(
+                        &channel,
+                        &format!("cli:{thread}"),
+                        Some(&thread),
+                        &chat_type,
+                    )
+                }
+            })
+            .await
+            .map_err(EgoPulseError::from)?;
+
+            if let Some(response) = crate::slash_commands::handle_slash_command(
+                state,
+                slash_chat_id,
+                &context.channel,
+                trimmed,
+                None,
+            )
+            .await
+            {
                 writeln!(stdout, "assistant: {response}")
-                    .map_err(crate::error::StorageError::Io)
-                    .map_err(EgoPulseError::from)?;
-                stdout
-                    .flush()
-                    .map_err(crate::error::StorageError::Io)
-                    .map_err(EgoPulseError::from)?;
-                continue;
-            }
-            Ok(None) => {}
-            Err(error) => {
-                writeln!(stdout, "assistant: Command error: {error}")
                     .map_err(crate::error::StorageError::Io)
                     .map_err(EgoPulseError::from)?;
                 stdout

--- a/egopulse/src/channels/discord.rs
+++ b/egopulse/src/channels/discord.rs
@@ -169,10 +169,39 @@ impl EventHandler for Handler {
             return;
         }
 
-        let sender_name = msg.author.name.clone();
-
         // microclaw パターン: chat_type を "discord" に統一
         let external_chat_id = external_channel_id.to_string();
+
+        // --- スラッシュコマンドインターセプト ---
+        if crate::slash_commands::is_slash_command(&text) {
+            let slash_chat_id =
+                crate::storage::call_blocking(std::sync::Arc::clone(&self.app_state.db), {
+                    let channel = "discord".to_string();
+                    let ext_id = external_chat_id.clone();
+                    let chat_type = "discord".to_string();
+                    move |db| db.resolve_or_create_chat_id(&channel, &ext_id, None, &chat_type)
+                })
+                .await;
+
+            if let Ok(chat_id) = slash_chat_id {
+                let sender_id = msg.author.id.get().to_string();
+                if let Some(response) = crate::slash_commands::handle_slash_command(
+                    &self.app_state,
+                    chat_id,
+                    "discord",
+                    &text,
+                    Some(&sender_id),
+                )
+                .await
+                {
+                    send_discord_response(&ctx, msg.channel_id, &response).await;
+                    return;
+                }
+            }
+        }
+        // --- インターセプトここまで ---
+
+        let sender_name = msg.author.name.clone();
 
         let context = SurfaceContext {
             channel: "discord".to_string(),

--- a/egopulse/src/channels/discord.rs
+++ b/egopulse/src/channels/discord.rs
@@ -183,18 +183,30 @@ impl EventHandler for Handler {
                 })
                 .await;
 
-            if let Ok(chat_id) = slash_chat_id {
-                let sender_id = msg.author.id.get().to_string();
-                if let Some(response) = crate::slash_commands::handle_slash_command(
-                    &self.app_state,
-                    chat_id,
-                    "discord",
-                    &text,
-                    Some(&sender_id),
-                )
-                .await
-                {
-                    send_discord_response(&ctx, msg.channel_id, &response).await;
+            match slash_chat_id {
+                Ok(chat_id) => {
+                    let sender_id = msg.author.id.get().to_string();
+                    if let Some(response) = crate::slash_commands::handle_slash_command(
+                        &self.app_state,
+                        chat_id,
+                        "discord",
+                        &text,
+                        Some(&sender_id),
+                    )
+                    .await
+                    {
+                        send_discord_response(&ctx, msg.channel_id, &response).await;
+                        return;
+                    }
+                }
+                Err(e) => {
+                    error!("failed to resolve chat_id for slash command: {e}");
+                    send_discord_response(
+                        &ctx,
+                        msg.channel_id,
+                        "An error occurred processing the command.",
+                    )
+                    .await;
                     return;
                 }
             }

--- a/egopulse/src/channels/telegram.rs
+++ b/egopulse/src/channels/telegram.rs
@@ -168,38 +168,47 @@ async fn handle_message(
     // グループ/スーパーグループでは message entity の Mention で正確に判定
     let is_group = chat_type != "telegram_private";
     if is_group {
-        let bot_username = state.config.telegram_bot_username();
-        let mentioned = match &bot_username {
-            Some(username) => msg
-                .parse_entities()
-                .into_iter()
-                .flatten()
-                .filter(|e| matches!(e.kind(), MessageEntityKind::Mention))
-                .any(|e| {
-                    e.text()
-                        .strip_prefix('@')
-                        .is_some_and(|m| m.eq_ignore_ascii_case(username))
-                }),
-            None => {
-                if BOT_USERNAME_WARN_EMITTED
-                    .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-                    .is_ok()
-                {
-                    warn!(
-                        chat_id = raw_chat_id,
-                        "telegram_bot_username not set; group messages will be ignored"
-                    );
-                }
-                false
-            }
-        };
+        let is_bot_command = msg
+            .entities()
+            .unwrap_or_default()
+            .iter()
+            .any(|e| matches!(e.kind, MessageEntityKind::BotCommand));
 
-        if !mentioned {
-            debug!(
-                chat_id = raw_chat_id,
-                "Telegram: skipping non-mentioned group message"
-            );
-            return Ok(());
+        if is_bot_command {
+        } else {
+            let bot_username = state.config.telegram_bot_username();
+            let mentioned = match &bot_username {
+                Some(username) => msg
+                    .parse_entities()
+                    .into_iter()
+                    .flatten()
+                    .filter(|e| matches!(e.kind(), MessageEntityKind::Mention))
+                    .any(|e| {
+                        e.text()
+                            .strip_prefix('@')
+                            .is_some_and(|m| m.eq_ignore_ascii_case(username))
+                    }),
+                None => {
+                    if BOT_USERNAME_WARN_EMITTED
+                        .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                        .is_ok()
+                    {
+                        warn!(
+                            chat_id = raw_chat_id,
+                            "telegram_bot_username not set; group messages will be ignored"
+                        );
+                    }
+                    false
+                }
+            };
+
+            if !mentioned {
+                debug!(
+                    chat_id = raw_chat_id,
+                    "Telegram: skipping non-mentioned group message"
+                );
+                return Ok(());
+            }
         }
     }
 

--- a/egopulse/src/channels/telegram.rs
+++ b/egopulse/src/channels/telegram.rs
@@ -168,13 +168,26 @@ async fn handle_message(
     // グループ/スーパーグループでは message entity の Mention で正確に判定
     let is_group = chat_type != "telegram_private";
     if is_group {
-        let is_bot_command = msg
+        let bot_username = state.config.telegram_bot_username();
+        let msg_text = text.as_str();
+        let is_own_command = msg
             .entities()
             .unwrap_or_default()
             .iter()
-            .any(|e| matches!(e.kind, MessageEntityKind::BotCommand));
+            .filter(|e| matches!(e.kind, MessageEntityKind::BotCommand))
+            .any(|e| {
+                let start = e.offset;
+                let end = start + e.length;
+                let cmd_text = msg_text.get(start..end).unwrap_or("");
+                if let Some(at_pos) = cmd_text.find('@') {
+                    let mention = &cmd_text[at_pos + 1..];
+                    bot_username.is_some_and(|u| mention.eq_ignore_ascii_case(u))
+                } else {
+                    true
+                }
+            });
 
-        if is_bot_command {
+        if is_own_command {
         } else {
             let bot_username = state.config.telegram_bot_username();
             let mentioned = match &bot_username {

--- a/egopulse/src/channels/telegram.rs
+++ b/egopulse/src/channels/telegram.rs
@@ -183,13 +183,11 @@ async fn handle_message(
                     let mention = &cmd_text[at_pos + 1..];
                     bot_username.is_some_and(|u| mention.eq_ignore_ascii_case(u))
                 } else {
-                    true
+                    bot_username.is_some()
                 }
             });
 
-        if is_own_command {
-        } else {
-            let bot_username = state.config.telegram_bot_username();
+        if !is_own_command {
             let mentioned = match &bot_username {
                 Some(username) => msg
                     .parse_entities()

--- a/egopulse/src/channels/telegram.rs
+++ b/egopulse/src/channels/telegram.rs
@@ -18,6 +18,8 @@ use crate::agent_loop::SurfaceContext;
 use crate::channel_adapter::ChannelAdapter;
 use crate::channel_adapter::ConversationKind;
 use crate::runtime::AppState;
+use crate::slash_commands;
+use crate::storage::call_blocking;
 use crate::text::split_text;
 
 /// Telegram メッセージ長制限 (文字数)。
@@ -207,7 +209,7 @@ async fn handle_message(
         channel: "telegram".to_string(),
         surface_user: sender_name,
         surface_thread: external_chat_id.clone(),
-        chat_type,
+        chat_type: chat_type.clone(),
     };
 
     info!(
@@ -216,6 +218,34 @@ async fn handle_message(
         text_length = text.len(),
         "Telegram message received"
     );
+
+    // --- スラッシュコマンドインターセプト ---
+    // process_turn より先に chat_id を解決し、
+    // スラッシュコマンドであればエージェントループに入らずに即応答する。
+    if slash_commands::is_slash_command(&text) {
+        let resolved_chat_id = call_blocking(std::sync::Arc::clone(&state.db), {
+            let channel = "telegram".to_string();
+            let ext_id = external_chat_id.clone();
+            move |db| db.resolve_or_create_chat_id(&channel, &ext_id, None, &chat_type)
+        })
+        .await
+        .expect("resolve chat_id for slash command");
+
+        let sender_id = msg.from.as_ref().map(|u| u.id.0.to_string());
+        if let Some(response) = slash_commands::handle_slash_command(
+            &state,
+            resolved_chat_id,
+            "telegram",
+            &text,
+            sender_id.as_deref(),
+        )
+        .await
+        {
+            send_telegram_response(&bot, msg.chat.id, &response).await;
+            return Ok(());
+        }
+    }
+    // --- インターセプトここまで ---
 
     // タイピングインジケーター (バックグラウンドタスクで定期的に送信)
     let typing_bot = bot.clone();
@@ -229,7 +259,6 @@ async fn handle_message(
         }
     });
 
-    // session 解決は process_turn() に一任 (二重解決を避ける)
     match crate::agent_loop::process_turn(&state, &context, &text).await {
         Ok(response) => {
             typing_handle.abort();
@@ -289,6 +318,26 @@ pub async fn start_telegram_bot(
     bot.delete_webhook().await.inspect_err(|e| {
         error!("Telegram: failed to delete webhook: {e}");
     })?;
+
+    // BotFather にコマンド一覧を登録 (メニュー表示用)
+    {
+        use teloxide::types::BotCommand;
+
+        let commands = vec![
+            BotCommand::new("new", "Clear current session"),
+            BotCommand::new("compact", "Force compact session"),
+            BotCommand::new("status", "Show current status"),
+            BotCommand::new("skills", "List available skills"),
+            BotCommand::new("restart", "Restart the bot"),
+            BotCommand::new("providers", "List LLM providers"),
+            BotCommand::new("provider", "Show/switch provider"),
+            BotCommand::new("models", "List models"),
+            BotCommand::new("model", "Show/switch model"),
+        ];
+        if let Err(e) = bot.set_my_commands(commands).await {
+            warn!("Telegram: failed to set bot commands: {e}");
+        }
+    }
 
     info!("Starting Telegram bot...");
 

--- a/egopulse/src/channels/telegram.rs
+++ b/egopulse/src/channels/telegram.rs
@@ -223,13 +223,25 @@ async fn handle_message(
     // process_turn より先に chat_id を解決し、
     // スラッシュコマンドであればエージェントループに入らずに即応答する。
     if slash_commands::is_slash_command(&text) {
-        let resolved_chat_id = call_blocking(std::sync::Arc::clone(&state.db), {
+        let resolved_chat_id = match call_blocking(std::sync::Arc::clone(&state.db), {
             let channel = "telegram".to_string();
             let ext_id = external_chat_id.clone();
             move |db| db.resolve_or_create_chat_id(&channel, &ext_id, None, &chat_type)
         })
         .await
-        .expect("resolve chat_id for slash command");
+        {
+            Ok(id) => id,
+            Err(e) => {
+                error!("failed to resolve chat_id for slash command: {e}");
+                send_telegram_response(
+                    &bot,
+                    msg.chat.id,
+                    "An error occurred processing the command.",
+                )
+                .await;
+                return Ok(());
+            }
+        };
 
         let sender_id = msg.from.as_ref().map(|u| u.id.0.to_string());
         if let Some(response) = slash_commands::handle_slash_command(

--- a/egopulse/src/channels/tui.rs
+++ b/egopulse/src/channels/tui.rs
@@ -24,7 +24,6 @@ use uuid::Uuid;
 use crate::agent_loop;
 use crate::agent_loop::SurfaceContext;
 use crate::error::{EgoPulseError, TuiError};
-use crate::llm_profile;
 use crate::runtime::AppState;
 use crate::storage::SessionSummary;
 
@@ -390,21 +389,53 @@ async fn run_loop(
                     }
                     PendingAction::SendMessage(prompt) => {
                         if let View::Chat(chat) = &mut app.view {
-                            match llm_profile::handle_command(&app.state, &chat.context, &prompt)
-                                .await
-                            {
-                                Ok(Some(response)) => {
-                                    chat.messages.push(RenderedMessage {
-                                        role: "assistant".to_string(),
-                                        content: response,
-                                    });
-                                    chat.status = "Command applied".to_string();
-                                    chat.conversation_scroll = 0;
+                            if crate::slash_commands::is_slash_command(&prompt) {
+                                let slash_chat_id = crate::storage::call_blocking(
+                                    std::sync::Arc::clone(&app.state.db),
+                                    {
+                                        let channel = chat.context.channel.clone();
+                                        let thread = chat.context.surface_thread.clone();
+                                        let chat_type = chat.context.chat_type.clone();
+                                        move |db| {
+                                            db.resolve_or_create_chat_id(
+                                                &channel,
+                                                &format!("tui:{thread}"),
+                                                Some(&thread),
+                                                &chat_type,
+                                            )
+                                        }
+                                    },
+                                )
+                                .await;
+
+                                match slash_chat_id {
+                                    Ok(chat_id) => {
+                                        if let Some(response) =
+                                            crate::slash_commands::handle_slash_command(
+                                                &app.state,
+                                                chat_id,
+                                                &chat.context.channel,
+                                                &prompt,
+                                                None,
+                                            )
+                                            .await
+                                        {
+                                            chat.messages.push(RenderedMessage {
+                                                role: "assistant".to_string(),
+                                                content: response,
+                                            });
+                                            chat.status = "Command applied".to_string();
+                                            chat.conversation_scroll = 0;
+                                        } else {
+                                            chat.status = "Unknown command".to_string();
+                                        }
+                                    }
+                                    Err(e) => {
+                                        chat.status = format!("Command error: {e}");
+                                    }
                                 }
-                                Ok(None) => start_send(app, prompt),
-                                Err(error) => {
-                                    chat.status = format!("Command error: {error}");
-                                }
+                            } else {
+                                start_send(app, prompt);
                             }
                         }
                     }

--- a/egopulse/src/channels/tui.rs
+++ b/egopulse/src/channels/tui.rs
@@ -390,6 +390,11 @@ async fn run_loop(
                     PendingAction::SendMessage(prompt) => {
                         if let View::Chat(chat) = &mut app.view {
                             if crate::slash_commands::is_slash_command(&prompt) {
+                                chat.messages.push(RenderedMessage {
+                                    role: "user".to_string(),
+                                    content: prompt.clone(),
+                                });
+                                chat.conversation_scroll = 0;
                                 let slash_chat_id = crate::storage::call_blocking(
                                     std::sync::Arc::clone(&app.state.db),
                                     {

--- a/egopulse/src/lib.rs
+++ b/egopulse/src/lib.rs
@@ -18,6 +18,7 @@ pub mod mcp;
 pub mod runtime;
 pub mod setup;
 pub mod skills;
+pub mod slash_commands;
 pub mod status;
 pub mod storage;
 pub mod text;

--- a/egopulse/src/skills.rs
+++ b/egopulse/src/skills.rs
@@ -110,6 +110,21 @@ impl SkillManager {
         }
     }
 
+    /// チャット表示用にプレーンテキストでスキル一覧を返す。
+    pub fn list_skills_formatted(&self) -> String {
+        let skills = self.discover_skills();
+        if skills.is_empty() {
+            return "No skills loaded.".to_string();
+        }
+
+        let mut out = String::from("Available skills:\n");
+        for skill in &skills {
+            out.push_str(&format!("- {} ({})\n", skill.name, skill.description));
+        }
+        out.pop();
+        out
+    }
+
     /// Build an XML-formatted skills catalog for injection into the system prompt.
     /// Switches to compact mode (name-only) when skill count exceeds threshold.
     pub fn build_skills_catalog(&self) -> String {
@@ -476,5 +491,31 @@ mod tests {
 
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].name, "pdf");
+    }
+
+    #[test]
+    fn list_skills_formatted_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let skills_dir = dir.path().join("workspace").join("skills");
+
+        let manager = SkillManager::from_skills_dir(skills_dir);
+        let formatted = manager.list_skills_formatted();
+
+        assert_eq!(formatted, "No skills loaded.");
+    }
+
+    #[test]
+    fn list_skills_formatted_multiple() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let skills_dir = dir.path().join("workspace").join("skills");
+        create_skill(&skills_dir, "pdf", "Use the PDF workflow.");
+        create_skill(&skills_dir, "docx", "Use the DOCX workflow.");
+
+        let manager = SkillManager::from_skills_dir(skills_dir);
+        let formatted = manager.list_skills_formatted();
+
+        assert!(formatted.starts_with("Available skills:\n"));
+        assert!(formatted.contains("- pdf (Description for pdf)"));
+        assert!(formatted.contains("- docx (Description for docx)"));
     }
 }

--- a/egopulse/src/slash_commands.rs
+++ b/egopulse/src/slash_commands.rs
@@ -1,0 +1,505 @@
+//! スラッシュコマンドの検出・ディスパッチ。
+//!
+//! Microclaw 準拠の公開 API を提供し、各チャネルから渡されたコマンドテキストを
+//! 対応するハンドラに振り分ける。`is_slash_command` で判定し、
+//! `handle_slash_command` で実行結果のメッセージを返す。
+
+use std::sync::Arc;
+
+use crate::agent_loop::SurfaceContext;
+use crate::agent_loop::compaction::force_compact;
+use crate::agent_loop::session::load_messages_for_turn;
+use crate::llm_profile;
+use crate::runtime::AppState;
+use crate::storage::call_blocking;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// 入力テキストがスラッシュコマンドかどうかを判定する。
+///
+/// 先頭のメンション (`@botname `, `<@U123456> `, `@bot/command`) を除去した後、
+/// 残りのテキストが `/` で始まる場合に `true` を返す。
+/// `//` (二重スラッシュ) や単独の `/` はコマンドとは見なさない。
+pub fn is_slash_command(text: &str) -> bool {
+    let normalized = strip_mentions(text.trim());
+    if normalized.is_empty() {
+        return false;
+    }
+    if !normalized.starts_with('/') {
+        return false;
+    }
+    // `//` を除外
+    if normalized.starts_with("//") {
+        return false;
+    }
+    // `/` 単独 (引数なし) を除外
+    if normalized.len() == 1 {
+        return false;
+    }
+    // `/ ` のようにスペースのみ続く場合も除外
+    let trimmed = normalized.trim();
+    if trimmed.len() == 1 {
+        return false;
+    }
+    true
+}
+
+/// スラッシュコマンドを実行し、結果メッセージを返す。
+///
+/// コマンドが未知または空の場合は `None` を返す。
+pub async fn handle_slash_command(
+    state: &AppState,
+    chat_id: i64,
+    caller_channel: &str,
+    command_text: &str,
+    sender_id: Option<&str>,
+) -> Option<String> {
+    let normalized = strip_mentions(command_text.trim());
+    if normalized.is_empty() {
+        return None;
+    }
+
+    let parts: Vec<&str> = normalized.splitn(2, char::is_whitespace).collect();
+    let command = parts.first().unwrap_or(&"").to_ascii_lowercase();
+    let _args = parts.get(1).copied().unwrap_or("");
+
+    match command.as_str() {
+        "/new" => handle_new(state, chat_id).await,
+        "/compact" => handle_compact(state, chat_id, caller_channel).await,
+        "/status" => handle_status(state, chat_id, caller_channel, sender_id).await,
+        "/skills" => Some(handle_skills(state)),
+        "/restart" => Some(handle_restart()),
+        "/providers" | "/provider" | "/models" | "/model" => {
+            handle_llm_profile(state, caller_channel, normalized).await
+        }
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mention stripping
+// ---------------------------------------------------------------------------
+
+/// 先頭のメンションプレフィクスを除去する。
+///
+/// パターン:
+/// - `@botname ` (Telegram スタイル)
+/// - `<@U123456> ` (Discord スタイル)
+/// - `@botname/command` (メンションとスラッシュの間にスペースなし)
+fn strip_mentions(text: &str) -> &str {
+    let mut rest = text;
+
+    // Discord スタイル: `<@...> `
+    if let Some(end) = rest.find('>') {
+        let prefix = &rest[..=end];
+        if prefix.starts_with("<@")
+            && prefix
+                .chars()
+                .all(|c| c == '<' || c == '@' || c == '>' || c.is_ascii_alphanumeric())
+        {
+            rest = rest[end + 1..].trim_start();
+        }
+    }
+
+    // Telegram スタイル: `@botname ` または `@botname/command`
+    if rest.starts_with('@') {
+        // 次のスペースまたは `/` までをメンションとして扱う
+        let mention_end = rest.find([' ', '/']).unwrap_or(rest.len());
+        if mention_end > 1 {
+            // `@` の後に少なくとも1文字ある
+            let after_mention = &rest[mention_end..];
+            if after_mention.starts_with('/') {
+                // `@bot/command` パターン: メンション部分だけ除去
+                rest = after_mention;
+            } else if after_mention.starts_with(' ') {
+                rest = after_mention.trim_start();
+            } else {
+                // `@bot` のみ → メンションはコマンドではない
+                // (テキスト全体が `@bot` のような場合)
+                rest = after_mention.trim_start();
+            }
+        }
+    }
+
+    rest
+}
+
+// ---------------------------------------------------------------------------
+// Command handlers
+// ---------------------------------------------------------------------------
+
+async fn handle_new(state: &AppState, chat_id: i64) -> Option<String> {
+    call_blocking(Arc::clone(&state.db), move |db| db.clear_session(chat_id))
+        .await
+        .ok();
+    Some("Session cleared.".to_string())
+}
+
+async fn handle_compact(state: &AppState, chat_id: i64, caller_channel: &str) -> Option<String> {
+    let loaded = load_messages_for_turn(state, chat_id).await.ok()?;
+    if loaded.messages.is_empty() {
+        return Some("Session is empty.".to_string());
+    }
+
+    let count = loaded.messages.len();
+    let context = SurfaceContext {
+        channel: caller_channel.to_string(),
+        surface_user: String::new(),
+        surface_thread: String::new(),
+        chat_type: String::new(),
+    };
+    let llm = state.global_llm().ok()?;
+
+    match force_compact(state, &context, chat_id, &loaded.messages, &llm).await {
+        Ok(_) => Some(format!("Compacted {count} messages.")),
+        Err(error) => Some(format!("Compaction failed: {error}")),
+    }
+}
+
+async fn handle_status(
+    state: &AppState,
+    chat_id: i64,
+    caller_channel: &str,
+    sender_id: Option<&str>,
+) -> Option<String> {
+    let config = state.try_current_config().ok()?;
+    let resolved = config.resolve_llm_for_channel(caller_channel).ok()?;
+
+    let messages = call_blocking(Arc::clone(&state.db), move |db| {
+        db.get_recent_messages(chat_id, 99999)
+    })
+    .await
+    .unwrap_or_default();
+
+    let session_line = if messages.is_empty() {
+        "Session: empty".to_string()
+    } else {
+        format!("Session: active ({} messages)", messages.len())
+    };
+
+    let mut status = format!(
+        "Status\n\
+         Channel: {caller_channel}\n\
+         Provider: {}\n\
+         Model: {}\n\
+         {session_line}",
+        resolved.provider, resolved.model,
+    );
+
+    if let Some(id) = sender_id {
+        status.push_str(&format!("\nSender: {id}"));
+    }
+
+    Some(status)
+}
+
+fn handle_skills(state: &AppState) -> String {
+    state.skills.list_skills_formatted()
+}
+
+fn handle_restart() -> String {
+    if std::path::Path::new("/etc/systemd/system/egopulse.service").exists() {
+        "Restarting via systemctl...".to_string()
+    } else {
+        "Restarting...".to_string()
+    }
+}
+
+async fn handle_llm_profile(state: &AppState, caller_channel: &str, input: &str) -> Option<String> {
+    let context = SurfaceContext {
+        channel: caller_channel.to_string(),
+        surface_user: String::new(),
+        surface_thread: String::new(),
+        chat_type: caller_channel.to_string(),
+    };
+    llm_profile::handle_command(state, &context, input)
+        .await
+        .ok()?
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+
+    use crate::agent_loop::turn::{build_state, test_config};
+    use crate::error::LlmError;
+    use crate::llm::{LlmProvider, Message, MessagesResponse};
+    use crate::runtime::AppState;
+    use crate::storage::{StoredMessage, call_blocking};
+
+    use super::{handle_slash_command, is_slash_command};
+
+    // -- is_slash_command tests ---------------------------------------------------
+
+    #[test]
+    fn is_slash_basic() {
+        assert!(is_slash_command("/status"));
+    }
+
+    #[test]
+    fn is_slash_with_args() {
+        assert!(is_slash_command("/model gpt-5"));
+    }
+
+    #[test]
+    fn is_slash_telegram_mention() {
+        assert!(is_slash_command("@mybot /status"));
+    }
+
+    #[test]
+    fn is_slash_discord_mention() {
+        assert!(is_slash_command("<@U123456> /status"));
+    }
+
+    #[test]
+    fn is_slash_mention_no_space() {
+        assert!(is_slash_command("@bot/status"));
+    }
+
+    #[test]
+    fn is_slash_plain_text() {
+        assert!(!is_slash_command("hello world"));
+    }
+
+    #[test]
+    fn is_slash_empty() {
+        assert!(!is_slash_command(""));
+    }
+
+    #[test]
+    fn is_slash_mention_only() {
+        assert!(!is_slash_command("@bot"));
+    }
+
+    #[test]
+    fn is_slash_double_slash() {
+        assert!(!is_slash_command("// comment"));
+    }
+
+    #[test]
+    fn is_slash_case_insensitive() {
+        assert!(is_slash_command("/STATUS"));
+    }
+
+    // -- Test helper: no-op LLM provider -----------------------------------------
+
+    struct NoOpProvider;
+
+    #[async_trait]
+    impl LlmProvider for NoOpProvider {
+        async fn send_message(
+            &self,
+            _system: &str,
+            _messages: Vec<Message>,
+            _tools: Option<Vec<crate::llm::ToolDefinition>>,
+        ) -> Result<MessagesResponse, LlmError> {
+            Ok(MessagesResponse {
+                content: "summary".to_string(),
+                tool_calls: Vec::new(),
+            })
+        }
+    }
+
+    fn build_test_state() -> (AppState, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = test_config(dir.path().to_str().expect("utf8").to_string());
+        let state = build_state(config, Box::new(NoOpProvider));
+        (state, dir)
+    }
+
+    // -- handle_slash_command tests -----------------------------------------------
+
+    #[tokio::test]
+    async fn handle_new_clears_session() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+        let chat_id = call_blocking(Arc::clone(&state.db), |db| {
+            db.resolve_or_create_chat_id("cli", "cli:test-new", Some("test-new"), "cli")
+        })
+        .await
+        .expect("chat_id");
+
+        call_blocking(Arc::clone(&state.db), {
+            move |db| {
+                db.store_message(&StoredMessage {
+                    id: "msg-1".to_string(),
+                    chat_id,
+                    sender_name: "user".to_string(),
+                    content: "hello".to_string(),
+                    is_from_bot: false,
+                    timestamp: "2024-01-01T00:00:00Z".to_string(),
+                })
+            }
+        })
+        .await
+        .expect("store message");
+
+        // Act
+        let result = handle_slash_command(&state, chat_id, "cli", "/new", None).await;
+
+        // Assert
+        assert_eq!(result, Some("Session cleared.".to_string()));
+        let messages = call_blocking(Arc::clone(&state.db), move |db| {
+            db.get_recent_messages(chat_id, 10)
+        })
+        .await
+        .expect("messages");
+        assert!(messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_compact_returns_count() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+        let chat_id = call_blocking(Arc::clone(&state.db), |db| {
+            db.resolve_or_create_chat_id("cli", "cli:test-compact", Some("test-compact"), "cli")
+        })
+        .await
+        .expect("chat_id");
+
+        let messages = vec![
+            Message::text("user", "hello"),
+            Message::text("assistant", "hi"),
+        ];
+        let json = serde_json::to_string(&messages).expect("json");
+        call_blocking(Arc::clone(&state.db), {
+            move |db| db.save_session(chat_id, &json)
+        })
+        .await
+        .expect("save session");
+
+        // Act
+        let result = handle_slash_command(&state, chat_id, "cli", "/compact", None).await;
+
+        // Assert
+        let response = result.expect("response");
+        assert!(response.contains("Compacted"), "response: {response}");
+        assert!(response.contains("2 messages"), "response: {response}");
+    }
+
+    #[tokio::test]
+    async fn handle_status_shows_info() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+        let chat_id = call_blocking(Arc::clone(&state.db), |db| {
+            db.resolve_or_create_chat_id("cli", "cli:test-status", Some("test-status"), "cli")
+        })
+        .await
+        .expect("chat_id");
+
+        // Act
+        let result =
+            handle_slash_command(&state, chat_id, "cli", "/status", Some("user-123")).await;
+
+        // Assert
+        let response = result.expect("response");
+        assert!(response.contains("Channel: cli"), "response: {response}");
+        assert!(response.contains("Provider:"), "response: {response}");
+        assert!(response.contains("Model:"), "response: {response}");
+        assert!(response.contains("Session:"), "response: {response}");
+        assert!(
+            response.contains("Sender: user-123"),
+            "response: {response}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_skills_empty() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+        let chat_id = 1;
+
+        // Act
+        let result = handle_slash_command(&state, chat_id, "cli", "/skills", None).await;
+
+        // Assert
+        let response = result.expect("response");
+        assert!(
+            response.contains("No skills loaded."),
+            "response: {response}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_providers_delegates_to_llm_profile() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+        let chat_id = 1;
+
+        // Act
+        let result = handle_slash_command(&state, chat_id, "cli", "/providers", None).await;
+
+        // Assert
+        let response = result.expect("response");
+        assert!(
+            response.contains("openai"),
+            "response should contain provider name: {response}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_unknown_returns_none() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+
+        // Act
+        let result = handle_slash_command(&state, 1, "cli", "/foo", None).await;
+
+        // Assert
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn handle_restart_returns_message() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+
+        // Act
+        let result = handle_slash_command(&state, 1, "cli", "/restart", None).await;
+
+        // Assert
+        let response = result.expect("response");
+        assert!(response.contains("Restarting"), "response: {response}");
+    }
+
+    #[tokio::test]
+    async fn handle_status_empty_session() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+        let chat_id = 999;
+
+        // Act
+        let result = handle_slash_command(&state, chat_id, "cli", "/status", None).await;
+
+        // Assert
+        let response = result.expect("response");
+        assert!(response.contains("Session: empty"), "response: {response}");
+    }
+
+    #[tokio::test]
+    async fn handle_compact_empty_session() {
+        // Arrange
+        let (state, _dir) = build_test_state();
+        let chat_id = 998;
+
+        // Act
+        let result = handle_slash_command(&state, chat_id, "cli", "/compact", None).await;
+
+        // Assert
+        // load_messages_for_turn は chat_id を直接受け取るため、
+        // チャット行が存在しなくても空セッションとして返す
+        let response = result.expect("response");
+        assert!(
+            response.contains("Session is empty"),
+            "response: {response}"
+        );
+    }
+}

--- a/egopulse/src/slash_commands.rs
+++ b/egopulse/src/slash_commands.rs
@@ -102,7 +102,7 @@ fn strip_mentions(text: &str) -> &str {
         if prefix.starts_with("<@")
             && prefix
                 .chars()
-                .all(|c| c == '<' || c == '@' || c == '>' || c.is_ascii_alphanumeric())
+                .all(|c| c == '<' || c == '@' || c == '!' || c == '>' || c.is_ascii_alphanumeric())
         {
             rest = rest[end + 1..].trim_start();
         }
@@ -168,11 +168,15 @@ async fn handle_compact(state: &AppState, chat_id: i64, caller_channel: &str) ->
 
     match force_compact(state, &context, chat_id, &loaded.messages, &llm).await {
         Ok(compacted) => {
-            let json = serde_json::to_string(&compacted).ok()?;
+            let json = match serde_json::to_string(&compacted) {
+                Ok(j) => j,
+                Err(e) => return Some(format!("Failed to serialize compacted session: {e}")),
+            };
             call_blocking(Arc::clone(&state.db), move |db| {
                 db.save_session(chat_id, &json)
             })
             .await
+            .map_err(|e| format!("Failed to save compacted session: {e}"))
             .ok()?;
             Some(format!(
                 "Compacted {count} messages to {}.",

--- a/egopulse/src/slash_commands.rs
+++ b/egopulse/src/slash_commands.rs
@@ -62,7 +62,12 @@ pub async fn handle_slash_command(
     }
 
     let parts: Vec<&str> = normalized.splitn(2, char::is_whitespace).collect();
-    let command = parts.first().unwrap_or(&"").to_ascii_lowercase();
+    let raw_command = parts.first().copied().unwrap_or("");
+    let bare_command = raw_command
+        .split_once('@')
+        .map(|(cmd, _)| cmd)
+        .unwrap_or(raw_command);
+    let command = bare_command.to_ascii_lowercase();
     let _args = parts.get(1).copied().unwrap_or("");
 
     match command.as_str() {
@@ -141,7 +146,10 @@ async fn handle_new(state: &AppState, chat_id: i64) -> Option<String> {
 }
 
 async fn handle_compact(state: &AppState, chat_id: i64, caller_channel: &str) -> Option<String> {
-    let loaded = load_messages_for_turn(state, chat_id).await.ok()?;
+    let loaded = match load_messages_for_turn(state, chat_id).await {
+        Ok(loaded) => loaded,
+        Err(e) => return Some(format!("Failed to load session: {e}")),
+    };
     if loaded.messages.is_empty() {
         return Some("Session is empty.".to_string());
     }
@@ -153,7 +161,10 @@ async fn handle_compact(state: &AppState, chat_id: i64, caller_channel: &str) ->
         surface_thread: String::new(),
         chat_type: String::new(),
     };
-    let llm = state.global_llm().ok()?;
+    let llm = match state.global_llm() {
+        Ok(llm) => llm,
+        Err(e) => return Some(format!("Failed to get LLM provider: {e}")),
+    };
 
     match force_compact(state, &context, chat_id, &loaded.messages, &llm).await {
         Ok(compacted) => {
@@ -178,8 +189,14 @@ async fn handle_status(
     caller_channel: &str,
     sender_id: Option<&str>,
 ) -> Option<String> {
-    let config = state.try_current_config().ok()?;
-    let resolved = config.resolve_llm_for_channel(caller_channel).ok()?;
+    let config = match state.try_current_config() {
+        Ok(config) => config,
+        Err(e) => return Some(format!("Failed to load config: {e}")),
+    };
+    let resolved = match config.resolve_llm_for_channel(caller_channel) {
+        Ok(r) => r,
+        Err(e) => return Some(format!("Failed to resolve LLM: {e}")),
+    };
 
     let messages = call_blocking(Arc::clone(&state.db), move |db| {
         db.get_recent_messages(chat_id, 99999)
@@ -214,11 +231,7 @@ fn handle_skills(state: &AppState) -> String {
 }
 
 fn handle_restart() -> String {
-    if std::path::Path::new("/etc/systemd/system/egopulse.service").exists() {
-        "Restarting via systemctl...".to_string()
-    } else {
-        "Restarting...".to_string()
-    }
+    "Not implemented yet.".to_string()
 }
 
 async fn handle_llm_profile(state: &AppState, caller_channel: &str, input: &str) -> Option<String> {
@@ -481,7 +494,7 @@ mod tests {
 
         // Assert
         let response = result.expect("response");
-        assert!(response.contains("Restarting"), "response: {response}");
+        assert!(response.contains("Not implemented"), "response: {response}");
     }
 
     #[tokio::test]

--- a/egopulse/src/slash_commands.rs
+++ b/egopulse/src/slash_commands.rs
@@ -172,16 +172,19 @@ async fn handle_compact(state: &AppState, chat_id: i64, caller_channel: &str) ->
                 Ok(j) => j,
                 Err(e) => return Some(format!("Failed to serialize compacted session: {e}")),
             };
-            call_blocking(Arc::clone(&state.db), move |db| {
+            match call_blocking(Arc::clone(&state.db), move |db| {
                 db.save_session(chat_id, &json)
             })
             .await
-            .map_err(|e| format!("Failed to save compacted session: {e}"))
-            .ok()?;
-            Some(format!(
-                "Compacted {count} messages to {}.",
-                compacted.len()
-            ))
+            {
+                Ok(_) => Some(format!(
+                    "Compacted {count} messages to {}.",
+                    compacted.len()
+                )),
+                Err(e) => Some(format!(
+                    "Compacted {count} messages but failed to save session: {e}"
+                )),
+            }
         }
         Err(error) => Some(format!("Compaction failed: {error}")),
     }
@@ -245,9 +248,10 @@ async fn handle_llm_profile(state: &AppState, caller_channel: &str, input: &str)
         surface_thread: String::new(),
         chat_type: caller_channel.to_string(),
     };
-    llm_profile::handle_command(state, &context, input)
-        .await
-        .ok()?
+    match llm_profile::handle_command(state, &context, input).await {
+        Ok(result) => result,
+        Err(e) => Some(format!("LLM profile error: {e}")),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/egopulse/src/slash_commands.rs
+++ b/egopulse/src/slash_commands.rs
@@ -131,10 +131,13 @@ fn strip_mentions(text: &str) -> &str {
 // ---------------------------------------------------------------------------
 
 async fn handle_new(state: &AppState, chat_id: i64) -> Option<String> {
-    call_blocking(Arc::clone(&state.db), move |db| db.clear_session(chat_id))
-        .await
-        .ok();
-    Some("Session cleared.".to_string())
+    match call_blocking(Arc::clone(&state.db), move |db| db.clear_session(chat_id)).await {
+        Ok(_) => Some("Session cleared.".to_string()),
+        Err(e) => {
+            tracing::warn!("failed to clear session: {e}");
+            Some(format!("Failed to clear session: {e}"))
+        }
+    }
 }
 
 async fn handle_compact(state: &AppState, chat_id: i64, caller_channel: &str) -> Option<String> {
@@ -153,7 +156,18 @@ async fn handle_compact(state: &AppState, chat_id: i64, caller_channel: &str) ->
     let llm = state.global_llm().ok()?;
 
     match force_compact(state, &context, chat_id, &loaded.messages, &llm).await {
-        Ok(_) => Some(format!("Compacted {count} messages.")),
+        Ok(compacted) => {
+            let json = serde_json::to_string(&compacted).ok()?;
+            call_blocking(Arc::clone(&state.db), move |db| {
+                db.save_session(chat_id, &json)
+            })
+            .await
+            .ok()?;
+            Some(format!(
+                "Compacted {count} messages to {}.",
+                compacted.len()
+            ))
+        }
         Err(error) => Some(format!("Compaction failed: {error}")),
     }
 }

--- a/egopulse/src/storage.rs
+++ b/egopulse/src/storage.rs
@@ -450,6 +450,14 @@ impl Database {
         Ok(())
     }
 
+    /// セッションスナップショットとメッセージ履歴を削除する。
+    pub fn clear_session(&self, chat_id: i64) -> Result<(), StorageError> {
+        let conn = self.lock_conn()?;
+        conn.execute("DELETE FROM sessions WHERE chat_id = ?1", params![chat_id])?;
+        conn.execute("DELETE FROM messages WHERE chat_id = ?1", params![chat_id])?;
+        Ok(())
+    }
+
     /// Atomically store a message and update the session snapshot.
     /// Uses optimistic concurrency via `expected_updated_at`; returns
     /// `SessionSnapshotConflict` on stale writes.
@@ -768,6 +776,49 @@ mod tests {
         assert_eq!(loaded_again, json2);
         assert!(second_updated_at >= first_updated_at);
         assert!(db.load_session(200).expect("other chat").is_none());
+    }
+
+    #[test]
+    fn clear_session_deletes_snapshots_and_messages() {
+        let (db, _dir) = test_db();
+        let chat_id = 100;
+
+        db.save_session(chat_id, r#"[{"role":"user","content":"hello"}]"#)
+            .expect("save session");
+        db.store_message(&StoredMessage {
+            id: "msg-1".to_string(),
+            chat_id,
+            sender_name: "alice".to_string(),
+            content: "hello".to_string(),
+            is_from_bot: false,
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+        })
+        .expect("store first message");
+        db.store_message(&StoredMessage {
+            id: "msg-2".to_string(),
+            chat_id,
+            sender_name: "assistant".to_string(),
+            content: "hi".to_string(),
+            is_from_bot: true,
+            timestamp: "2024-01-01T00:00:01Z".to_string(),
+        })
+        .expect("store second message");
+
+        db.clear_session(chat_id).expect("clear session");
+
+        assert!(db.load_session(chat_id).expect("load session").is_none());
+        assert!(
+            db.get_recent_messages(chat_id, 10)
+                .expect("load recent messages")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn clear_session_idempotent_on_empty_chat() {
+        let (db, _dir) = test_db();
+
+        db.clear_session(999).expect("clear missing session");
     }
 
     #[test]

--- a/egopulse/src/web/stream.rs
+++ b/egopulse/src/web/stream.rs
@@ -192,6 +192,60 @@ pub(super) async fn start_stream_run(
     let run_id = Uuid::new_v4().to_string();
     state.run_hub.create(&run_id, actor.to_string()).await;
 
+    if crate::slash_commands::is_slash_command(&message) {
+        let slash_chat_id = match call_blocking(std::sync::Arc::clone(&state.app_state.db), {
+            let channel = context.channel.clone();
+            let ext_id = context.surface_thread.clone();
+            let chat_type = context.chat_type.clone();
+            move |db| db.resolve_or_create_chat_id(&channel, &ext_id, None, &chat_type)
+        })
+        .await
+        {
+            Ok(id) => id,
+            Err(e) => {
+                state
+                    .run_hub
+                    .publish(
+                        &run_id,
+                        "error",
+                        json!({"error": e.to_string()}).to_string(),
+                    )
+                    .await;
+                state
+                    .run_hub
+                    .remove_later(run_id.clone(), RUN_TTL_SECONDS)
+                    .await;
+                return Ok(StartedRun {
+                    run_id,
+                    session_key,
+                });
+            }
+        };
+
+        let response = crate::slash_commands::handle_slash_command(
+            &state.app_state,
+            slash_chat_id,
+            &context.channel,
+            &message,
+            None,
+        )
+        .await
+        .unwrap_or_else(|| "Unknown command.".to_string());
+
+        state
+            .run_hub
+            .publish(&run_id, "done", json!({"response": response}).to_string())
+            .await;
+        state
+            .run_hub
+            .remove_later(run_id.clone(), RUN_TTL_SECONDS)
+            .await;
+        return Ok(StartedRun {
+            run_id,
+            session_key,
+        });
+    }
+
     let state_for_task = state.clone();
     let run_id_for_task = run_id.clone();
     let context_for_task = context;

--- a/egopulse/src/web/stream.rs
+++ b/egopulse/src/web/stream.rs
@@ -227,7 +227,7 @@ pub(super) async fn start_stream_run(
             slash_chat_id,
             &context.channel,
             &message,
-            None,
+            Some(actor),
         )
         .await
         .unwrap_or_else(|| "Unknown command.".to_string());


### PR DESCRIPTION
## Summary

EgoPulse にスラッシュコマンド機能を追加し、CLI / Telegram / Discord の全チャネルから統一的にセッション管理・LLM設定・ステータス確認を行えるようにする。

Plan: `docs/30.egopulse/plan-slash-commands.md`

## 変更内容

### 基盤機能
- **`Database::clear_session()`** — セッションスナップショットとメッセージ履歴を削除 (`/new` 用)
- **`force_compact()`** — 閾値に関わらず必ず圧縮を実行 (`/compact` 用)
- **`SkillManager::list_skills_formatted()`** — チャット表示用プレーンテキスト (`/skills` 用)

### コアモジュール
- **`slash_commands.rs`** — メンション除去 (`@bot`, `<@U123>`) + コマンドディスパッチ
  - `/new` — セッションクリア
  - `/compact` — 強制圧縮
  - `/status` — チャネル・プロバイダー・モデル・セッション情報
  - `/skills` — スキル一覧
  - `/restart` — 再起動要求
  - `/providers`, `/provider`, `/models`, `/model` — LLM設定 (`llm_profile` に委譲)

### チャネル統合
- **Telegram** — `handle_message` でインターセプト + `setMyCommands` 登録
- **Discord** — `Handler::message` でインターセプト
- **CLI** — `run_chat` で `slash_commands` 経由に移行

## テスト

- **170 tests passed** (19 new: 10 `is_slash_command` + 9 `handle_slash_command` + 各基盤テスト)
- `cargo clippy` — 0 warnings
- `cargo fmt` — clean

## Commits (5)

1. `e298fea` feat: add Database::clear_session for slash command support
2. `7d48368` feat: add force_compact for on-demand session compaction
3. `ba38d92` feat: add SkillManager::list_skills_formatted for chat display
4. `f43676a` feat: add slash_commands module with command dispatch
5. `8cff408` feat: integrate slash commands into CLI, Telegram, Discord channels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * スラッシュコマンド追加：/new、/compact、/status、/skills、/restart、プロバイダ系コマンドをサポートし、CLI/Discord/Telegram/TUI/ウェブで優先処理されます。
  * スキル一覧の整形表示を追加。
  * セッション完全クリアと強制コンパクト機能を追加。

* **Bug Fixes**
  * スラッシュ処理・DB解決失敗時の安全な早期終了とエラーメッセージ改善。

* **Tests**
  * コマンド処理、コンパクト、ストレージ、スキル一覧などのユニット/統合テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->