### PR TITLE
feat: Discord / WebUI スラッシュコマンド UI 実装

### DIFF
--- a/docs/30.egopulse/commands.md
+++ b/docs/30.egopulse/commands.md
@@ -257,7 +257,7 @@ Available skills:
 
 #### CommandDef レジストリ
 
-全チャネルのコマンド定義は `slash_commands.rs` の `CommandDef` 配列（`all_commands()`）に一元化されている。各チャネルはこのレジストリを通じてコマンドメタデータ（名前・説明・使用法）を参照する。コマンド定義の重複を排除し、単一ソースオブテュースを実現している。
+全チャネルのコマンド定義は `slash_commands.rs` の `CommandDef` 配列（`all_commands()`）に一元化されている。各チャネルはこのレジストリを通じてコマンドメタデータ（名前・説明・使用法）を参照する。コマンド定義の重複を排除し、単一ソースオブトゥルース（Single Source of Truth）を実現している。
 
 #### Discord: Application Commands (ネイティブ UI)
 

--- a/docs/30.egopulse/commands.md
+++ b/docs/30.egopulse/commands.md
@@ -252,3 +252,25 @@ Available skills:
 | `/skills` | | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `/status` | | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `/restart` | | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+### 4.3 コマンド UI の実装詳細
+
+#### CommandDef レジストリ
+
+全チャネルのコマンド定義は `slash_commands.rs` の `CommandDef` 配列（`all_commands()`）に一元化されている。各チャネルはこのレジストリを通じてコマンドメタデータ（名前・説明・使用法）を参照する。コマンド定義の重複を排除し、単一ソースオブテュースを実現している。
+
+#### Discord: Application Commands (ネイティブ UI)
+
+Discord はテキストベースの `/` 入力に加え、Discord Application Commands（Interactions API）を登録している。Bot 起動時（`ready` イベント）に `Command::set_global_commands` で一括登録し、`interaction_create` イベントで応答する。これにより Discord ネイティブのオートコンプリート UI が提供される。
+
+- **登録タイミング**: Bot 起動時の `ready` ハンドラ
+- **応答方式**: `CreateInteractionResponse::Message` で即座に応答
+- **フォールバック**: テキストベースの `/` 入力も引き続きサポート
+
+#### WebUI: コマンドサジェスト
+
+Web チャットでは `/` 入力時にクライアントサイドでコマンド候補をポップアップ表示する。`Composer` コンポーネントが `/` で始まる入力を検知し、`filterCommands()` で候補をフィルタして `CommandSuggest` コンポーネントに渡す。
+
+- **キーボード操作**: `↑↓` で候補選択、`Tab` / `Enter` で確定、`Escape` で閉じる
+- **マウス操作**: クリックで選択
+- **コマンド定義**: `commands.ts` にハードコード（コマンド数が少なく変更頻度も低いため）

--- a/egopulse/src/channels/discord.rs
+++ b/egopulse/src/channels/discord.rs
@@ -271,7 +271,23 @@ impl EventHandler for Handler {
 
         let commands: Vec<serenity::builder::CreateCommand> = crate::slash_commands::all_commands()
             .iter()
-            .map(|c| serenity::builder::CreateCommand::new(c.name).description(c.description))
+            .map(|c| {
+                let builder =
+                    serenity::builder::CreateCommand::new(c.name).description(c.description);
+                // 引数を持つコマンドには String option を追加
+                if c.usage.contains('[') {
+                    builder.add_option(
+                        serenity::builder::CreateCommandOption::new(
+                            serenity::model::application::CommandOptionType::String,
+                            "name",
+                            c.description,
+                        )
+                        .required(false),
+                    )
+                } else {
+                    builder
+                }
+            })
             .collect();
 
         if let Err(e) = Command::set_global_commands(&ctx.http, commands).await {
@@ -288,7 +304,21 @@ impl EventHandler for Handler {
             return;
         };
 
-        let command_text = interaction_to_command_text(&cmd.data.name);
+        // Discord 3秒ルール対応: 即座に defer して "thinking..." を表示
+        if let Err(e) = cmd
+            .create_response(
+                &ctx.http,
+                serenity::builder::CreateInteractionResponse::Defer(
+                    serenity::builder::CreateInteractionResponseMessage::new(),
+                ),
+            )
+            .await
+        {
+            tracing::warn!("Discord: failed to defer interaction: {e}");
+            return;
+        }
+
+        let command_text = interaction_to_command_text(&cmd.data.name, &cmd.data.options);
 
         // チャネル ID を解決して内部 chat_id を取得
         let channel_id = cmd.channel_id.get();
@@ -322,16 +352,15 @@ impl EventHandler for Handler {
             }
         };
 
-        let message =
-            serenity::builder::CreateInteractionResponseMessage::new().content(response_text);
+        // defer 後の編集で最終応答を送信
         if let Err(e) = cmd
-            .create_response(
+            .edit_response(
                 &ctx.http,
-                serenity::builder::CreateInteractionResponse::Message(message),
+                serenity::builder::EditInteractionResponse::new().content(response_text),
             )
             .await
         {
-            tracing::warn!("Discord: failed to respond to interaction: {e}");
+            tracing::warn!("Discord: failed to edit interaction response: {e}");
         }
     }
 }
