### PR TITLE
fix: slash commands fallthrough and mention filter ordering

### DIFF
--- a/egopulse/src/channels/cli.rs
+++ b/egopulse/src/channels/cli.rs
@@ -56,7 +56,7 @@ pub async fn run_chat(state: &AppState, session: &str) -> Result<(), EgoPulseErr
             .await
             .map_err(EgoPulseError::from)?;
 
-            if let Some(response) = crate::slash_commands::handle_slash_command(
+            let response = crate::slash_commands::handle_slash_command(
                 state,
                 slash_chat_id,
                 &context.channel,
@@ -64,16 +64,15 @@ pub async fn run_chat(state: &AppState, session: &str) -> Result<(), EgoPulseErr
                 None,
             )
             .await
-            {
-                writeln!(stdout, "assistant: {response}")
-                    .map_err(crate::error::StorageError::Io)
-                    .map_err(EgoPulseError::from)?;
-                stdout
-                    .flush()
-                    .map_err(crate::error::StorageError::Io)
-                    .map_err(EgoPulseError::from)?;
-                continue;
-            }
+            .unwrap_or_else(crate::slash_commands::unknown_command_response);
+            writeln!(stdout, "assistant: {response}")
+                .map_err(crate::error::StorageError::Io)
+                .map_err(EgoPulseError::from)?;
+            stdout
+                .flush()
+                .map_err(crate::error::StorageError::Io)
+                .map_err(EgoPulseError::from)?;
+            continue;
         }
 
         writeln!(stdout, "you: {trimmed}")

--- a/egopulse/src/channels/discord.rs
+++ b/egopulse/src/channels/discord.rs
@@ -161,19 +161,18 @@ impl EventHandler for Handler {
             true
         };
 
-        if !should_respond {
-            return;
-        }
-
-        if text.is_empty() {
-            return;
-        }
-
         // microclaw パターン: chat_type を "discord" に統一
         let external_chat_id = external_channel_id.to_string();
 
         // --- スラッシュコマンドインターセプト ---
