### PR TITLE
refactor: align egopulse directory structure with TOBE spec

### DIFF
--- a/egopulse/src/agent_loop/compaction.rs
+++ b/egopulse/src/agent_loop/compaction.rs
@@ -45,7 +45,13 @@ async fn summarize_and_compact(
     llm: &std::sync::Arc<dyn crate::llm::LlmProvider>,
     label: &str,
 ) -> Result<Vec<Message>, EgoPulseError> {
-    archive_conversation(&state.config.data_dir, &context.channel, chat_id, messages).await;
+    archive_conversation(
+        &state.config.state_root,
+        &context.channel,
+        chat_id,
+        messages,
+    )
+    .await;
 
     let keep_recent = state.config.compact_keep_recent.min(messages.len());
     if keep_recent == messages.len() {
@@ -118,17 +124,17 @@ async fn summarize_and_compact(
 }
 
 pub(crate) async fn archive_conversation(
-    data_dir: &str,
+    state_root: &str,
     channel: &str,
     chat_id: i64,
     messages: &[Message],
 ) {
-    let data_dir = data_dir.to_string();
+    let state_root = state_root.to_string();
     let channel = channel.to_string();
     let messages = messages.to_vec();
     let join_channel = channel.clone();
     let join_result = tokio::task::spawn_blocking(move || {
-        archive_conversation_blocking(&data_dir, &channel, chat_id, &messages);
+        archive_conversation_blocking(&state_root, &channel, chat_id, &messages);
     })
     .await;
 
@@ -141,7 +147,7 @@ pub(crate) async fn archive_conversation(
 }
 
 pub(crate) fn archive_conversation_blocking(
-    data_dir: &str,
+    state_root: &str,
     channel: &str,
     chat_id: i64,
     messages: &[Message],
@@ -153,7 +159,8 @@ pub(crate) fn archive_conversation_blocking(
     } else {
         channel.trim()
     };
-    let dir = std::path::PathBuf::from(data_dir)
+    let dir = std::path::PathBuf::from(state_root)
+        .join("runtime")
         .join("groups")
         .join(channel_dir)
         .join(chat_id.to_string())
@@ -356,6 +363,7 @@ mod tests {
 
         let archive_dir = dir
             .path()
+            .join("runtime")
             .join("groups")
             .join("cli")
             .join(chat_id.to_string())
@@ -534,7 +542,7 @@ mod tests {
     #[serial]
     async fn force_compact_produces_archive() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let data_dir = dir.path().to_str().expect("utf8").to_string();
+        let state_root = dir.path().to_str().expect("utf8").to_string();
         let provider = RecordingProvider::new(
             vec![Ok(MessagesResponse {
                 content: "summary text".to_string(),
@@ -542,7 +550,7 @@ mod tests {
             })],
             vec![0],
         );
-        let config = test_config_with_compaction(data_dir.clone(), 40, 1);
+        let config = test_config_with_compaction(state_root.clone(), 40, 1);
         let state = build_state(config, Box::new(provider.clone()));
         let context = cli_context("force-compact-archive");
         let llm = state.global_llm().expect("llm");
@@ -558,6 +566,7 @@ mod tests {
 
         let archive_dir = dir
             .path()
+            .join("runtime")
             .join("groups")
             .join("cli")
             .join(chat_id.to_string())

--- a/egopulse/src/agent_loop/compaction.rs
+++ b/egopulse/src/agent_loop/compaction.rs
@@ -46,7 +46,7 @@ async fn summarize_and_compact(
     label: &str,
 ) -> Result<Vec<Message>, EgoPulseError> {
     archive_conversation(
-        &state.config.state_root,
+        &state.config.groups_dir(),
         &context.channel,
         chat_id,
         messages,
@@ -124,17 +124,17 @@ async fn summarize_and_compact(
 }
 
 pub(crate) async fn archive_conversation(
-    state_root: &str,
+    groups_dir: &std::path::Path,
     channel: &str,
     chat_id: i64,
     messages: &[Message],
 ) {
-    let state_root = state_root.to_string();
+    let groups_dir = groups_dir.to_path_buf();
     let channel = channel.to_string();
     let messages = messages.to_vec();
     let join_channel = channel.clone();
     let join_result = tokio::task::spawn_blocking(move || {
-        archive_conversation_blocking(&state_root, &channel, chat_id, &messages);
+        archive_conversation_blocking(&groups_dir, &channel, chat_id, &messages);
     })
     .await;
 
@@ -147,7 +147,7 @@ pub(crate) async fn archive_conversation(
 }
 
 pub(crate) fn archive_conversation_blocking(
-    state_root: &str,
+    groups_dir: &std::path::Path,
     channel: &str,
     chat_id: i64,
     messages: &[Message],
@@ -159,9 +159,7 @@ pub(crate) fn archive_conversation_blocking(
     } else {
         channel.trim()
     };
-    let dir = std::path::PathBuf::from(state_root)
-        .join("runtime")
-        .join("groups")
+    let dir = groups_dir
         .join(channel_dir)
         .join(chat_id.to_string())
         .join("conversations");

--- a/egopulse/src/agent_loop/session.rs
+++ b/egopulse/src/agent_loop/session.rs
@@ -418,7 +418,7 @@ mod tests {
         }
     }
 
-    fn test_config(data_dir: String) -> Config {
+    fn test_config(state_root: String) -> Config {
         Config {
             default_provider: "openai".to_string(),
             default_model: Some("gpt-4o-mini".to_string()),
@@ -432,7 +432,7 @@ mod tests {
                     models: vec!["gpt-4o-mini".to_string()],
                 },
             )]),
-            data_dir,
+            state_root,
             log_level: "info".to_string(),
             compaction_timeout_secs: 180,
             max_history_messages: 50,
@@ -459,21 +459,22 @@ mod tests {
         }
     }
 
-    fn build_state_with_provider(data_dir: String, llm: Box<dyn LlmProvider>) -> AppState {
+    fn build_state_with_provider(state_root: String, llm: Box<dyn LlmProvider>) -> AppState {
         use crate::channel_adapter::ChannelRegistry;
-        let config = test_config(data_dir.clone());
-        let skills = Arc::new(SkillManager::from_skills_dir(
+        let config = test_config(state_root.clone());
+        let skills = Arc::new(SkillManager::from_dirs(
+            config.user_skills_dir().expect("user_skills_dir"),
             config.skills_dir().expect("skills_dir"),
         ));
         AppState {
-            db: Arc::new(Database::new(&data_dir).expect("db")),
+            db: Arc::new(Database::new(&state_root).expect("db")),
             config: config.clone(),
             config_path: None,
             llm_override: Some(Arc::from(llm)),
             channels: Arc::new(ChannelRegistry::new()),
             skills: Arc::clone(&skills),
             tools: Arc::new(ToolRegistry::new(&config, skills)),
-            assets: Arc::new(AssetStore::new(&data_dir).expect("assets")),
+            assets: Arc::new(AssetStore::new(&state_root).expect("assets")),
         }
     }
 

--- a/egopulse/src/agent_loop/session.rs
+++ b/egopulse/src/agent_loop/session.rs
@@ -467,14 +467,14 @@ mod tests {
             config.skills_dir().expect("skills_dir"),
         ));
         AppState {
-            db: Arc::new(Database::new(&state_root).expect("db")),
+            db: Arc::new(Database::new(&config.db_path()).expect("db")),
             config: config.clone(),
             config_path: None,
             llm_override: Some(Arc::from(llm)),
             channels: Arc::new(ChannelRegistry::new()),
             skills: Arc::clone(&skills),
             tools: Arc::new(ToolRegistry::new(&config, skills)),
-            assets: Arc::new(AssetStore::new(&state_root).expect("assets")),
+            assets: Arc::new(AssetStore::new(&config.assets_dir()).expect("assets")),
         }
     }
 

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -783,7 +783,7 @@ impl RecordingProvider {
 }
 
 #[cfg(test)]
-pub(crate) fn test_config(data_dir: String) -> crate::config::Config {
+pub(crate) fn test_config(state_root: String) -> crate::config::Config {
     crate::config::Config {
         default_provider: "openai".to_string(),
         default_model: Some("gpt-4o-mini".to_string()),
@@ -799,7 +799,7 @@ pub(crate) fn test_config(data_dir: String) -> crate::config::Config {
                 models: vec!["gpt-4o-mini".to_string()],
             },
         )]),
-        data_dir,
+        state_root,
         log_level: "info".to_string(),
         compaction_timeout_secs: 180,
         max_history_messages: 50,
@@ -819,11 +819,11 @@ pub(crate) fn test_config(data_dir: String) -> crate::config::Config {
 
 #[cfg(test)]
 pub(crate) fn test_config_with_compaction(
-    data_dir: String,
+    state_root: String,
     max_session_messages: usize,
     compact_keep_recent: usize,
 ) -> crate::config::Config {
-    let mut config = test_config(data_dir);
+    let mut config = test_config(state_root);
     config.max_session_messages = max_session_messages;
     config.compact_keep_recent = compact_keep_recent;
     config
@@ -867,9 +867,10 @@ pub(crate) fn build_state(
     use crate::storage::Database;
     use crate::tools::ToolRegistry;
 
-    let data_dir = config.data_dir.clone();
-    let db = std::sync::Arc::new(Database::new(&data_dir).expect("db"));
-    let skills = std::sync::Arc::new(SkillManager::from_skills_dir(
+    let state_root = config.state_root.clone();
+    let db = std::sync::Arc::new(Database::new(&state_root).expect("db"));
+    let skills = std::sync::Arc::new(SkillManager::from_dirs(
+        config.user_skills_dir().expect("user_skills_dir"),
         config.skills_dir().expect("skills_dir"),
     ));
     AppState {
@@ -880,16 +881,16 @@ pub(crate) fn build_state(
         channels: std::sync::Arc::new(ChannelRegistry::new()),
         skills: std::sync::Arc::clone(&skills),
         tools: std::sync::Arc::new(ToolRegistry::new(&config, skills)),
-        assets: std::sync::Arc::new(AssetStore::new(&data_dir).expect("assets")),
+        assets: std::sync::Arc::new(AssetStore::new(&state_root).expect("assets")),
     }
 }
 
 #[cfg(test)]
 pub(crate) fn build_state_with_provider(
-    data_dir: String,
+    state_root: String,
     llm: Box<dyn crate::llm::LlmProvider>,
 ) -> AppState {
-    build_state(test_config(data_dir), llm)
+    build_state(test_config(state_root), llm)
 }
 
 #[cfg(test)]

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -867,8 +867,7 @@ pub(crate) fn build_state(
     use crate::storage::Database;
     use crate::tools::ToolRegistry;
 
-    let state_root = config.state_root.clone();
-    let db = std::sync::Arc::new(Database::new(&state_root).expect("db"));
+    let db = std::sync::Arc::new(Database::new(&config.db_path()).expect("db"));
     let skills = std::sync::Arc::new(SkillManager::from_dirs(
         config.user_skills_dir().expect("user_skills_dir"),
         config.skills_dir().expect("skills_dir"),
@@ -881,7 +880,7 @@ pub(crate) fn build_state(
         channels: std::sync::Arc::new(ChannelRegistry::new()),
         skills: std::sync::Arc::clone(&skills),
         tools: std::sync::Arc::new(ToolRegistry::new(&config, skills)),
-        assets: std::sync::Arc::new(AssetStore::new(&state_root).expect("assets")),
+        assets: std::sync::Arc::new(AssetStore::new(&config.assets_dir()).expect("assets")),
     }
 }
 

--- a/egopulse/src/assets.rs
+++ b/egopulse/src/assets.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 
 use crate::error::StorageError;
 
-/// Content-addressable file store for image assets under `{data_dir}/assets/images/`.
+/// Content-addressable file store for image assets under `{state_root}/runtime/assets/images/`.
 #[derive(Debug, Clone)]
 pub struct AssetStore {
     root: PathBuf,
@@ -32,8 +32,8 @@ struct ImageAssetMetadata {
 
 impl AssetStore {
     /// Create the asset store, ensuring the `assets/images/` directory tree exists.
-    pub fn new(data_dir: &str) -> Result<Self, StorageError> {
-        let root = Path::new(data_dir).join("assets");
+    pub fn new(state_root: &str) -> Result<Self, StorageError> {
+        let root = Path::new(state_root).join("runtime").join("assets");
         std::fs::create_dir_all(root.join("images"))?;
         Ok(Self { root })
     }

--- a/egopulse/src/assets.rs
+++ b/egopulse/src/assets.rs
@@ -31,11 +31,12 @@ struct ImageAssetMetadata {
 }
 
 impl AssetStore {
-    /// Create the asset store, ensuring the `assets/images/` directory tree exists.
-    pub fn new(state_root: &str) -> Result<Self, StorageError> {
-        let root = Path::new(state_root).join("runtime").join("assets");
-        std::fs::create_dir_all(root.join("images"))?;
-        Ok(Self { root })
+    /// Create the asset store, ensuring the `images/` directory tree exists.
+    pub fn new(assets_dir: &Path) -> Result<Self, StorageError> {
+        std::fs::create_dir_all(assets_dir.join("images"))?;
+        Ok(Self {
+            root: assets_dir.to_path_buf(),
+        })
     }
 
     /// Parse a `data:<mime>;base64,...` URL, write the decoded bytes to disk (deduplicated by SHA-256).
@@ -170,7 +171,7 @@ mod tests {
     #[test]
     fn persists_and_hydrates_images_by_reference() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let store = AssetStore::new(dir.path().to_str().expect("utf8")).expect("store");
+        let store = AssetStore::new(dir.path()).expect("store");
         let data_url = "data:image/png;base64,AAAA";
 
         let stored = store
@@ -187,7 +188,7 @@ mod tests {
     #[test]
     fn deduplicates_identical_images_and_sweeps_unreferenced() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let store = AssetStore::new(dir.path().to_str().expect("utf8")).expect("store");
+        let store = AssetStore::new(dir.path()).expect("store");
         let data_url = "data:image/png;base64,AAAA";
 
         let first = store

--- a/egopulse/src/config.rs
+++ b/egopulse/src/config.rs
@@ -171,7 +171,7 @@ pub struct Config {
     /// Optional global model override (YAML `default_model`).
     pub default_model: Option<String>,
     pub providers: HashMap<String, ProviderConfig>,
-    pub data_dir: String,
+    pub state_root: String,
     pub log_level: String,
     pub compaction_timeout_secs: u64,
     pub max_history_messages: usize,
@@ -186,7 +186,7 @@ impl std::fmt::Debug for Config {
             .field("default_provider", &self.default_provider)
             .field("default_model", &self.default_model)
             .field("providers", &self.providers)
-            .field("data_dir", &self.data_dir)
+            .field("state_root", &self.state_root)
             .field("log_level", &self.log_level)
             .field("compaction_timeout_secs", &self.compaction_timeout_secs)
             .field("max_history_messages", &self.max_history_messages)
@@ -369,14 +369,44 @@ impl Config {
             .and_then(|c| c.bot_username.as_deref())
     }
 
-    /// Directory containing skill definitions.
+    /// 組み込みスキルディレクトリ: `state_root/skills`。
     pub fn skills_dir(&self) -> Result<PathBuf, ConfigError> {
+        default_state_root().map(|root| root.join("skills"))
+    }
+
+    /// ユーザースキルディレクトリ: `state_root/workspace/skills`。
+    pub fn user_skills_dir(&self) -> Result<PathBuf, ConfigError> {
         default_workspace_dir().map(|dir| dir.join("skills"))
     }
 
     /// Workspace directory for agent file operations.
     pub fn workspace_dir(&self) -> Result<PathBuf, ConfigError> {
         default_workspace_dir()
+    }
+
+    /// ランタイムデータディレクトリ: `state_root/runtime`。
+    pub fn runtime_dir(&self) -> PathBuf {
+        Path::new(&self.state_root).join("runtime")
+    }
+
+    /// データベースファイルパス: `state_root/runtime/egopulse.db`。
+    pub fn db_path(&self) -> PathBuf {
+        self.runtime_dir().join("egopulse.db")
+    }
+
+    /// アセットディレクトリ: `state_root/runtime/assets`。
+    pub fn assets_dir(&self) -> PathBuf {
+        self.runtime_dir().join("assets")
+    }
+
+    /// アーカイブディレクトリ: `state_root/runtime/groups`。
+    pub fn groups_dir(&self) -> PathBuf {
+        self.runtime_dir().join("groups")
+    }
+
+    /// ステータスファイルパス: `state_root/runtime/status.json`。
+    pub fn status_json_path(&self) -> PathBuf {
+        self.runtime_dir().join("status.json")
     }
 
     /// Atomically writes the current config to a YAML file.
@@ -406,11 +436,6 @@ pub fn default_state_root() -> Result<PathBuf, ConfigError> {
     dirs::home_dir()
         .map(|home| home.join(".egopulse"))
         .ok_or(ConfigError::HomeDirectoryUnresolved)
-}
-
-/// Default data directory: `~/.egopulse/data`.
-pub fn default_data_dir() -> Result<PathBuf, ConfigError> {
-    default_state_root().map(|root| root.join("data"))
 }
 
 /// Default workspace directory: `~/.egopulse/workspace`.
@@ -593,7 +618,7 @@ fn build_config(
 
     let default_model = normalize_string(file_default_model);
 
-    let data_dir = default_data_dir()?.to_string_lossy().into_owned();
+    let state_root = default_state_root()?.to_string_lossy().into_owned();
 
     let log_level = first_non_empty([env_var("EGOPULSE_LOG_LEVEL"), file_log_level])
         .unwrap_or_else(|| "info".to_string());
@@ -617,7 +642,7 @@ fn build_config(
         default_provider,
         default_model,
         providers,
-        data_dir,
+        state_root,
         log_level,
         compaction_timeout_secs,
         max_history_messages,
@@ -784,7 +809,7 @@ struct SerializableConfig {
     default_provider: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_model: Option<String>,
-    data_dir: String,
+    state_root: String,
     log_level: String,
     compaction_timeout_secs: u64,
     max_history_messages: usize,
@@ -879,7 +904,7 @@ impl From<&Config> for SerializableConfig {
         Self {
             default_provider: config.default_provider.clone(),
             default_model: config.default_model.clone(),
-            data_dir: config.data_dir.clone(),
+            state_root: config.state_root.clone(),
             log_level: config.log_level.clone(),
             compaction_timeout_secs: config.compaction_timeout_secs,
             max_history_messages: config.max_history_messages,
@@ -976,7 +1001,7 @@ mod tests {
 
     use std::path::PathBuf;
 
-    use super::{Config, default_data_dir, default_workspace_dir};
+    use super::{Config, default_state_root, default_workspace_dir};
     use crate::error::ConfigError;
     use crate::test_env::EnvVarGuard;
 
@@ -1031,14 +1056,17 @@ channels:
 
         assert_eq!(config.default_provider, "openai");
         assert_eq!(config.global_provider().label, "OpenAI");
-        assert_eq!(PathBuf::from(&config.data_dir), default_data_dir().unwrap());
+        assert_eq!(
+            PathBuf::from(&config.state_root),
+            default_state_root().unwrap()
+        );
         assert_eq!(
             config.workspace_dir().unwrap(),
             default_workspace_dir().unwrap()
         );
         assert_eq!(
             config.skills_dir().unwrap(),
-            default_workspace_dir().unwrap().join("skills")
+            default_state_root().unwrap().join("skills")
         );
         assert!(config.web_enabled());
         assert_eq!(config.web_auth_token(), Some("web-secret"));

--- a/egopulse/src/config.rs
+++ b/egopulse/src/config.rs
@@ -371,17 +371,17 @@ impl Config {
 
     /// 組み込みスキルディレクトリ: `state_root/skills`。
     pub fn skills_dir(&self) -> Result<PathBuf, ConfigError> {
-        default_state_root().map(|root| root.join("skills"))
+        Ok(Path::new(&self.state_root).join("skills"))
     }
 
     /// ユーザースキルディレクトリ: `state_root/workspace/skills`。
     pub fn user_skills_dir(&self) -> Result<PathBuf, ConfigError> {
-        default_workspace_dir().map(|dir| dir.join("skills"))
+        Ok(self.workspace_dir()?.join("skills"))
     }
 
-    /// Workspace directory for agent file operations.
+    /// エージェント作業ディレクトリ: `state_root/workspace`。
     pub fn workspace_dir(&self) -> Result<PathBuf, ConfigError> {
-        default_workspace_dir()
+        Ok(Path::new(&self.state_root).join("workspace"))
     }
 
     /// ランタイムデータディレクトリ: `state_root/runtime`。

--- a/egopulse/src/gateway.rs
+++ b/egopulse/src/gateway.rs
@@ -72,9 +72,11 @@ fn render_systemd_unit(exe_path: &str, config_path: &std::path::Path) -> String 
     let working_dir = config_path
         .parent()
         .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|| dirs::home_dir()
-            .map(|h| h.join(".egopulse").to_string_lossy().to_string())
-            .unwrap_or_else(|| ".".to_string()));
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .map(|h| h.join(".egopulse").to_string_lossy().to_string())
+                .unwrap_or_else(|| ".".to_string())
+        });
 
     format!(
         "[Unit]

--- a/egopulse/src/runtime.rs
+++ b/egopulse/src/runtime.rs
@@ -101,9 +101,12 @@ pub async fn build_app_state_with_path(
     config: Config,
     config_path: Option<PathBuf>,
 ) -> Result<AppState, EgoPulseError> {
-    let db = Arc::new(Database::new(&config.data_dir)?);
-    let assets = Arc::new(AssetStore::new(&config.data_dir)?);
-    let skills = Arc::new(SkillManager::from_skills_dir(config.skills_dir()?));
+    let db = Arc::new(Database::new(&config.state_root)?);
+    let assets = Arc::new(AssetStore::new(&config.state_root)?);
+    let skills = Arc::new(SkillManager::from_dirs(
+        config.user_skills_dir()?,
+        config.skills_dir()?,
+    ));
 
     let mut channels = ChannelRegistry::new();
     channels.register(Arc::new(WebAdapter));
@@ -358,13 +361,7 @@ async fn write_startup_status(state: &AppState) {
         },
     };
 
-    let state_root = match crate::config::default_state_root() {
-        Ok(path) => path,
-        Err(error) => {
-            tracing::warn!("failed to resolve state root for startup status: {error}");
-            return;
-        }
-    };
+    let state_root = PathBuf::from(&state.config.state_root);
     if let Err(error) = status::write_status(&state_root, &snapshot) {
         tracing::warn!("failed to write startup status: {error}");
     }

--- a/egopulse/src/runtime.rs
+++ b/egopulse/src/runtime.rs
@@ -101,8 +101,8 @@ pub async fn build_app_state_with_path(
     config: Config,
     config_path: Option<PathBuf>,
 ) -> Result<AppState, EgoPulseError> {
-    let db = Arc::new(Database::new(&config.state_root)?);
-    let assets = Arc::new(AssetStore::new(&config.state_root)?);
+    let db = Arc::new(Database::new(&config.db_path())?);
+    let assets = Arc::new(AssetStore::new(&config.assets_dir())?);
     let skills = Arc::new(SkillManager::from_dirs(
         config.user_skills_dir()?,
         config.skills_dir()?,

--- a/egopulse/src/setup/channels.rs
+++ b/egopulse/src/setup/channels.rs
@@ -75,6 +75,17 @@ pub(crate) fn extract_existing_web_auth_token(
         .map(|s| s.to_string())
 }
 
+pub(crate) fn extract_existing_state_root(
+    original_yaml: &Option<serde_yml::Value>,
+) -> Option<String> {
+    original_yaml
+        .as_ref()
+        .and_then(|v| v.as_mapping())
+        .and_then(|m| m.get(serde_yml::Value::String("state_root".into())))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
 pub(crate) fn build_channel_configs(
     auth_token: String,
     discord_enabled: bool,

--- a/egopulse/src/setup/summary.rs
+++ b/egopulse/src/setup/summary.rs
@@ -19,7 +19,8 @@ use super::provider::{
 };
 use super::{Field, SetupApp};
 use crate::config::{
-    Config, ProviderConfig, base_url_allows_empty_api_key, default_data_dir, default_workspace_dir,
+    Config, ProviderConfig, base_url_allows_empty_api_key, default_state_root,
+    default_workspace_dir,
 };
 use crate::error::EgoPulseError;
 
@@ -125,8 +126,8 @@ pub(crate) fn save_config(
         fs::create_dir_all(config_dir)
             .map_err(|e| format!("Failed to create config directory: {e}"))?;
     }
-    fs::create_dir_all(default_data_dir().map_err(|e| e.to_string())?)
-        .map_err(|e| format!("Failed to create data directory: {e}"))?;
+    fs::create_dir_all(default_state_root().map_err(|e| e.to_string())?)
+        .map_err(|e| format!("Failed to create state root directory: {e}"))?;
     fs::create_dir_all(default_workspace_dir().map_err(|e| e.to_string())?)
         .map_err(|e| format!("Failed to create workspace directory: {e}"))?;
 
@@ -179,7 +180,7 @@ pub(crate) fn save_config(
         default_provider: provider_id.clone(),
         default_model: Some(model.clone()),
         providers,
-        data_dir: default_data_dir()
+        state_root: default_state_root()
             .map_err(|e| e.to_string())?
             .to_string_lossy()
             .into_owned(),

--- a/egopulse/src/setup/summary.rs
+++ b/egopulse/src/setup/summary.rs
@@ -11,7 +11,8 @@ use secrecy::SecretString;
 use url::Url;
 
 use super::channels::{
-    build_channel_configs, extract_existing_web_auth_token, generate_auth_token,
+    build_channel_configs, extract_existing_state_root, extract_existing_web_auth_token,
+    generate_auth_token,
 };
 use super::provider::{
     find_provider_preset, normalize_provider_id, provider_default_base_url, provider_default_model,
@@ -116,6 +117,8 @@ pub(crate) fn save_config(
     let has_existing_token = existing_token.is_some();
     let auth_token = existing_token.unwrap_or_else(generate_auth_token);
 
+    let existing_state_root = extract_existing_state_root(original_yaml);
+
     let discord_enabled = field_bool(fields, "DISCORD_ENABLED");
     let discord_bot_token = field_value(fields, "DISCORD_BOT_TOKEN").to_string();
     let telegram_enabled = field_bool(fields, "TELEGRAM_ENABLED");
@@ -180,10 +183,13 @@ pub(crate) fn save_config(
         default_provider: provider_id.clone(),
         default_model: Some(model.clone()),
         providers,
-        state_root: default_state_root()
-            .map_err(|e| e.to_string())?
-            .to_string_lossy()
-            .into_owned(),
+        state_root: existing_state_root.unwrap_or_else(|| {
+            default_state_root()
+                .map_err(|e| e.to_string())
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        }),
         log_level: "info".to_string(),
         compaction_timeout_secs: 180,
         max_history_messages: 50,

--- a/egopulse/src/skills.rs
+++ b/egopulse/src/skills.rs
@@ -39,7 +39,8 @@ pub struct LoadedSkill {
 /// Discovers, validates, and loads skills from the workspace skill directories.
 #[derive(Debug, Clone)]
 pub struct SkillManager {
-    skills_dir: PathBuf,
+    user_skills_dir: PathBuf,
+    builtin_skills_dir: PathBuf,
 }
 
 const MAX_SKILLS_CATALOG_ITEMS: usize = 40;
@@ -47,15 +48,33 @@ const MAX_SKILL_DESCRIPTION_CHARS: usize = 120;
 const COMPACT_SKILLS_MODE_THRESHOLD: usize = 20;
 
 impl SkillManager {
-    /// Create a manager rooted at the given skills directory.
-    pub fn from_skills_dir(skills_dir: impl Into<PathBuf>) -> Self {
+    /// Create a manager scanning both user and built-in skill directories.
+    pub fn from_dirs(
+        user_skills_dir: impl Into<PathBuf>,
+        builtin_skills_dir: impl Into<PathBuf>,
+    ) -> Self {
         Self {
-            skills_dir: skills_dir.into(),
+            user_skills_dir: user_skills_dir.into(),
+            builtin_skills_dir: builtin_skills_dir.into(),
+        }
+    }
+
+    /// Backward-compatible constructor using a single skills directory.
+    pub fn from_skills_dir(skills_dir: impl Into<PathBuf>) -> Self {
+        let dir = skills_dir.into();
+        let builtin = dir
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|root| root.join("skills"))
+            .unwrap_or_else(|| dir.clone());
+        Self {
+            user_skills_dir: dir.clone(),
+            builtin_skills_dir: builtin,
         }
     }
 
     pub fn skills_dir(&self) -> &Path {
-        &self.skills_dir
+        &self.user_skills_dir
     }
 
     /// Scan the workspace for available skills, filtering by platform and dependency availability.
@@ -174,19 +193,25 @@ impl SkillManager {
     fn discover_skill_dirs(&self) -> Vec<PathBuf> {
         let mut candidates = Vec::new();
 
-        // Highest priority: ~/.egopulse/workspace/skills/*
-        collect_skill_dirs_direct_children(&self.skills_dir, &mut candidates);
+        // Highest priority: user skills (workspace/skills/*)
+        collect_skill_dirs_direct_children(&self.user_skills_dir, &mut candidates);
 
-        // Then recursively scan the rest of workspace for SKILL.md files.
-        let Some(workspace_root) = self.skills_dir.parent() else {
+        // Then recursively scan workspace for SKILL.md files.
+        let Some(workspace_root) = self.user_skills_dir.parent() else {
             return candidates;
         };
-        let Ok(skills_dir_canonical) = std::fs::canonicalize(&self.skills_dir) else {
-            collect_skill_dirs_recursive(workspace_root, &self.skills_dir, &mut candidates);
+        let Ok(user_skills_dir_canonical) = std::fs::canonicalize(&self.user_skills_dir) else {
+            collect_skill_dirs_recursive(workspace_root, &self.user_skills_dir, &mut candidates);
             return candidates;
         };
 
-        collect_skill_dirs_recursive(workspace_root, &skills_dir_canonical, &mut candidates);
+        collect_skill_dirs_recursive(workspace_root, &user_skills_dir_canonical, &mut candidates);
+
+        // Built-in skills: state_root/skills/*
+        if self.builtin_skills_dir != self.user_skills_dir {
+            collect_skill_dirs_direct_children(&self.builtin_skills_dir, &mut candidates);
+        }
+
         candidates
     }
 }

--- a/egopulse/src/status.rs
+++ b/egopulse/src/status.rs
@@ -100,7 +100,9 @@ pub struct ProviderStatus {
 
 /// `status.json` にスナップショットを書き出す。
 pub fn write_status(state_root: &Path, snapshot: &StatusSnapshot) -> std::io::Result<()> {
-    let path = state_root.join(STATUS_FILE);
+    let runtime_dir = state_root.join("runtime");
+    std::fs::create_dir_all(&runtime_dir)?;
+    let path = runtime_dir.join(STATUS_FILE);
     let json = serde_json::to_string_pretty(snapshot)?;
     fs::write(path, json)
 }
@@ -109,7 +111,7 @@ pub fn write_status(state_root: &Path, snapshot: &StatusSnapshot) -> std::io::Re
 ///
 /// ファイルが存在しない、またはパースに失敗した場合は `None` を返す。
 pub fn read_status(state_root: &Path) -> Option<StatusSnapshot> {
-    let path = state_root.join(STATUS_FILE);
+    let path = state_root.join("runtime").join(STATUS_FILE);
     let data = fs::read_to_string(path).ok()?;
     serde_json::from_str(&data).ok()
 }
@@ -275,7 +277,9 @@ mod tests {
     fn read_invalid_json_returns_none() {
         // Arrange
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join(STATUS_FILE);
+        let runtime_dir = dir.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).unwrap();
+        let path = runtime_dir.join(STATUS_FILE);
         fs::write(&path, "not json").unwrap();
 
         // Act

--- a/egopulse/src/status.rs
+++ b/egopulse/src/status.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -200,7 +200,9 @@ fn format_channels(channels: &ChannelsStatus, lines: &mut Vec<String>) {
 
 /// `status.json` からスナップショットを読み取り、表示する。
 pub fn run_status(json_output: bool) -> Result<(), String> {
-    let state_root = crate::config::default_state_root().map_err(|e| e.to_string())?;
+    let config_path = crate::config::default_config_path().map_err(|e| e.to_string())?;
+    let config = crate::config::Config::load(Some(&config_path)).map_err(|e| e.to_string())?;
+    let state_root = PathBuf::from(&config.state_root);
     let snapshot = read_status(&state_root).ok_or("EgoPulse has not been started yet")?;
     if json_output {
         println!("{}", serde_json::to_string_pretty(&snapshot).unwrap());

--- a/egopulse/src/storage.rs
+++ b/egopulse/src/storage.rs
@@ -85,10 +85,11 @@ where
 const SCHEMA_VERSION: i64 = 1;
 
 impl Database {
-    /// Open (or create) the database at `{data_dir}/egopulse.db` and initialize schema.
-    pub fn new(data_dir: &str) -> Result<Self, StorageError> {
-        let db_path = Path::new(data_dir).join("egopulse.db");
-        std::fs::create_dir_all(data_dir)?;
+    /// Open (or create) the database at `{state_root}/runtime/egopulse.db` and initialize schema.
+    pub fn new(state_root: &str) -> Result<Self, StorageError> {
+        let runtime_dir = Path::new(state_root).join("runtime");
+        let db_path = runtime_dir.join("egopulse.db");
+        std::fs::create_dir_all(&runtime_dir)?;
 
         let conn = Connection::open(db_path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL;")?;

--- a/egopulse/src/storage.rs
+++ b/egopulse/src/storage.rs
@@ -85,12 +85,13 @@ where
 const SCHEMA_VERSION: i64 = 1;
 
 impl Database {
-    /// Open (or create) the database at `{state_root}/runtime/egopulse.db` and initialize schema.
-    pub fn new(state_root: &str) -> Result<Self, StorageError> {
-        let runtime_dir = Path::new(state_root).join("runtime");
-        let db_path = runtime_dir.join("egopulse.db");
-
-        let legacy_db = Path::new(state_root).join("data").join("egopulse.db");
+    /// Open (or create) the database at `db_path` and initialize schema.
+    pub fn new(db_path: &Path) -> Result<Self, StorageError> {
+        let legacy_db = db_path
+            .parent()
+            .and_then(|runtime| runtime.parent())
+            .map(|root| root.join("data").join("egopulse.db"))
+            .unwrap_or_else(|| Path::new("data").join("egopulse.db"));
         if legacy_db.exists() && !db_path.exists() {
             return Err(StorageError::InitFailed(format!(
                 "legacy_db_pending_migration: found {}, but {} does not exist. \
@@ -102,7 +103,9 @@ impl Database {
             )));
         }
 
-        std::fs::create_dir_all(&runtime_dir)?;
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
 
         let conn = Connection::open(db_path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL;")?;
@@ -717,7 +720,8 @@ mod tests {
 
     fn test_db() -> (Database, tempfile::TempDir) {
         let dir = tempfile::tempdir().expect("tempdir");
-        let db = Database::new(dir.path().to_str().expect("path")).expect("db");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        let db = Database::new(&db_path).expect("db");
         (db, dir)
     }
 
@@ -968,7 +972,7 @@ mod tests {
     #[test]
     fn migration_history_is_recorded() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let db = Database::new(dir.path().to_str().expect("path")).expect("db");
+        let db = Database::new(&dir.path().join("runtime").join("egopulse.db")).expect("db");
 
         let conn = db.conn.lock().expect("lock");
         let mut stmt = conn
@@ -988,14 +992,14 @@ mod tests {
     #[test]
     fn reopen_db_preserves_schema_version() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().to_str().expect("path").to_string();
+        let db_path = dir.path().join("runtime").join("egopulse.db");
 
         let first_version = {
-            let db = Database::new(&path).expect("db");
+            let db = Database::new(&db_path).expect("db");
             db.schema_version().expect("version")
         };
 
-        let db = Database::new(&path).expect("reopen db");
+        let db = Database::new(&db_path).expect("reopen db");
         let second_version = db.schema_version().expect("version");
 
         assert_eq!(

--- a/egopulse/src/storage.rs
+++ b/egopulse/src/storage.rs
@@ -89,6 +89,19 @@ impl Database {
     pub fn new(state_root: &str) -> Result<Self, StorageError> {
         let runtime_dir = Path::new(state_root).join("runtime");
         let db_path = runtime_dir.join("egopulse.db");
+
+        let legacy_db = Path::new(state_root).join("data").join("egopulse.db");
+        if legacy_db.exists() && !db_path.exists() {
+            return Err(StorageError::InitFailed(format!(
+                "legacy_db_pending_migration: found {}, but {} does not exist. \
+                 run 'mv {} {}' to migrate.",
+                legacy_db.display(),
+                db_path.display(),
+                legacy_db.display(),
+                db_path.display(),
+            )));
+        }
+
         std::fs::create_dir_all(&runtime_dir)?;
 
         let conn = Connection::open(db_path)?;

--- a/egopulse/src/tools/mod.rs
+++ b/egopulse/src/tools/mod.rs
@@ -557,7 +557,7 @@ mod tests {
         }
     }
 
-    fn test_config(data_dir: &str) -> Config {
+    fn test_config(state_root: &str) -> Config {
         Config {
             default_provider: "local".to_string(),
             default_model: Some("gpt-4o-mini".to_string()),
@@ -571,7 +571,7 @@ mod tests {
                     models: vec!["gpt-4o-mini".to_string()],
                 },
             )]),
-            data_dir: data_dir.to_string(),
+            state_root: state_root.to_string(),
             log_level: "info".to_string(),
             compaction_timeout_secs: 180,
             max_history_messages: 50,

--- a/egopulse/src/web/auth.rs
+++ b/egopulse/src/web/auth.rs
@@ -184,7 +184,7 @@ mod tests {
                     models: vec!["gpt-4o-mini".to_string()],
                 },
             )]),
-            data_dir: ".egopulse".to_string(),
+            state_root: ".egopulse".to_string(),
             log_level: "info".to_string(),
             compaction_timeout_secs: 180,
             max_history_messages: 50,

--- a/egopulse/src/web/config.rs
+++ b/egopulse/src/web/config.rs
@@ -40,7 +40,7 @@ struct ConfigPayload {
     default_provider: String,
     default_model: Option<String>,
     effective_model: String,
-    data_dir: String,
+    state_root: String,
     workspace_dir: String,
     web_enabled: bool,
     web_host: String,
@@ -352,7 +352,7 @@ fn default_payload(path: &std::path::Path) -> Result<ConfigPayload, ConfigError>
         default_provider: String::new(),
         default_model: None,
         effective_model: String::new(),
-        data_dir: crate::config::default_data_dir()?
+        state_root: crate::config::default_state_root()?
             .to_string_lossy()
             .into_owned(),
         workspace_dir: crate::config::default_workspace_dir()?
@@ -416,7 +416,7 @@ fn payload_from_config(
         default_provider: resolved.provider,
         default_model: config.default_model.clone(),
         effective_model: resolved.model,
-        data_dir: config.data_dir.clone(),
+        state_root: config.state_root.clone(),
         workspace_dir: crate::config::default_workspace_dir()?
             .to_string_lossy()
             .into_owned(),

--- a/egopulse/src/web/config.rs
+++ b/egopulse/src/web/config.rs
@@ -417,9 +417,7 @@ fn payload_from_config(
         default_model: config.default_model.clone(),
         effective_model: resolved.model,
         state_root: config.state_root.clone(),
-        workspace_dir: crate::config::default_workspace_dir()?
-            .to_string_lossy()
-            .into_owned(),
+        workspace_dir: config.workspace_dir()?.to_string_lossy().into_owned(),
         web_enabled: config.web_enabled(),
         web_host: config.web_host().to_string(),
         web_port: config.web_port(),


### PR DESCRIPTION
## 概要

`Config.data_dir`（`~/.egopulse/data/`）を `Config.state_root`（`~/.egopulse`）にリネームし、全モジュールのパス参照を `state_root` から派生する構成に統一。TOBE ディレクトリ仕様（`directory.md`）との整合を取る。

Plan: `docs/30.egopulse/plan-directory-restructure.md`

## 変更内容

### パス設計の統一
- **`state_root` = `~/.egopulse`** を唯一のYAMLパス設定項目に（旧 `data_dir` は完全削除）
- 派生アクセサ追加: `runtime_dir()`, `workspace_dir()`, `skills_dir()`, `user_skills_dir()`, `db_path()`, `assets_dir()`, `groups_dir()`, `status_json_path()`
- 内部ディレクトリ構造（`runtime/`, `workspace/`, `skills/` 等）は全てハードコードで派生

### ファイル配置の変更
| 旧パス | 新パス |
|---|---|
| `~/.egopulse/data/egopulse.db` | `~/.egopulse/runtime/egopulse.db` |
| `~/.egopulse/data/assets/` | `~/.egopulse/runtime/assets/` |
| `~/.egopulse/data/groups/` | `~/.egopulse/runtime/groups/` |
| `~/.egopulse/status.json` | `~/.egopulse/runtime/status.json` |

### スキル2層構造の実装
- 組み込みスキル: `state_root/skills/`（新規スキャン追加）
- ユーザースキル: `state_root/workspace/skills/`（従来通り、同名時優先）

## マイグレーション

ユーザー側で手動対応が必要:
```bash
mv ~/.egopulse/data ~/.egopulse/runtime
```

## 検証

- `cargo fmt --check` ✓
- `cargo check -p egopulse` ✓
- `cargo test -p egopulse` — 224 passed, 0 failed ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓

## 変更ファイル（14ファイル）

- `config.rs` — `data_dir` → `state_root`、派生アクセサ追加、`default_data_dir()` 削除
- `storage.rs` — DBパスを `runtime/` に移動
- `assets.rs` — assets パスを `runtime/` に移動
- `agent_loop/compaction.rs` — archive パスを `runtime/groups/` に移動
- `status.rs` — `status.json` を `runtime/` に移動
- `skills.rs` — 組み込みスキルスキャン追加、`from_dirs()` コンストラクタ
- `runtime.rs`, `web/config.rs`, `web/auth.rs`, `setup/summary.rs` — 呼び出し側追従
- `tools/mod.rs`, `agent_loop/session.rs`, `agent_loop/turn.rs`, `gateway.rs` — テスト追従

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 永続化ルートを再整理し、データベース・アセット・状態ファイルを runtime/ 配下に移動して管理を統一
  * 設定周りのルート指向を見直し、ワークスペースやアセット、ステータスのパスを明確化
  * スキル管理を改良し、ユーザー提供スキルと組み込みスキルを別々に扱うように変更

* **Behavior**
  * 起動状態（status.json）やアーカイブ保存先が runtime/ 以下に移動し、読み書き場所が更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->