@@ -357,10 +386,20 @@ fn parse_discord_chat_id(external_chat_id: &str) -> Result<u64, String> {
         .map_err(|_| format!("invalid Discord external_chat_id: '{external_chat_id}'"))
 }
 
-/// Discord Interaction のコマンド名を handle_slash_command が
-/// 受け付ける形式（"/command"）に正規化する。
-fn interaction_to_command_text(name: &str) -> String {
-    format!("/{name}")
+/// Discord Interaction のコマンド名と引数を handle_slash_command が
+/// 受け付ける形式（"/command [args]"）に正規化する。
+fn interaction_to_command_text(
+    name: &str,
+    options: &[serenity::model::application::CommandDataOption],
+) -> String {
+    let mut text = format!("/{name}");
+    for opt in options {
+        if let serenity::model::application::CommandDataOptionValue::String(value) = &opt.value {
+            text.push(' ');
+            text.push_str(value);
+        }
+    }
+    text
 }
 
 /// Starts the Discord bot and supervises its gateway lifecycle.
@@ -435,17 +474,17 @@ mod tests {
     /// Interaction コマンド名 → "/command" 形式の正規化が正しいこと。
     #[test]
     fn interaction_command_text_normalizes() {
-        // Arrange & Act & Assert
-        assert_eq!(interaction_to_command_text("status"), "/status");
-        assert_eq!(interaction_to_command_text("new"), "/new");
-        assert_eq!(interaction_to_command_text("model"), "/model");
+        // Arrange & Act & Assert: 引数なし
+        assert_eq!(interaction_to_command_text("status", &[]), "/status");
+        assert_eq!(interaction_to_command_text("new", &[]), "/new");
+        assert_eq!(interaction_to_command_text("model", &[]), "/model");
     }
 
     /// 未知コマンド名を正規化した場合、handle_slash_command が unknown_command_response を返すこと。
     #[test]
     fn interaction_unknown_command_responds() {
         // Arrange
-        let command_text = interaction_to_command_text("nonexistent_cmd");
+        let command_text = interaction_to_command_text("nonexistent_cmd", &[]);
 
         // Act: 正規化後のテキストが is_slash_command に認識されることを確認
         assert!(crate::slash_commands::is_slash_command(&command_text));

--- a/egopulse/src/channels/discord.rs
+++ b/egopulse/src/channels/discord.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde_json::json;
 use serenity::builder::{CreateAllowedMentions, CreateMessage};
+use serenity::model::application::Command;
 use serenity::model::channel::Message as DiscordMessage;
 use serenity::model::gateway::Ready;
 use serenity::model::id::ChannelId;
@@ -265,8 +266,67 @@ impl EventHandler for Handler {
         }
     }
 
-    async fn ready(&self, _ctx: Context, ready: Ready) {
+    async fn ready(&self, ctx: Context, ready: Ready) {
         info!("Discord bot connected as {}", ready.user.name);
+
+        let commands: Vec<serenity::builder::CreateCommand> =
+            crate::slash_commands::all_commands()
+                .iter()
+                .map(|c| serenity::builder::CreateCommand::new(c.name).description(c.description))
+                .collect();
+
+        if let Err(e) = Command::set_global_commands(&ctx.http, commands).await {
+            tracing::warn!("Discord: failed to register slash commands: {e}");
+        }
+    }
+
+    async fn interaction_create(&self, ctx: Context, interaction: serenity::model::application::Interaction) {
+        let Some(cmd) = interaction.clone().command() else {
+            return;
+        };
+
+        let command_text = interaction_to_command_text(&cmd.data.name);
+
+        // チャネル ID を解決して内部 chat_id を取得
+        let channel_id = cmd.channel_id.get();
+        let external_chat_id = channel_id.to_string();
+
+        let slash_chat_id =
+            crate::storage::call_blocking(std::sync::Arc::clone(&self.app_state.db), {
+                let channel = "discord".to_string();
+                let ext_id = external_chat_id.clone();
+                let chat_type = "discord".to_string();
+                move |db| db.resolve_or_create_chat_id(&channel, &ext_id, None, &chat_type)
+            })
+            .await;
+
+        let response_text = match slash_chat_id {
+            Ok(chat_id) => {
+                let sender_id = cmd.user.id.get().to_string();
+                crate::slash_commands::handle_slash_command(
+                    &self.app_state,
+                    chat_id,
+                    "discord",
+                    &command_text,
+                    Some(&sender_id),
+                )
+                .await
+                .unwrap_or_else(|| crate::slash_commands::unknown_command_response())
+            }
+            Err(e) => {
+                tracing::error!("failed to resolve chat_id for interaction: {e}");
+                "An error occurred processing the command.".to_string()
+            }
+        };
+
+        let message = serenity::builder::CreateInteractionResponseMessage::new()
+            .content(response_text);
+        if let Err(e) = cmd
+            .create_response(&ctx.http, serenity::builder::CreateInteractionResponse::Message(message))
+            .await
+        {
+            tracing::warn!("Discord: failed to respond to interaction: {e}");
+        }
     }
 }
 
@@ -289,6 +349,12 @@ fn parse_discord_chat_id(external_chat_id: &str) -> Result<u64, String> {
         .unwrap_or(external_chat_id)
         .parse::<u64>()
         .map_err(|_| format!("invalid Discord external_chat_id: '{external_chat_id}'"))
+}
+
+/// Discord Interaction のコマンド名を handle_slash_command が
+/// 受け付ける形式（"/command"）に正規化する。
+fn interaction_to_command_text(name: &str) -> String {
+    format!("/{name}")
 }
 
 /// Starts the Discord bot and supervises its gateway lifecycle.
@@ -358,5 +424,28 @@ mod tests {
             12345
         );
         assert!(parse_discord_chat_id("discord:not-a-number").is_err());
+    }
+
+    /// Interaction コマンド名 → "/command" 形式の正規化が正しいこと。
+    #[test]
+    fn interaction_command_text_normalizes() {
+        // Arrange & Act & Assert
+        assert_eq!(interaction_to_command_text("status"), "/status");
+        assert_eq!(interaction_to_command_text("new"), "/new");
+        assert_eq!(interaction_to_command_text("model"), "/model");
+    }
+
+    /// 未知コマンド名を正規化した場合、handle_slash_command が unknown_command_response を返すこと。
+    #[test]
+    fn interaction_unknown_command_responds() {
+        // Arrange
+        let command_text = interaction_to_command_text("nonexistent_cmd");
+
+        // Act: 正規化後のテキストが is_slash_command に認識されることを確認
+        assert!(crate::slash_commands::is_slash_command(&command_text));
+
+        // Assert: handle_slash_command が None を返す（未知コマンド）
+        // ※ AppState が必要なため、ここでは正規化結果の形式のみ検証
+        assert_eq!(command_text, "/nonexistent_cmd");
     }
 }