+        // process_turn より先に chat_id を解決し、
+        // スラッシュコマンドであればエージェントループに入らずに即応答する。
         if crate::slash_commands::is_slash_command(&text) {
+            // guild ではメンション必須
+            if msg.guild_id.is_some() && !should_respond {
+                return;
+            }
+
             let slash_chat_id =
                 crate::storage::call_blocking(std::sync::Arc::clone(&self.app_state.db), {
                     let channel = "discord".to_string();
@@ -196,8 +195,15 @@ impl EventHandler for Handler {
                     .await
                     {
                         send_discord_response(&ctx, msg.channel_id, &response).await;
-                        return;
+                    } else {
+                        send_discord_response(
+                            &ctx,
+                            msg.channel_id,
+                            &crate::slash_commands::unknown_command_response(),
+                        )
+                        .await;
                     }
+                    return;
                 }
                 Err(e) => {
                     error!("failed to resolve chat_id for slash command: {e}");
@@ -212,6 +218,14 @@ impl EventHandler for Handler {
             }
         }
         // --- インターセプトここまで ---
+
+        if !should_respond {
+            return;
+        }
+
+        if text.is_empty() {
+            return;
+        }
 
         let sender_name = msg.author.name.clone();
 

--- a/egopulse/src/channels/telegram.rs
+++ b/egopulse/src/channels/telegram.rs
@@ -165,9 +165,14 @@ async fn handle_message(
         }
     }
 
-    // グループ/スーパーグループでは message entity の Mention で正確に判定
     let is_group = chat_type != "telegram_private";
-    if is_group {
+    let external_chat_id = raw_chat_id.to_string();
+
+    // グループメンション判定 (スラッシュコマンドと通常メッセージで共用)。
+    // BotCommand エンティティの @botname またはテキストメンションのいずれかで true。
+    let is_mentioned_in_group = if !is_group {
+        true
+    } else {
         let bot_username = state.config.telegram_bot_username();
         let msg_text = text.as_str();
         let is_own_command = msg
@@ -187,8 +192,10 @@ async fn handle_message(
                 }
             });
 
-        if !is_own_command {
-            let mentioned = match &bot_username {
+        if is_own_command {
+            true
+        } else {
+            match &bot_username {
                 Some(username) => msg
                     .parse_entities()
                     .into_iter()
@@ -211,38 +218,23 @@ async fn handle_message(
                     }
                     false
                 }
-            };
-
-            if !mentioned {
-                debug!(
-                    chat_id = raw_chat_id,
-                    "Telegram: skipping non-mentioned group message"
-                );
-                return Ok(());
             }
         }
-    }
-
-    let external_chat_id = raw_chat_id.to_string();
-
-    let context = SurfaceContext {
-        channel: "telegram".to_string(),
-        surface_user: sender_name,
-        surface_thread: external_chat_id.clone(),
-        chat_type: chat_type.clone(),
     };
-
-    info!(
-        chat_id = raw_chat_id,
-        sender = %context.surface_user,
-        text_length = text.len(),
-        "Telegram message received"
-    );
 
     // --- スラッシュコマンドインターセプト ---
     // process_turn より先に chat_id を解決し、
     // スラッシュコマンドであればエージェントループに入らずに即応答する。
     if slash_commands::is_slash_command(&text) {
+        // グループではメンション必須
+        if !is_mentioned_in_group {
+            debug!(
+                chat_id = raw_chat_id,
+                "Telegram: skipping non-mentioned slash command in group"
+            );
+            return Ok(());
+        }
+
         let resolved_chat_id = match call_blocking(std::sync::Arc::clone(&state.db), {
             let channel = "telegram".to_string();
             let ext_id = external_chat_id.clone();
@@ -274,10 +266,40 @@ async fn handle_message(
         .await
         {
             send_telegram_response(&bot, msg.chat.id, &response).await;
-            return Ok(());
+        } else {
+            send_telegram_response(
+                &bot,
+                msg.chat.id,
+                &slash_commands::unknown_command_response(),
+            )
+            .await;
         }
+        return Ok(());
     }
     // --- インターセプトここまで ---
+
+    // グループ/スーパーグループではメンション必須 (通常メッセージ向け)
+    if !is_mentioned_in_group {
+        debug!(
+            chat_id = raw_chat_id,
+            "Telegram: skipping non-mentioned group message"
+        );
+        return Ok(());
+    }
+
+    let context = SurfaceContext {
+        channel: "telegram".to_string(),
+        surface_user: sender_name,
+        surface_thread: external_chat_id.clone(),
+        chat_type: chat_type.clone(),
+    };
+
+    info!(
+        chat_id = raw_chat_id,
+        sender = %context.surface_user,
+        text_length = text.len(),
+        "Telegram message received"
+    );
 
     // タイピングインジケーター (バックグラウンドタスクで定期的に送信)
     let typing_bot = bot.clone();

--- a/egopulse/src/channels/tui.rs
+++ b/egopulse/src/channels/tui.rs
@@ -432,7 +432,8 @@ async fn run_loop(
                                             chat.status = "Command applied".to_string();
                                             chat.conversation_scroll = 0;
                                         } else {
-                                            chat.status = "Unknown command".to_string();
+                                            chat.status =
+                                                crate::slash_commands::unknown_command_response();
                                         }
                                     }
                                     Err(e) => {

--- a/egopulse/src/slash_commands.rs
+++ b/egopulse/src/slash_commands.rs
@@ -19,17 +19,12 @@ use crate::storage::call_blocking;
 
 /// 入力テキストがスラッシュコマンドかどうかを判定する。
 ///
-/// 先頭のメンション (`@botname `, `<@U123456> `, `@bot/command`) を除去した後、
-/// 残りのテキストが `/` で始まる場合に `true` を返す。
-/// `//` (二重スラッシュ) や単独の `/` はコマンドとは見なさない。
+/// 先頭のメンションをループで除去した後、残りのテキストが `/` で始まる場合に
+/// `true` を返す。`//` (二重スラッシュ) や単独の `/` はコマンドとは見なさない。
 pub fn is_slash_command(text: &str) -> bool {
-    let normalized = strip_mentions(text.trim());
-    if normalized.is_empty() {
+    let Some(normalized) = normalized_slash_command(text) else {
         return false;
-    }
-    if !normalized.starts_with('/') {
-        return false;
-    }
+    };
     // `//` を除外
     if normalized.starts_with("//") {
         return false;
@@ -39,8 +34,7 @@ pub fn is_slash_command(text: &str) -> bool {
         return false;
     }
     // `/ ` のようにスペースのみ続く場合も除外
-    let trimmed = normalized.trim();
-    if trimmed.len() == 1 {
+    if normalized.trim().len() == 1 {
         return false;
     }
     true
@@ -56,10 +50,7 @@ pub async fn handle_slash_command(
     command_text: &str,
     sender_id: Option<&str>,
 ) -> Option<String> {
-    let normalized = strip_mentions(command_text.trim());
-    if normalized.is_empty() {
-        return None;
-    }
+    let normalized = normalized_slash_command(command_text)?;
 
     let parts: Vec<&str> = normalized.splitn(2, char::is_whitespace).collect();
     let raw_command = parts.first().copied().unwrap_or("");
@@ -84,51 +75,44 @@ pub async fn handle_slash_command(
 }
 
 // ---------------------------------------------------------------------------
-// Mention stripping
+// 正規化
 // ---------------------------------------------------------------------------
 
-/// 先頭のメンションプレフィクスを除去する。
+/// 先頭のメンションをループで除去し、スラッシュコマンド部分を返す。
 ///
-/// パターン:
-/// - `@botname ` (Telegram スタイル)
-/// - `<@U123456> ` (Discord スタイル)
-/// - `@botname/command` (メンションとスラッシュの間にスペースなし)
-fn strip_mentions(text: &str) -> &str {
-    let mut rest = text;
-
-    // Discord スタイル: `<@...> `
-    if let Some(end) = rest.find('>') {
-        let prefix = &rest[..=end];
-        if prefix.starts_with("<@")
-            && prefix
-                .chars()
-                .all(|c| c == '<' || c == '@' || c == '!' || c == '>' || c.is_ascii_alphanumeric())
-        {
-            rest = rest[end + 1..].trim_start();
+/// 対応パターン:
+/// - `<@U123456>` (Discord スタイル) — 複数回出現してもループで全て除去
+/// - `@botname` (Telegram スタイル) — 複数回出現してもループで全て除去
+fn normalized_slash_command(text: &str) -> Option<&str> {
+    let mut s = text.trim_start();
+    loop {
+        if s.starts_with('/') {
+            return Some(s);
         }
-    }
-
-    // Telegram スタイル: `@botname ` または `@botname/command`
-    if rest.starts_with('@') {
-        // 次のスペースまたは `/` までをメンションとして扱う
-        let mention_end = rest.find([' ', '/']).unwrap_or(rest.len());
-        if mention_end > 1 {
-            // `@` の後に少なくとも1文字ある
-            let after_mention = &rest[mention_end..];
-            if after_mention.starts_with('/') {
-                // `@bot/command` パターン: メンション部分だけ除去
-                rest = after_mention;
-            } else if after_mention.starts_with(' ') {
-                rest = after_mention.trim_start();
-            } else {
-                // `@bot` のみ → メンションはコマンドではない
-                // (テキスト全体が `@bot` のような場合)
-                rest = after_mention.trim_start();
+        if s.starts_with("<@") {
+            let end = s.find('>')?;
+            s = s[end + 1..].trim_start();
+            continue;
+        }
+        if let Some(rest) = s.strip_prefix('@') {
+            if rest.is_empty() {
+                return None;
             }
+            let end = rest
+                .char_indices()
+                .find(|(_, c)| c.is_whitespace() || *c == '/')
+                .map(|(i, _)| i)
+                .unwrap_or(rest.len());
+            s = rest[end..].trim_start();
+            continue;
         }
+        return None;
     }
+}
 
-    rest
+/// 未知コマンド時の応答メッセージを返す。
+pub fn unknown_command_response() -> String {
+    "Unknown command.".to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -322,6 +306,11 @@ mod tests {
     #[test]
     fn is_slash_case_insensitive() {
         assert!(is_slash_command("/STATUS"));
+    }
+
+    #[test]
+    fn is_slash_multiple_mentions() {
+        assert!(is_slash_command("<@U123>   @bot   /status"));
     }
 
     // -- Test helper: no-op LLM provider -----------------------------------------

--- a/egopulse/src/web/stream.rs
+++ b/egopulse/src/web/stream.rs
@@ -230,7 +230,7 @@ pub(super) async fn start_stream_run(
             Some(actor),
         )
         .await
-        .unwrap_or_else(|| "Unknown command.".to_string());
+        .unwrap_or_else(crate::slash_commands::unknown_command_response);
 
         state
             .run_hub


### PR DESCRIPTION
## 概要

PR #146 で実装したスラッシュコマンドが Telegram/WebUI/Discord で動作しなかった3つの根本バグを修正する。microclaw `chat_commands.rs` のパターンに準拠。

## 修正内容

### 1. `normalized_slash_command` のループ式化 (`slash_commands.rs`)
- 単一パスの `strip_mentions` を microclaw 準拠の `loop` ベース `normalized_slash_command` に置換
- 複数メンション (`<@U123>   @bot   /status`) に正しく対応
- `unknown_command_response()` を追加し、全チャネルで統一フォールバックメッセージを使用

### 2. 未知コマンドのフォールスルー防止 (全チャネル)
- `handle_slash_command` が `None` を返すと、これまで `process_turn` (LLM) にフォールスルーしていた
- Telegram/Discord/CLI/TUI/Web すべてで "Unknown command." を返して return するよう修正

### 3. スラッシュコマンド判定をメンションフィルタ前に移動 (Telegram/Discord)
- グループでメンションなしの `/model` が、メンションフィルタで弾かれてスラッシュコマンド判定に到達しなかった問題を修正
- スラッシュコマンドブロック内でグループメンション要件を適用するよう移動
- グループでメンションなしのスラッシュコマンドを無視する既存挙動は維持

## テスト

- 171テスト全通過 (`cargo test -p egopulse`)
- Clippy 警告なし (`cargo clippy -p egopulse --all-targets --all-features -- -D warnings`)
- フォーマット適合 (`cargo fmt -p egopulse --check`)

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `slash_commands.rs` | `strip_mentions` → `normalized_slash_command`、`unknown_command_response` 追加 |
| `channels/telegram.rs` | スラッシュコマンド判定をメンションフィルタ前に移動 + フォールスルー防止 |
| `channels/discord.rs` | スラッシュコマンド判定をメンションフィルタ前に移動 + フォールスルー防止 |
| `channels/cli.rs` | フォールスルー防止 |
| `channels/tui.rs` | `unknown_command_response()` 使用 |
| `web/stream.rs` | `unknown_command_response()` 使用 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 未知のスラッシュコマンドに対して、すべてのプラットフォーム（CLI、Discord、Telegram、Web、TUI）で一貫性のあるエラーレスポンスを返すようになりました
  * 複数のメンション付きスラッシュコマンドの認識精度を改善しました
  * スラッシュコマンド処理をすべてのチャネル間で統一化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->