--- a/egopulse/src/channels/discord.rs
+++ b/egopulse/src/channels/discord.rs
@@ -269,18 +269,21 @@ impl EventHandler for Handler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         info!("Discord bot connected as {}", ready.user.name);
 
-        let commands: Vec<serenity::builder::CreateCommand> =
-            crate::slash_commands::all_commands()
-                .iter()
-                .map(|c| serenity::builder::CreateCommand::new(c.name).description(c.description))
-                .collect();
+        let commands: Vec<serenity::builder::CreateCommand> = crate::slash_commands::all_commands()
+            .iter()
+            .map(|c| serenity::builder::CreateCommand::new(c.name).description(c.description))
+            .collect();
 
         if let Err(e) = Command::set_global_commands(&ctx.http, commands).await {
             tracing::warn!("Discord: failed to register slash commands: {e}");
         }
     }
 
-    async fn interaction_create(&self, ctx: Context, interaction: serenity::model::application::Interaction) {
+    async fn interaction_create(
+        &self,
+        ctx: Context,
+        interaction: serenity::model::application::Interaction,
+    ) {
         let Some(cmd) = interaction.clone().command() else {
             return;
         };
@@ -311,7 +314,7 @@ impl EventHandler for Handler {
                     Some(&sender_id),
                 )
                 .await
-                .unwrap_or_else(|| crate::slash_commands::unknown_command_response())
+                .unwrap_or_else(crate::slash_commands::unknown_command_response)
             }
             Err(e) => {
                 tracing::error!("failed to resolve chat_id for interaction: {e}");
@@ -319,10 +322,13 @@ impl EventHandler for Handler {
             }
         };
 
-        let message = serenity::builder::CreateInteractionResponseMessage::new()
-            .content(response_text);
+        let message =
+            serenity::builder::CreateInteractionResponseMessage::new().content(response_text);
         if let Err(e) = cmd
-            .create_response(&ctx.http, serenity::builder::CreateInteractionResponse::Message(message))
+            .create_response(
+                &ctx.http,
+                serenity::builder::CreateInteractionResponse::Message(message),
+            )
             .await
         {
             tracing::warn!("Discord: failed to respond to interaction: {e}");

--- a/egopulse/src/channels/telegram.rs
+++ b/egopulse/src/channels/telegram.rs
@@ -377,17 +377,10 @@ pub async fn start_telegram_bot(
     {
         use teloxide::types::BotCommand;
 
-        let commands = vec![
-            BotCommand::new("new", "Clear current session"),
-            BotCommand::new("compact", "Force compact session"),
-            BotCommand::new("status", "Show current status"),
-            BotCommand::new("skills", "List available skills"),
-            BotCommand::new("restart", "Restart the bot"),
-            BotCommand::new("providers", "List LLM providers"),
-            BotCommand::new("provider", "Show/switch provider"),
-            BotCommand::new("models", "List models"),
-            BotCommand::new("model", "Show/switch model"),
-        ];
+        let commands: Vec<BotCommand> = slash_commands::all_commands()
+            .iter()
+            .map(|c| BotCommand::new(c.name, c.description))
+            .collect();
         if let Err(e) = bot.set_my_commands(commands).await {
             warn!("Telegram: failed to set bot commands: {e}");
         }
@@ -461,5 +454,26 @@ mod tests {
             12345
         );
         assert!(parse_telegram_chat_id("telegram:not-a-number").is_err());
+    }
+
+    /// Telegram BotCommand リストが all_commands() レジストリと整合することを確認。
+    #[test]
+    fn telegram_commands_match_registry() {
+        use teloxide::types::BotCommand;
+
+        let registry = crate::slash_commands::all_commands();
+        let bot_commands: Vec<BotCommand> = registry
+            .iter()
+            .map(|c| BotCommand::new(c.name, c.description))
+            .collect();
+
+        // 同数であること
+        assert_eq!(bot_commands.len(), registry.len());
+
+        // 名前と説明が順序含めて一致すること
+        for (bot_cmd, reg) in bot_commands.iter().zip(registry.iter()) {
+            assert_eq!(bot_cmd.command, reg.name);
+            assert_eq!(bot_cmd.description, reg.description);
+        }
     }
 }

--- a/egopulse/src/channels/tui.rs
+++ b/egopulse/src/channels/tui.rs
@@ -360,10 +360,8 @@ async fn run_loop(
                             next_action = Some(PendingAction::SendMessage(raw_input));
                         }
                     }
-                    KeyCode::Char(c) => {
-                        if !key.modifiers.contains(KeyModifiers::CONTROL) {
-                            insert_input_char(chat, c);
-                        }
+                    KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        insert_input_char(chat, c);
                     }
                     _ => {}
                 },

--- a/egopulse/src/slash_commands.rs
+++ b/egopulse/src/slash_commands.rs
@@ -239,6 +239,79 @@ async fn handle_llm_profile(state: &AppState, caller_channel: &str, input: &str)
 }
 
 // ---------------------------------------------------------------------------
+// Command Metadata Registry
+// ---------------------------------------------------------------------------
+
+/// スラッシュコマンド定義のメタデータ。
+///
+/// 各チャネル (Telegram, Discord, WebUI) はこのレジストリを通じて
+/// コマンド名・説明・使用法を参照する。
+pub struct CommandDef {
+    /// コマンド名（`/` なし）。
+    pub name: &'static str,
+    /// コマンドの短い説明。
+    pub description: &'static str,
+    /// 使用例（`/` で始まる）。
+    pub usage: &'static str,
+}
+
+/// 登録済みコマンド一覧を返す。
+pub const fn all_commands() -> &'static [CommandDef] {
+    &[
+        CommandDef {
+            name: "new",
+            description: "Clear current session",
+            usage: "/new",
+        },
+        CommandDef {
+            name: "compact",
+            description: "Force compact session",
+            usage: "/compact",
+        },
+        CommandDef {
+            name: "status",
+            description: "Show current status",
+            usage: "/status",
+        },
+        CommandDef {
+            name: "skills",
+            description: "List available skills",
+            usage: "/skills",
+        },
+        CommandDef {
+            name: "restart",
+            description: "Restart the bot",
+            usage: "/restart",
+        },
+        CommandDef {
+            name: "providers",
+            description: "List LLM providers",
+            usage: "/providers",
+        },
+        CommandDef {
+            name: "provider",
+            description: "Show/switch provider",
+            usage: "/provider [name]",
+        },
+        CommandDef {
+            name: "models",
+            description: "List models",
+            usage: "/models",
+        },
+        CommandDef {
+            name: "model",
+            description: "Show/switch model",
+            usage: "/model [name]",
+        },
+    ]
+}
+
+/// 名前から CommandDef を検索する。
+pub fn find_command(name: &str) -> Option<&'static CommandDef> {
+    all_commands().iter().find(|c| c.name == name)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -254,7 +327,7 @@ mod tests {
     use crate::runtime::AppState;
     use crate::storage::{StoredMessage, call_blocking};
 
-    use super::{handle_slash_command, is_slash_command};
+    use super::{all_commands, find_command, handle_slash_command, is_slash_command};
 
     // -- is_slash_command tests ---------------------------------------------------
 
@@ -525,5 +598,84 @@ mod tests {
             response.contains("Session is empty"),
             "response: {response}"
         );
+    }
+
+    // -- CommandDef registry tests -----------------------------------------------
+
+    #[test]
+    fn all_commands_returns_all() {
+        // Arrange & Act
+        let commands = all_commands();
+
+        // Assert: 9 コマンドが返る
+        assert_eq!(commands.len(), 9);
+        let names: Vec<&str> = commands.iter().map(|c| c.name).collect();
+        assert!(names.contains(&"new"));
+        assert!(names.contains(&"compact"));
+        assert!(names.contains(&"status"));
+        assert!(names.contains(&"skills"));
+        assert!(names.contains(&"restart"));
+        assert!(names.contains(&"providers"));
+        assert!(names.contains(&"provider"));
+        assert!(names.contains(&"models"));
+        assert!(names.contains(&"model"));
+    }
+
+    #[test]
+    fn all_commands_has_valid_metadata() {
+        // Arrange & Act
+        let commands = all_commands();
+
+        // Assert: 各 CommandDef のメタデータが有効
+        for cmd in commands {
+            assert!(!cmd.name.is_empty(), "name must not be empty");
+            assert!(
+                !cmd.description.is_empty(),
+                "description for '{}' must not be empty",
+                cmd.name
+            );
+            assert!(
+                !cmd.usage.is_empty(),
+                "usage for '{}' must not be empty",
+                cmd.name
+            );
+            assert!(
+                cmd.usage.starts_with('/'),
+                "usage for '{}' must start with '/': got '{}'",
+                cmd.name,
+                cmd.usage
+            );
+        }
+    }
+
+    #[test]
+    fn all_commands_names_are_unique() {
+        // Arrange & Act
+        let commands = all_commands();
+
+        // Assert: name が重複しない
+        let names: Vec<&str> = commands.iter().map(|c| c.name).collect();
+        let unique: std::collections::HashSet<&str> = names.iter().copied().collect();
+        assert_eq!(names.len(), unique.len());
+    }
+
+    #[test]
+    fn find_command_by_name_known() {
+        // Arrange & Act
+        let found = find_command("status");
+
+        // Assert
+        let cmd = found.expect("status command should exist");
+        assert_eq!(cmd.name, "status");
+        assert_eq!(cmd.usage, "/status");
+    }
+
+    #[test]
+    fn find_command_by_name_unknown() {
+        // Arrange & Act
+        let found = find_command("nonexistent");
+
+        // Assert
+        assert!(found.is_none());
     }
 }

--- a/egopulse/src/tools/mod.rs
+++ b/egopulse/src/tools/mod.rs
@@ -372,7 +372,7 @@ pub(crate) fn redact_secrets(output: &str, secrets: &[(String, String)]) -> Stri
         .iter()
         .filter(|(_, value)| !value.is_empty())
         .collect();
-    sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
     let mut redacted = output.to_string();
     for (key, value) in &sorted {
         redacted = redacted.replace(value, &format!("[REDACTED:{key}]"));

--- a/egopulse/web/src/__tests__/CommandSuggest.test.tsx
+++ b/egopulse/web/src/__tests__/CommandSuggest.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CommandSuggest } from "../components/CommandSuggest";
+import { SLASH_COMMANDS } from "../commands";
+
+describe("CommandSuggest", () => {
+  it("コマンドリストが表示される", () => {
+    // Arrange
+    const commands = SLASH_COMMANDS.slice(0, 3);
+
+    // Act
+    render(
+      <CommandSuggest
+        commands={commands}
+        activeIndex={0}
+        onSelect={() => {}}
+      />,
+    );
+
+    // Assert
+    expect(screen.getByRole("listbox")).toBeDefined();
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+  });
+
+  it("選択中インデックスのアイテムがアクティブ表示", () => {
+    // Arrange
+    const commands = SLASH_COMMANDS.slice(0, 3);
+
+    // Act
+    const { container } = render(
+      <CommandSuggest
+        commands={commands}
+        activeIndex={1}
+        onSelect={() => {}}
+      />,
+    );
+
+    // Assert: DOM クエリで active クラスを確認
+    const items = container.querySelectorAll(".command-suggest-item");
+    expect(items).toHaveLength(3);
+    expect(items[1].classList.contains("active")).toBe(true);
+    expect(items[0].classList.contains("active")).toBe(false);
+  });
+
+  it("マッチなしで何もレンダリングしない", () => {
+    // Arrange & Act
+    const { container } = render(
+      <CommandSuggest commands={[]} activeIndex={0} onSelect={() => {}} />,
+    );
+
+    // Assert
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("click でコマンドが選択される", () => {
+    // Arrange
+    const onSelect = vi.fn();
+    const commands = SLASH_COMMANDS.slice(0, 2);
+
+    // Act
+    const { container } = render(
+      <CommandSuggest
+        commands={commands}
+        activeIndex={0}
+        onSelect={onSelect}
+      />,
+    );
+
+    const items = container.querySelectorAll(".command-suggest-item");
+    fireEvent.click(items[1]);
+
+    // Assert
+    expect(onSelect).toHaveBeenCalledWith(commands[1]);
+  });
+});

--- a/egopulse/web/src/__tests__/Composer.test.tsx
+++ b/egopulse/web/src/__tests__/Composer.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { Composer } from "../components/Composer";
+
+describe("Composer", () => {
+  afterEach(cleanup);
+
+  const defaultProps = {
+    draft: "",
+    setDraft: vi.fn(),
+    onSubmit: vi.fn(),
+  };
+
+  function renderComposer(overrides: Partial<typeof defaultProps> = {}) {
+    return render(
+      <Composer {...defaultProps} {...overrides} />,
+    );
+  }
+
+  it("/ 入力でサジェストが表示される", () => {
+    // Arrange & Act
+    renderComposer({ draft: "/" });
+
+    // Assert: command-suggest が DOM に存在する
+    const suggest = document.querySelector(".command-suggest");
+    expect(suggest).not.toBeNull();
+  });
+
+  it("/st 入力で status のみフィルタされる", () => {
+    // Arrange & Act
+    renderComposer({ draft: "/st" });
+
+    // Assert
+    const items = document.querySelectorAll(".command-suggest-item");
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toContain("status");
+  });
+
+  it("通常テキストでサジェスト非表示", () => {
+    // Arrange & Act
+    renderComposer({ draft: "hello" });
+
+    // Assert
+    const suggest = document.querySelector(".command-suggest");
+    expect(suggest).toBeNull();
+  });
+
+  it("Escape キーでサジェスト非表示", () => {
+    // Arrange
+    const { container } = renderComposer({ draft: "/" });
+
+    // Act
+    const textarea = container.querySelector("textarea")!;
+    fireEvent.keyDown(textarea, { key: "Escape" });
+
+    // Assert
+    const suggest = document.querySelector(".command-suggest");
+    expect(suggest).toBeNull();
+  });
+
+  it("Tab キーで選択中コマンドが挿入される", () => {
+    // Arrange
+    const setDraft = vi.fn();
+    const { container } = renderComposer({ draft: "/", setDraft });
+
+    // Act
+    const textarea = container.querySelector("textarea")!;
+    fireEvent.keyDown(textarea, { key: "Tab" });
+
+    // Assert: setDraft がコマンド usage で呼ばれる
+    expect(setDraft).toHaveBeenCalledWith("/new ");
+  });
+
+  it("Enter キーで選択中コマンドが挿入される", () => {
+    // Arrange
+    const setDraft = vi.fn();
+    const { container } = renderComposer({ draft: "/", setDraft });
+
+    // Act
+    const textarea = container.querySelector("textarea")!;
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    // Assert
+    expect(setDraft).toHaveBeenCalledWith("/new ");
+  });
+
+  it("ArrowDown/Up でインデックスが移動する", () => {
+    // Arrange
+    const { container } = renderComposer({ draft: "/" });
+
+    const textarea = container.querySelector("textarea")!;
+
+    // 初期状態: index=0 が active
+    let items = container.querySelectorAll(".command-suggest-item");
+    expect(items[0].classList.contains("active")).toBe(true);
+
+    // Act: ArrowDown → index=1 が active
+    fireEvent.keyDown(textarea, { key: "ArrowDown" });
+    items = container.querySelectorAll(".command-suggest-item");
+    expect(items[1].classList.contains("active")).toBe(true);
+
+    // Act: ArrowUp → index=0 に戻る
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    items = container.querySelectorAll(".command-suggest-item");
+    expect(items[0].classList.contains("active")).toBe(true);
+  });
+});

--- a/egopulse/web/src/__tests__/commands.test.ts
+++ b/egopulse/web/src/__tests__/commands.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { SLASH_COMMANDS, filterCommands } from "../commands";
+
+describe("filterCommands", () => {
+  it("空クエリで全9コマンドが返る", () => {
+    // Arrange & Act
+    const result = filterCommands("");
+
+    // Assert
+    expect(result).toHaveLength(9);
+  });
+
+  it('"st" で status のみフィルタされる', () => {
+    // Arrange & Act
+    const result = filterCommands("st");
+
+    // Assert
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("status");
+  });
+
+  it('"new" で new のみマッチ', () => {
+    // Arrange & Act
+    const result = filterCommands("new");
+
+    // Assert
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("new");
+  });
+
+  it('"xyz" で空配列', () => {
+    // Arrange & Act
+    const result = filterCommands("xyz");
+
+    // Assert
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("SLASH_COMMANDS", () => {
+  it("全コマンドの usage が / で始まる", () => {
+    // Arrange & Act & Assert
+    for (const cmd of SLASH_COMMANDS) {
+      expect(cmd.usage.startsWith("/")).toBe(true);
+      expect(cmd.name.length).toBeGreaterThan(0);
+      expect(cmd.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("name が重複しない", () => {
+    // Arrange & Act
+    const names = SLASH_COMMANDS.map((c) => c.name);
+    const unique = new Set(names);
+
+    // Assert
+    expect(names.length).toBe(unique.size);
+  });
+});

--- a/egopulse/web/src/app.css
+++ b/egopulse/web/src/app.css
@@ -246,6 +246,55 @@
   box-shadow: 0 0 0 3px rgba(192, 132, 252, 0.12);
 }
 
+/* ── Command Suggest ── */
+
+.composer-wrapper {
+  position: relative;
+}
+
+.command-suggest {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 4px;
+  list-style: none;
+  padding: 6px 0;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  background: rgba(8, 16, 32, 0.95);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 -8px 30px rgba(0, 0, 0, 0.3);
+  max-height: 280px;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.command-suggest-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.command-suggest-item:hover,
+.command-suggest-item.active {
+  background: rgba(192, 132, 252, 0.1);
+}
+
+.command-suggest-item .cmd-name {
+  font-weight: 600;
+  font-size: 0.88rem;
+  white-space: nowrap;
+}
+
+.command-suggest-item .cmd-desc {
+  color: var(--color-muted);
+  font-size: 0.8rem;
+}
+
 /* ── Config Form ── */
 
 .config-form {

--- a/egopulse/web/src/commands.ts
+++ b/egopulse/web/src/commands.ts
@@ -1,0 +1,23 @@
+export interface SlashCommand {
+  name: string;
+  description: string;
+  usage: string;
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  { name: "new", description: "Clear current session", usage: "/new" },
+  { name: "compact", description: "Force compact session", usage: "/compact" },
+  { name: "status", description: "Show current status", usage: "/status" },
+  { name: "skills", description: "List available skills", usage: "/skills" },
+  { name: "restart", description: "Restart the bot", usage: "/restart" },
+  { name: "providers", description: "List LLM providers", usage: "/providers" },
+  { name: "provider", description: "Show/switch provider", usage: "/provider [name]" },
+  { name: "models", description: "List models", usage: "/models" },
+  { name: "model", description: "Show/switch model", usage: "/model [name]" },
+];
+
+/** 入力テキストからコマンド候補をフィルタする。"/" は入力済み前提。 */
+export function filterCommands(query: string): SlashCommand[] {
+  const prefix = query.toLowerCase();
+  return SLASH_COMMANDS.filter((c) => c.name.startsWith(prefix));
+}

--- a/egopulse/web/src/components/CommandSuggest.tsx
+++ b/egopulse/web/src/components/CommandSuggest.tsx
@@ -1,0 +1,33 @@
+import type { SlashCommand } from "../commands";
+
+type CommandSuggestProps = {
+  commands: SlashCommand[];
+  activeIndex: number;
+  onSelect: (command: SlashCommand) => void;
+};
+
+export function CommandSuggest({
+  commands,
+  activeIndex,
+  onSelect,
+}: CommandSuggestProps) {
+  if (commands.length === 0) return null;
+
+  return (
+    <ul className="command-suggest" role="listbox">
+      {commands.map((cmd, i) => (
+        <li
+          key={cmd.name}
+          className={`command-suggest-item${i === activeIndex ? " active" : ""}`}
+          role="option"
+          aria-selected={i === activeIndex}
+          onClick={() => onSelect(cmd)}
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          <span className="cmd-name">{cmd.usage}</span>
+          <span className="cmd-desc">{cmd.description}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/egopulse/web/src/components/Composer.tsx
+++ b/egopulse/web/src/components/Composer.tsx
@@ -1,4 +1,6 @@
-import { FormEvent } from "react";
+import { FormEvent, useCallback, useRef, useState } from "react";
+import { SLASH_COMMANDS, filterCommands } from "../commands";
+import { CommandSuggest } from "./CommandSuggest";
 
 type ComposerProps = {
   draft: string;
@@ -7,20 +9,104 @@ type ComposerProps = {
 };
 
 export function Composer({ draft, setDraft, onSubmit }: ComposerProps) {
+  const [showSuggest, setShowSuggest] = useState(() => draft.startsWith("/") && !draft.startsWith("//"));
+  const [activeIndex, setActiveIndex] = useState(0);
+  const committedRef = useRef(false);
+
+  const isSlash = draft.startsWith("/") && !draft.startsWith("//");
+
+  const filtered = isSlash ? filterCommands(draft.slice(1)) : [];
+  const visible = showSuggest && isSlash && filtered.length > 0;
+
+  const handleChange = useCallback(
+    (value: string) => {
+      setDraft(value);
+
+      if (value.startsWith("/") && !value.startsWith("//")) {
+        setShowSuggest(true);
+        setActiveIndex(0);
+      } else {
+        setShowSuggest(false);
+      }
+    },
+    [setDraft],
+  );
+
+  const selectCommand = useCallback(
+    (command: (typeof SLASH_COMMANDS)[number]) => {
+      setDraft(command.usage + " ");
+      setShowSuggest(false);
+    },
+    [setDraft],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!visible) {
+        // サジェスト非表示時の既存ショートカット
+        if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+          event.preventDefault();
+          onSubmit(event as unknown as FormEvent);
+        }
+        return;
+      }
+
+      committedRef.current = false;
+
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+          setActiveIndex((i) => (i + 1) % filtered.length);
+          break;
+        }
+        case "ArrowUp": {
+          event.preventDefault();
+          setActiveIndex((i) => (i - 1 + filtered.length) % filtered.length);
+          break;
+        }
+        case "Tab":
+        case "Enter": {
+          event.preventDefault();
+          committedRef.current = true;
+          selectCommand(filtered[activeIndex]);
+          break;
+        }
+        case "Escape": {
+          event.preventDefault();
+          setShowSuggest(false);
+          break;
+        }
+      }
+    },
+    [visible, filtered, activeIndex, selectCommand, onSubmit],
+  );
+
   return (
     <form className="composer" onSubmit={onSubmit}>
-      <textarea
-        value={draft}
-        onChange={(event) => setDraft(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
-            event.preventDefault();
-            onSubmit(event as unknown as FormEvent);
-          }
-        }}
-        placeholder="Type a message"
-        rows={3}
-      />
+      <div className="composer-wrapper">
+        <textarea
+          value={draft}
+          onChange={(event) => handleChange(event.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => {
+            // Tab/Enter による選択直後は閉じない
+            if (committedRef.current) {
+              committedRef.current = false;
+              return;
+            }
+            setShowSuggest(false);
+          }}
+          placeholder="Type a message"
+          rows={3}
+        />
+        {visible && (
+          <CommandSuggest
+            commands={filtered}
+            activeIndex={activeIndex}
+            onSelect={selectCommand}
+          />
+        )}
+      </div>
       <button className="primary-button" type="submit">
         Send
       </button>


### PR DESCRIPTION
## Summary

- `CommandDef` レジストリを導入し、全チャネルがコマンド定義を単一ソース (`all_commands()`) から参照するようリファクタ
- Discord: Application Commands (Interactions API) を登録し、プラットフォームネイティブのオートコンプリート UI を提供
- Telegram: ハードコードの `BotCommand` リストを `all_commands()` からの生成に置換
- WebUI: `/` 入力時にコマンド候補をポップアップ表示する `CommandSuggest` コンポーネント + `Composer` 統合
- ドキュメント: `commands.md` に Discord / WebUI のコマンド UI 実装詳細を追記

## 変更ファイル一覧

| ファイル | 変更種別 | 内容 |
|---|---|---|
| `egopulse/src/slash_commands.rs` | 変更 | `CommandDef` + `all_commands()` + `find_command()` 追加 |
| `egopulse/src/channels/telegram.rs` | 変更 | `set_my_commands` を `all_commands()` から生成 |
| `egopulse/src/channels/discord.rs` | 変更 | Application Command 登録 + `interaction_create` ハンドラ |
| `egopulse/web/src/commands.ts` | 新規 | フロントエンド用コマンド定数 + `filterCommands()` |
| `egopulse/web/src/components/CommandSuggest.tsx` | 新規 | コマンドサジェスト表示コンポーネント |
| `egopulse/web/src/components/Composer.tsx` | 変更 | サジェスト状態管理 + キーボード操作 + CommandSuggest レンダー |
| `egopulse/web/src/app.css` | 変更 | `.command-suggest` 系スタイル追加 |
| `docs/30.egopulse/commands.md` | 変更 | 4.3 セクション追加（CommandDef レジストリ / Discord / WebUI 詳細） |

## テスト

- Rust: 225 テストパス（追加: CommandDef レジストリ 5件、Telegram 1件、Discord 2件）
- WebUI: 42 テストパス（追加: commands 6件、CommandSuggest 4件、Composer 7件）
- `cargo fmt` / `cargo clippy` / `npm run build` 全てクリア

## Test plan

- [ ] `cargo test -p egopulse` がパスする
- [ ] `cd egopulse/web && npm test` がパスする
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` がクリア
- [ ] WebUI ブラウザで `/` 入力時にコマンド候補がポップアップ表示される
- [ ] WebUI で `↑↓` キーで候補選択、`Tab`/`Enter` で確定、`Escape` で非表示
- [ ] Discord で `/` 入力時にネイティブサジェストが表示される（※Bot接続時）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * チャットコンポーザーにコマンド入力補助を追加。`/`で候補が表示され、矢印/Tab/Enter/Escapeやクリックで操作可能。
  * Discordボットがネイティブのスラッシュコマンド登録と対話応答に対応。
  * コマンド定義の共通レジストリを導入し、Telegramのコマンドと同期。

* **テスト**
  * CommandSuggest/Composer/commands のユニット／UIテストを追加。

* **ドキュメント**
  * コマンドUIの実装詳細ドキュメントを追記。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->