### PR TITLE
refactor: organize ToolRegistry and MCP responsibility boundaries

### DIFF
--- a/docs/30.egopulse/mcp.md
+++ b/docs/30.egopulse/mcp.md
@@ -34,14 +34,17 @@ MCP 統合に関係する主要ファイルは以下である。
 - [`egopulse/src/mcp.rs`](../../egopulse/src/mcp.rs)
   - config 読み込み
   - server 接続
-  - tool definition 生成
+  - adapter 生成 (`create_tool_adapters()`)
   - tool 実行
+- [`egopulse/src/tools/mcp_adapter.rs`](../../egopulse/src/tools/mcp_adapter.rs)
+  - MCP tool → `Tool` trait の adapter
+  - tool definition 変換
+  - MCP server 呼び出し
+- [`egopulse/src/tools/sanitizer.rs`](../../egopulse/src/tools/sanitizer.rs)
+  - 秘匿情報マスキング (全 tool の出力に適用)
 - [`egopulse/src/runtime.rs`](../../egopulse/src/runtime.rs)
   - `AppState` 構築時の `McpManager` 初期化
-- [`egopulse/src/tools.rs`](../../egopulse/src/tools.rs)
-  - built-in tool registry
-  - MCP tool definition の合成
-  - MCP tool dispatch
+  - adapter を `ToolRegistry` に登録
 - [`egopulse/src/error.rs`](../../egopulse/src/error.rs)
   - MCP 固有 error 型
 
@@ -175,9 +178,17 @@ MCP は `AppState` 構築時に初期化される。
 ```rust
 let mut tools = ToolRegistry::new(&config, Arc::clone(&skills));
 
-let mcp_manager = crate::mcp::McpManager::new(&config.workspace_dir()).await;
-let mcp_arc = Arc::new(tokio::sync::RwLock::new(mcp_manager));
-tools.set_mcp_manager(mcp_arc);
+let mcp_manager = McpManager::new(&workspace_dir).await?;
+let mcp_arc = Arc::new(RwLock::new(mcp_manager));
+
+// MCP tool を adapter 経由で registry に登録
+let adapters = McpManager::create_tool_adapters(&mcp_arc).await;
+for adapter in adapters {
+    tools.register_tool(adapter);
+}
+
+// AppState が mcp_manager を直接保持 (status snapshot 用)
+AppState { ..., mcp_manager: Some(mcp_arc), ... }
 ```
 
 処理順は次の通り。
@@ -186,27 +197,29 @@ tools.set_mcp_manager(mcp_arc);
 2. `McpManager::new()` で config を読み込む
 3. 各 server に接続する
 4. 各 server から `tools/list` を取得する
-5. `ToolRegistry` に MCP manager を渡す
-6. turn loop で LLM へ built-in + MCP tool definitions を返す
+5. `create_tool_adapters()` で各 MCP tool を `McpToolAdapter` にラップする
+6. 各 adapter を `register_tool()` で registry に登録する
+7. `McpManager` への参照は `AppState` が直接保持する
+8. turn loop で LLM へ全 tool definitions を返す
 
 ## 10. Tool 公開
 
-MCP tool は built-in tool と同じ `ToolDefinition` 形式で LLM に公開される。
+MCP tool は `McpToolAdapter` 経由で built-in tool と同じ `ToolDefinition` 形式で LLM に公開される。`ToolRegistry` は built-in / MCP の区別なく全 tool を一様に管理する。
 
-実装: [`egopulse/src/tools.rs`](../../egopulse/src/tools.rs)
+実装: [`egopulse/src/tools/mcp_adapter.rs`](../../egopulse/src/tools/mcp_adapter.rs)
 
-### definition 合成
+### definition 列挙
 
-- `definitions_async()`
-  - built-in tool definitions を集める
-  - MCP manager から動的 tool definitions を追加する
+- `ToolRegistry::definitions_async()`
+  - 全 tool (built-in + MCP adapter) を一様に iterate して定義を収集
+  - MCP 特有の分岐なし
 
 ### dispatch
 
-- `execute()`
-  - まず built-in tool を探索する
-  - 見つからなければ MCP tool かどうかを確認する
-  - MCP tool なら対応 server へ dispatch する
+- `ToolRegistry::execute()`
+  - 全 tool を名前で探索して dispatch
+  - MCP adapter の `execute()` が内部で MCP server に委譲
+  - MCP 特有の分岐なし
 
 ## 11. Tool Naming
 

--- a/docs/30.egopulse/tools.md
+++ b/docs/30.egopulse/tools.md
@@ -23,9 +23,9 @@
 
 ## Tool Registry
 
-現在 registry には、静的 built-in tool と動的 MCP tool の 2 種類が存在する。
+`ToolRegistry` は全 tool を `Box<dyn Tool>` として一元管理する。built-in / MCP の区別なく、統一的に定義列挙・実行 dispatch を行う。
 
-### 静的 built-in tool
+### Built-in tool
 
 registry に静的登録されている tool は次の 8 つ。
 
@@ -38,11 +38,11 @@ registry に静的登録されている tool は次の 8 つ。
 - `ls`
 - `activate_skill`
 
-登録箇所: [egopulse/src/tools.rs](../../egopulse/src/tools.rs)
+登録箇所: [egopulse/src/tools/mod.rs](../../egopulse/src/tools/mod.rs)
 
-### 動的 MCP tool
+### MCP tool (Adapter 経由)
 
-MCP が有効な場合、接続済み MCP server が公開する tool が `mcp_{server}_{tool}` 形式で動的追加される。
+MCP が有効な場合、`McpManager.create_tool_adapters()` が各 MCP tool を `McpToolAdapter` (Tool trait 実装) として生成し、`ToolRegistry.register_tool()` で登録する。Registry は MCP の存在を意識しない。
 
 命名規則:
 
@@ -55,6 +55,8 @@ MCP が有効な場合、接続済み MCP server が公開する tool が `mcp_{
 - `mcp_filesystem_read_file` — 標準的な命名
 - `mcp_db_query_1_` — `query(1)` の `(` `)` が `_` に置換される
 - `mcp_a1b2c3d4` — server/tool 名の合計が 64 文字を超える場合のハッシュ短縮
+
+実装: [egopulse/src/tools/mcp_adapter.rs](../../egopulse/src/tools/mcp_adapter.rs)
 
 MCP の詳細は以下を参照。
 

--- a/egopulse/src/agent_loop/session.rs
+++ b/egopulse/src/agent_loop/session.rs
@@ -474,6 +474,7 @@ mod tests {
             channels: Arc::new(ChannelRegistry::new()),
             skills: Arc::clone(&skills),
             tools: Arc::new(ToolRegistry::new(&config, skills)),
+            mcp_manager: None,
             assets: Arc::new(AssetStore::new(&config.assets_dir()).expect("assets")),
         }
     }

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -880,6 +880,7 @@ pub(crate) fn build_state(
         channels: std::sync::Arc::new(ChannelRegistry::new()),
         skills: std::sync::Arc::clone(&skills),
         tools: std::sync::Arc::new(ToolRegistry::new(&config, skills)),
+        mcp_manager: None,
         assets: std::sync::Arc::new(AssetStore::new(&config.assets_dir()).expect("assets")),
     }
 }

--- a/egopulse/src/mcp.rs
+++ b/egopulse/src/mcp.rs
@@ -437,6 +437,44 @@ impl McpManager {
     pub fn get_client_by_index(&self, index: usize) -> Option<&DynClient> {
         self.servers.get(index).map(|s| s.client())
     }
+
+    /// 接続済み全サーバーの全ツールについて McpToolAdapter を生成する。
+    ///
+    /// 名前衝突したツールはスキップする（初期化時の warn ログと同じ方針）。
+    pub async fn create_tool_adapters(
+        manager: &std::sync::Arc<tokio::sync::RwLock<Self>>,
+    ) -> Vec<Box<dyn crate::tools::Tool>> {
+        use crate::tools::McpToolAdapter;
+
+        let guard = manager.read().await;
+        let mut adapters: Vec<Box<dyn crate::tools::Tool>> = Vec::new();
+        let mut seen_names = std::collections::HashSet::new();
+
+        for (idx, server) in guard.servers.iter().enumerate() {
+            for tool in &server.cached_tools {
+                let full_name = sanitize_tool_name(&server.name, tool.name.as_ref());
+                if !seen_names.insert(full_name.clone()) {
+                    continue;
+                }
+                let definition = ToolDefinition {
+                    name: full_name.clone(),
+                    description: tool.description.clone().unwrap_or_default().to_string(),
+                    parameters: serde_json::to_value(&tool.input_schema)
+                        .unwrap_or(serde_json::json!({"type": "object", "properties": {}})),
+                };
+                adapters.push(Box::new(McpToolAdapter::new(
+                    full_name,
+                    tool.name.to_string(),
+                    idx,
+                    server.config.request_timeout_secs,
+                    definition,
+                    std::sync::Arc::clone(manager),
+                )));
+            }
+        }
+
+        adapters
+    }
 }
 
 async fn connect_server(

--- a/egopulse/src/mcp.rs
+++ b/egopulse/src/mcp.rs
@@ -87,12 +87,6 @@ struct ConnectedServer {
     cached_tools: Vec<Tool>,
 }
 
-impl ConnectedServer {
-    fn client(&self) -> &DynClient {
-        &self.client
-    }
-}
-
 pub fn mcp_config_paths(workspace_dir: &Path) -> Result<Vec<PathBuf>, ConfigError> {
     let state_root = default_state_root()?;
     Ok(vec![
@@ -417,10 +411,6 @@ impl McpManager {
         })
     }
 
-    pub fn get_client_by_index(&self, index: usize) -> Option<&DynClient> {
-        self.servers.get(index).map(|s| s.client())
-    }
-
     /// 接続済み全サーバーの全ツールについて McpToolAdapter を生成する。
     ///
     /// 名前衝突したツールはスキップする（初期化時の warn ログと同じ方針）。
@@ -437,6 +427,12 @@ impl McpManager {
             for tool in &server.cached_tools {
                 let full_name = sanitize_tool_name(&server.name, tool.name.as_ref());
                 if !seen_names.insert(full_name.clone()) {
+                    warn!(
+                        server = %server.name,
+                        original = %tool.name,
+                        sanitized = %full_name,
+                        "skipping MCP tool adapter: sanitized name collides across servers"
+                    );
                     continue;
                 }
                 let definition = ToolDefinition {

--- a/egopulse/src/mcp.rs
+++ b/egopulse/src/mcp.rs
@@ -84,7 +84,6 @@ struct ConnectedServer {
     name: String,
     config: McpServerConfig,
     client: DynClient,
-    tool_name_map: HashMap<String, String>,
     cached_tools: Vec<Tool>,
 }
 
@@ -207,12 +206,12 @@ impl McpManager {
         for (name, config) in &configs {
             match connect_server(name, config, workspace_dir).await {
                 Ok((client, tools)) => {
-                    let mut tool_name_map = HashMap::new();
+                    let mut seen_names = std::collections::HashSet::new();
                     let mut filtered_tools = Vec::new();
                     let mut tool_display_names = Vec::new();
                     for t in &tools {
                         let full = sanitize_tool_name(name, t.name.as_ref());
-                        if tool_name_map.contains_key(&full) {
+                        if !seen_names.insert(full.clone()) {
                             warn!(
                                 server = name,
                                 original = %t.name,
@@ -221,7 +220,6 @@ impl McpManager {
                             );
                             continue;
                         }
-                        tool_name_map.insert(full.clone(), t.name.to_string());
                         tool_display_names.push(full);
                         filtered_tools.push(t.clone());
                     }
@@ -235,7 +233,6 @@ impl McpManager {
                         name: name.clone(),
                         config: (*config).clone(),
                         client,
-                        tool_name_map,
                         cached_tools: filtered_tools,
                     });
                 }
@@ -418,20 +415,6 @@ impl McpManager {
         } else {
             output
         })
-    }
-
-    pub fn is_mcp_tool(&self, name: &str) -> Option<(usize, String, String, u64)> {
-        for (i, s) in self.servers.iter().enumerate() {
-            if let Some(original_name) = s.tool_name_map.get(name) {
-                return Some((
-                    i,
-                    s.name.clone(),
-                    original_name.clone(),
-                    s.config.request_timeout_secs,
-                ));
-            }
-        }
-        None
     }
 
     pub fn get_client_by_index(&self, index: usize) -> Option<&DynClient> {

--- a/egopulse/src/runtime.rs
+++ b/egopulse/src/runtime.rs
@@ -33,6 +33,7 @@ pub struct AppState {
     pub channels: Arc<ChannelRegistry>,
     pub skills: Arc<SkillManager>,
     pub tools: Arc<ToolRegistry>,
+    pub mcp_manager: Option<Arc<tokio::sync::RwLock<crate::mcp::McpManager>>>,
     pub assets: Arc<AssetStore>,
 }
 
@@ -46,6 +47,7 @@ impl Clone for AppState {
             channels: Arc::clone(&self.channels),
             skills: Arc::clone(&self.skills),
             tools: Arc::clone(&self.tools),
+            mcp_manager: self.mcp_manager.clone(),
             assets: Arc::clone(&self.assets),
         }
     }
@@ -132,7 +134,12 @@ pub async fn build_app_state_with_path(
     let workspace_dir = config.workspace_dir()?;
     let mcp_manager = crate::mcp::McpManager::new(&workspace_dir).await?;
     let mcp_arc = Arc::new(tokio::sync::RwLock::new(mcp_manager));
-    tools.set_mcp_manager(mcp_arc);
+
+    // Register MCP tools as adapters
+    let adapters = crate::mcp::McpManager::create_tool_adapters(&mcp_arc).await;
+    for adapter in adapters {
+        tools.register_tool(adapter);
+    }
 
     let tools = Arc::new(tools);
 
@@ -144,6 +151,7 @@ pub async fn build_app_state_with_path(
         channels,
         skills,
         tools,
+        mcp_manager: Some(mcp_arc),
         assets,
     })
 }
@@ -312,7 +320,7 @@ fn channel_join_error(name: &str, error: JoinError) -> EgoPulseError {
 }
 
 async fn write_startup_status(state: &AppState) {
-    let mcp = if let Some(m) = state.tools.mcp_manager() {
+    let mcp = if let Some(m) = &state.mcp_manager {
         m.read().await.status_snapshot()
     } else {
         Default::default()

--- a/egopulse/src/tools/mcp_adapter.rs
+++ b/egopulse/src/tools/mcp_adapter.rs
@@ -96,9 +96,11 @@ mod tests {
     use crate::tools::Tool;
 
     use serde_json::json;
+    use serial_test::serial;
 
     /// name() がサニタイズ済み mcp_{server}_{tool} 形式の名前を返すことを検証する。
     #[test]
+    #[serial]
     fn test_adapter_name_matches_sanitized() {
         // Arrange
         let adapter = create_test_adapter(
@@ -115,6 +117,7 @@ mod tests {
 
     /// definition() が正しい ToolDefinition を返すことを検証する。
     #[test]
+    #[serial]
     fn test_adapter_definition_converts_schema() {
         // Arrange
         let definition = ToolDefinition {
@@ -152,6 +155,7 @@ mod tests {
     /// このテストは adapter の構築と trait メソッドの呼び出し可能性を検証する。
     /// 実際の MCP 呼び出しの成功パスは integration test でカバーする。
     #[test]
+    #[serial]
     fn test_adapter_holds_correct_fields_for_success_path() {
         // Arrange
         let adapter = create_test_adapter(
@@ -169,6 +173,7 @@ mod tests {
 
     /// 複数サーバー・複数ツールの adapter が独立して名前を保持することを検証する。
     #[test]
+    #[serial]
     fn test_adapter_distinguishes_multiple_servers() {
         // Arrange
         let adapter_a = create_test_adapter("mcp_serverA_tool1".to_string(), "tool1".to_string());
@@ -182,6 +187,7 @@ mod tests {
 
     /// definition() を複数回呼び出しても同じ内容が返ることを検証する。
     #[test]
+    #[serial]
     fn test_adapter_definition_is_idempotent() {
         // Arrange
         let adapter = create_test_adapter("mcp_db_query".to_string(), "query".to_string());
@@ -198,6 +204,7 @@ mod tests {
 
     /// Tool trait オブジェクトとして扱えることを検証する。
     #[test]
+    #[serial]
     fn test_adapter_is_dyn_tool_compatible() {
         // Arrange
         let adapter = create_test_adapter(

--- a/egopulse/src/tools/mcp_adapter.rs
+++ b/egopulse/src/tools/mcp_adapter.rs
@@ -1,0 +1,289 @@
+//! MCP ツールを Tool trait 実装としてラップするアダプター。
+//!
+//! `McpToolAdapter` は、`McpManager` が検出した各 MCP ツールを
+//! `Tool` trait の実装として `ToolRegistry` に登録できるようにする。
+//! これにより、ビルトインツールと MCP ツールを統一的に扱える。
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use super::{Tool, ToolExecutionContext, ToolResult};
+use crate::llm::ToolDefinition;
+use crate::mcp::McpManager;
+
+/// MCP サーバー上の単一ツールを Tool trait で包むアダプター。
+///
+/// 各インスタンスは接続済みサーバー内の1ツールに対応し、
+/// サニタイズ済み名前・定義・実行を一元的に扱う。
+pub(crate) struct McpToolAdapter {
+    name: String,
+    original_name: String,
+    server_idx: usize,
+    timeout_secs: u64,
+    definition: ToolDefinition,
+    manager: Arc<RwLock<McpManager>>,
+}
+
+impl McpToolAdapter {
+    /// 新しい MCP ツールアダプターを生成する。
+    ///
+    /// # Arguments
+    /// * `name` - サニタイズ済みツール名 (`mcp_{server}_{tool}`)
+    /// * `original_name` - MCP サーバー上のオリジナルツール名
+    /// * `server_idx` - `McpManager.servers` 内のサーバーインデックス
+    /// * `timeout_secs` - リクエストタイムアウト (秒)
+    /// * `definition` - キャッシュ済み `ToolDefinition`
+    /// * `manager` - `McpManager` への共有参照
+    pub(crate) fn new(
+        name: String,
+        original_name: String,
+        server_idx: usize,
+        timeout_secs: u64,
+        definition: ToolDefinition,
+        manager: Arc<RwLock<McpManager>>,
+    ) -> Self {
+        Self {
+            name,
+            original_name,
+            server_idx,
+            timeout_secs,
+            definition,
+            manager,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for McpToolAdapter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        self.definition.clone()
+    }
+
+    async fn execute(
+        &self,
+        input: serde_json::Value,
+        _context: &ToolExecutionContext,
+    ) -> ToolResult {
+        let result = {
+            let guard = self.manager.read().await;
+            guard
+                .execute_tool(
+                    self.server_idx,
+                    self.original_name.clone(),
+                    self.timeout_secs,
+                    input,
+                )
+                .await
+        };
+
+        match result {
+            Ok(output) => ToolResult::success(output),
+            Err(error) => ToolResult::error(error.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::ToolDefinition;
+    use crate::tools::Tool;
+
+    use serde_json::json;
+
+    /// name() がサニタイズ済み mcp_{server}_{tool} 形式の名前を返すことを検証する。
+    #[test]
+    fn test_adapter_name_matches_sanitized() {
+        // Arrange
+        let adapter = create_test_adapter(
+            "mcp_filesystem_read_file".to_string(),
+            "read_file".to_string(),
+        );
+
+        // Act
+        let name = adapter.name();
+
+        // Assert
+        assert_eq!(name, "mcp_filesystem_read_file");
+    }
+
+    /// definition() が正しい ToolDefinition を返すことを検証する。
+    #[test]
+    fn test_adapter_definition_converts_schema() {
+        // Arrange
+        let definition = ToolDefinition {
+            name: "mcp_filesystem_read_file".to_string(),
+            description: "Read a file from the filesystem".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the file"
+                    }
+                },
+                "required": ["path"]
+            }),
+        };
+        let adapter = create_test_adapter_with_definition(
+            "mcp_filesystem_read_file".to_string(),
+            "read_file".to_string(),
+            definition.clone(),
+        );
+
+        // Act
+        let result = adapter.definition();
+
+        // Assert
+        assert_eq!(result.name, "mcp_filesystem_read_file");
+        assert_eq!(result.description, "Read a file from the filesystem");
+        assert_eq!(result.parameters["properties"]["path"]["type"], "string");
+    }
+
+    /// execute() が成功レスポンスを ToolResult::success に変換することを検証する。
+    ///
+    /// McpManager::execute_tool が actual MCP 接続を必要とするため、
+    /// このテストは adapter の構築と trait メソッドの呼び出し可能性を検証する。
+    /// 実際の MCP 呼び出しの成功パスは integration test でカバーする。
+    #[test]
+    fn test_adapter_holds_correct_fields_for_success_path() {
+        // Arrange
+        let adapter = create_test_adapter(
+            "mcp_filesystem_read_file".to_string(),
+            "read_file".to_string(),
+        );
+
+        // Assert — フィールドが正しく保持されていることを確認
+        assert_eq!(adapter.name(), "mcp_filesystem_read_file");
+        assert_eq!(adapter.original_name, "read_file");
+        assert_eq!(adapter.server_idx, 0);
+        assert_eq!(adapter.timeout_secs, 60);
+        assert_eq!(adapter.definition.name, "mcp_filesystem_read_file");
+    }
+
+    /// 複数サーバー・複数ツールの adapter が独立して名前を保持することを検証する。
+    #[test]
+    fn test_adapter_distinguishes_multiple_servers() {
+        // Arrange
+        let adapter_a = create_test_adapter("mcp_serverA_tool1".to_string(), "tool1".to_string());
+        let adapter_b = create_test_adapter("mcp_serverB_tool2".to_string(), "tool2".to_string());
+
+        // Act & Assert
+        assert_ne!(adapter_a.name(), adapter_b.name());
+        assert_eq!(adapter_a.name(), "mcp_serverA_tool1");
+        assert_eq!(adapter_b.name(), "mcp_serverB_tool2");
+    }
+
+    /// definition() を複数回呼び出しても同じ内容が返ることを検証する。
+    #[test]
+    fn test_adapter_definition_is_idempotent() {
+        // Arrange
+        let adapter = create_test_adapter("mcp_db_query".to_string(), "query".to_string());
+
+        // Act
+        let def1 = adapter.definition();
+        let def2 = adapter.definition();
+
+        // Assert
+        assert_eq!(def1.name, def2.name);
+        assert_eq!(def1.description, def2.description);
+        assert_eq!(def1.parameters, def2.parameters);
+    }
+
+    /// Tool trait オブジェクトとして扱えることを検証する。
+    #[test]
+    fn test_adapter_is_dyn_tool_compatible() {
+        // Arrange
+        let adapter = create_test_adapter(
+            "mcp_filesystem_read_file".to_string(),
+            "read_file".to_string(),
+        );
+
+        // Act — Box<dyn Tool> にキャストできることを確認
+        let tool: Box<dyn Tool> = Box::new(adapter);
+
+        // Assert
+        assert_eq!(tool.name(), "mcp_filesystem_read_file");
+    }
+
+    // --- テストヘルパー ---
+
+    /// テスト用の最小 McpToolAdapter を生成する。
+    ///
+    /// 実際の MCP 接続は不要で、構造体のフィールド保持のみを検証する。
+    /// execute() を呼び出すテストでは実際の McpManager が必要になるため、
+    /// 単体テストでは name/definition の検証に留める。
+    fn create_test_adapter(name: String, original_name: String) -> McpToolAdapter {
+        let definition = ToolDefinition {
+            name: name.clone(),
+            description: format!("MCP tool: {original_name}"),
+            parameters: json!({"type": "object", "properties": {}}),
+        };
+        McpToolAdapter {
+            name,
+            original_name,
+            server_idx: 0,
+            timeout_secs: 60,
+            definition,
+            // テストでは実行しないのでダミーの manager を入れない。
+            // 代わりに、Unit テストでは execute を呼ばない。
+            // これをコンパイルするため、ダミーの McpManager が必要。
+            // McpManager は actual MCP connection を要求するため、
+            // test_helper では直接構築できない。
+            // → テスト用に minimal な構造体を new で組み立てる。
+            manager: Arc::new(tokio::sync::RwLock::new(create_stub_mcp_manager())),
+        }
+    }
+
+    fn create_test_adapter_with_definition(
+        name: String,
+        original_name: String,
+        definition: ToolDefinition,
+    ) -> McpToolAdapter {
+        McpToolAdapter {
+            name,
+            original_name,
+            server_idx: 0,
+            timeout_secs: 60,
+            definition,
+            manager: Arc::new(tokio::sync::RwLock::new(create_stub_mcp_manager())),
+        }
+    }
+
+    /// テスト用の空の McpManager を生成する。
+    ///
+    /// `McpManager::new()` は MCP 設定ファイルを読み込むため、
+    /// テスト環境では safe な stub を生成する必要がある。
+    /// servers が空の McpManager は execute_tool でエラーを返すが、
+    /// name/definition のテストでは実行しないため問題ない。
+    fn create_stub_mcp_manager() -> McpManager {
+        // McpManager は pub フィールドを持たず、new() が async で MCP 接続する。
+        // テスト用に安全に生成する方法がない場合、
+        // テスト環境に一時ディレクトリを設定して new() を呼ぶ。
+        // しかし、これは async な MCP 接続を伴うため、
+        // 代わりに name/definition テストに限定する方針を取る。
+        //
+        // 実際には McpManager のフィールドが private なので、
+        // 外部から構築できない。ここではテストモジュール内でのみ
+        // 必要な最小限の対応を行う。
+        //
+        // McpManager::new() に空の workspace を渡せば、
+        // MCP 設定ファイルが存在しないため servers 空で返る。
+        // ただし async なので block する必要がある。
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime for test");
+        let dir = tempfile::tempdir().expect("tempdir for stub mcp");
+        let state_root = dir.path().join(".egopulse");
+        let workspace = state_root.join("workspace");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+
+        let _home = crate::test_env::EnvVarGuard::set("HOME", dir.path());
+
+        rt.block_on(async { McpManager::new(&workspace).await.expect("stub McpManager") })
+    }
+}

--- a/egopulse/src/tools/mod.rs
+++ b/egopulse/src/tools/mod.rs
@@ -128,7 +128,6 @@ pub trait Tool: Send + Sync {
 /// Owns all tool instances and dispatches execution by tool name.
 pub struct ToolRegistry {
     tools: Vec<Box<dyn Tool>>,
-    mcp_manager: Option<std::sync::Arc<tokio::sync::RwLock<crate::mcp::McpManager>>>,
     config_secrets: Vec<(String, String)>,
 }
 
@@ -141,7 +140,6 @@ impl ToolRegistry {
                 tracing::warn!("failed to resolve workspace dir: {error}");
                 return Self {
                     tools: vec![Box::new(ActivateSkillTool::new(skill_manager))],
-                    mcp_manager: None,
                     config_secrets: collect_config_secrets(config),
                 };
             }
@@ -164,7 +162,6 @@ impl ToolRegistry {
                 Box::new(LsTool::new(workspace_dir)),
                 Box::new(ActivateSkillTool::new(skill_manager)),
             ],
-            mcp_manager: None,
             config_secrets: collect_config_secrets(config),
         }
     }
@@ -173,46 +170,9 @@ impl ToolRegistry {
         self.tools.push(tool);
     }
 
-    /// Set the MCP manager for dynamic tool dispatch.
-    pub fn set_mcp_manager(
-        &mut self,
-        manager: std::sync::Arc<tokio::sync::RwLock<crate::mcp::McpManager>>,
-    ) {
-        self.mcp_manager = Some(manager);
-    }
-
-    /// Returns a reference to the MCP manager, if configured.
-    pub fn mcp_manager(
-        &self,
-    ) -> Option<&std::sync::Arc<tokio::sync::RwLock<crate::mcp::McpManager>>> {
-        self.mcp_manager.as_ref()
-    }
-
-    /// Collect tool definitions synchronously (internal only).
-    /// External callers must use [`definitions_async`] to avoid blocking an async runtime.
-    #[allow(dead_code)]
-    pub(crate) fn definitions(&self) -> Vec<ToolDefinition> {
-        let mut defs: Vec<ToolDefinition> =
-            self.tools.iter().map(|tool| tool.definition()).collect();
-
-        if let Some(mcp) = &self.mcp_manager {
-            let mcp_defs = mcp.blocking_read().all_tool_definitions();
-            defs.extend(mcp_defs);
-        }
-
-        defs
-    }
-
-    /// Collect tool definitions asynchronously (preferred when MCP is present).
+    /// Collect tool definitions asynchronously.
     pub async fn definitions_async(&self) -> Vec<ToolDefinition> {
-        let mut defs: Vec<ToolDefinition> =
-            self.tools.iter().map(|tool| tool.definition()).collect();
-
-        if let Some(mcp) = &self.mcp_manager {
-            defs.extend(mcp.read().await.all_tool_definitions());
-        }
-
-        defs
+        self.tools.iter().map(|tool| tool.definition()).collect()
     }
 
     /// Find and execute a tool by name. Returns an error result for unknown tools.
@@ -228,36 +188,6 @@ impl ToolRegistry {
                 return sanitize_tool_result(result, &self.config_secrets);
             }
         }
-
-        if let Some(mcp) = &self.mcp_manager {
-            let mcp_info = {
-                let guard = mcp.read().await;
-                guard.is_mcp_tool(name)
-            };
-            if let Some((idx, _, original_tool_name, request_timeout_secs)) = mcp_info {
-                let result = {
-                    let guard = mcp.read().await;
-                    guard
-                        .execute_tool(idx, original_tool_name, request_timeout_secs, input)
-                        .await
-                };
-                match result {
-                    Ok(output) => {
-                        return sanitize_tool_result(
-                            ToolResult::success(output),
-                            &self.config_secrets,
-                        );
-                    }
-                    Err(error) => {
-                        return sanitize_tool_result(
-                            ToolResult::error(error.to_string()),
-                            &self.config_secrets,
-                        );
-                    }
-                }
-            }
-        }
-
         sanitize_tool_result(
             ToolResult::error(format!("Unknown tool: {name}")),
             &self.config_secrets,

--- a/egopulse/src/tools/mod.rs
+++ b/egopulse/src/tools/mod.rs
@@ -6,7 +6,9 @@
 
 mod command_guard;
 mod files;
+mod mcp_adapter;
 mod path_guard;
+mod sanitizer;
 mod search;
 mod shell;
 mod text;
@@ -15,7 +17,10 @@ mod text;
 pub(crate) use command_guard::*;
 pub(crate) use files::*;
 #[allow(unused_imports)] // re-export for future use from other modules
+pub(crate) use mcp_adapter::*;
+#[allow(unused_imports)] // re-export for future use from other modules
 pub(crate) use path_guard::*;
+pub(crate) use sanitizer::*;
 pub(crate) use search::*;
 pub(crate) use shell::*;
 pub(crate) use text::*;
@@ -37,36 +42,6 @@ const DEFAULT_LS_LIMIT: usize = 500;
 const GREP_MAX_LINE_LENGTH: usize = 500;
 const DEFAULT_BASH_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_GREP_TIMEOUT_SECS: u64 = 30;
-
-/// Well-known secret パターン。出力に含まれる場合 [REDACTED] に置換する。
-const SECRET_PATTERNS: &[&str] = &[
-    // OpenAI
-    "sk-",
-    // OpenRouter
-    "sk-or-",
-    // Anthropic
-    "sk-ant-",
-    // Slack
-    "xoxb-",
-    "xapp-",
-    // GitHub
-    "ghp_",
-    "gho_",
-    "ghu_",
-    "ghs_",
-    "github_pat_",
-    // GitLab
-    "glpat-",
-    // AWS Access Key ID
-    "AKIA",
-    "ASIA",
-    // Google API Key / OAuth
-    "AIza",
-    // Stripe
-    "sk_live_",
-    "sk_test_",
-    "rk_live_",
-];
 
 /// Contextual metadata passed to every tool execution (chat identity, channel, thread).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -361,152 +336,6 @@ fn truncation_json(truncation: &TruncationResult) -> serde_json::Value {
         "maxLines": truncation.max_lines,
         "maxBytes": truncation.max_bytes
     })
-}
-
-/// Config から収集したシークレット値で出力をリダクションする。
-pub(crate) fn redact_secrets(output: &str, secrets: &[(String, String)]) -> String {
-    if secrets.is_empty() {
-        return output.to_string();
-    }
-    let mut sorted: Vec<_> = secrets
-        .iter()
-        .filter(|(_, value)| !value.is_empty())
-        .collect();
-    sorted.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
-    let mut redacted = output.to_string();
-    for (key, value) in &sorted {
-        redacted = redacted.replace(value, &format!("[REDACTED:{key}]"));
-    }
-    redacted
-}
-
-/// Well-known secret プレフィックスに基づくパターンリダクション。
-pub(crate) fn redact_known_secret_patterns(output: &str) -> String {
-    let mut result = output.to_string();
-    for prefix in SECRET_PATTERNS {
-        let mut start = 0usize;
-        while let Some(offset) = result[start..].find(prefix) {
-            let abs_offset = start + offset;
-            let preceded_by_boundary = abs_offset == 0
-                || result[..abs_offset]
-                    .chars()
-                    .last()
-                    .is_some_and(|c| !c.is_alphanumeric() && c != '_');
-            if !preceded_by_boundary {
-                start = abs_offset + 1;
-                continue;
-            }
-            let prefix_end = abs_offset + prefix.len();
-            let secret_end = result[prefix_end..]
-                .find(|c: char| c.is_whitespace() || c == '\'' || c == '"' || c == '\n' || c == ';')
-                .map(|i| prefix_end + i)
-                .unwrap_or(result.len());
-            if secret_end > prefix_end {
-                result = format!(
-                    "{}[REDACTED:secret]{}",
-                    &result[..abs_offset],
-                    &result[secret_end..]
-                );
-            }
-            start = abs_offset + "[REDACTED:secret]".len();
-            if start >= result.len() {
-                break;
-            }
-        }
-    }
-    result
-}
-
-fn sanitize_output_string(output: &str, secrets: &[(String, String)]) -> String {
-    let redacted = redact_secrets(output, secrets);
-    redact_known_secret_patterns(&redacted)
-}
-
-fn sanitize_message_content(
-    content: crate::llm::MessageContent,
-    secrets: &[(String, String)],
-) -> crate::llm::MessageContent {
-    use crate::llm::{MessageContent, MessageContentPart};
-
-    match content {
-        MessageContent::Text(text) => MessageContent::Text(sanitize_output_string(&text, secrets)),
-        MessageContent::Parts(parts) => MessageContent::Parts(
-            parts
-                .into_iter()
-                .map(|part| match part {
-                    MessageContentPart::InputText { text } => MessageContentPart::InputText {
-                        text: sanitize_output_string(&text, secrets),
-                    },
-                    MessageContentPart::InputImage { image_url, detail } => {
-                        MessageContentPart::InputImage {
-                            image_url: sanitize_output_string(&image_url, secrets),
-                            detail: detail.map(|value| sanitize_output_string(&value, secrets)),
-                        }
-                    }
-                })
-                .collect(),
-        ),
-    }
-}
-
-fn sanitize_json_value(
-    value: serde_json::Value,
-    secrets: &[(String, String)],
-) -> serde_json::Value {
-    match value {
-        serde_json::Value::String(text) => {
-            serde_json::Value::String(sanitize_output_string(&text, secrets))
-        }
-        serde_json::Value::Array(values) => serde_json::Value::Array(
-            values
-                .into_iter()
-                .map(|item| sanitize_json_value(item, secrets))
-                .collect(),
-        ),
-        serde_json::Value::Object(map) => serde_json::Value::Object(
-            map.into_iter()
-                .map(|(key, value)| (key, sanitize_json_value(value, secrets)))
-                .collect(),
-        ),
-        other => other,
-    }
-}
-
-fn sanitize_tool_result(mut result: ToolResult, secrets: &[(String, String)]) -> ToolResult {
-    result.content = sanitize_output_string(&result.content, secrets);
-    result.llm_content = sanitize_message_content(result.llm_content, secrets);
-    result.details = result
-        .details
-        .take()
-        .map(|details| sanitize_json_value(details, secrets));
-    result
-}
-
-/// Config から抽出したシークレット値のリストを構築する。
-pub(crate) fn collect_config_secrets(config: &crate::config::Config) -> Vec<(String, String)> {
-    let mut secrets = Vec::new();
-    use secrecy::ExposeSecret;
-    for (name, provider) in &config.providers {
-        if let Some(key) = &provider.api_key {
-            let value = ExposeSecret::expose_secret(key).to_string();
-            secrets.push((format!("provider.{name}.api_key"), value));
-        }
-    }
-    for (name, channel) in &config.channels {
-        if let Some(token) = &channel.auth_token {
-            secrets.push((format!("channel.{name}.auth_token"), token.clone()));
-        }
-        if let Some(token) = &channel.file_auth_token {
-            secrets.push((format!("channel.{name}.file_auth_token"), token.clone()));
-        }
-        if let Some(token) = &channel.bot_token {
-            secrets.push((format!("channel.{name}.bot_token"), token.clone()));
-        }
-        if let Some(token) = &channel.file_bot_token {
-            secrets.push((format!("channel.{name}.file_bot_token"), token.clone()));
-        }
-    }
-    secrets
 }
 
 fn schema_object(properties: serde_json::Value, required: &[&str]) -> serde_json::Value {

--- a/egopulse/src/tools/sanitizer.rs
+++ b/egopulse/src/tools/sanitizer.rs
@@ -80,8 +80,10 @@ pub(crate) fn redact_known_secret_patterns(output: &str) -> String {
                     &result[..abs_offset],
                     &result[secret_end..]
                 );
+                start = abs_offset + "[REDACTED:secret]".len();
+            } else {
+                start = prefix_end;
             }
-            start = abs_offset + "[REDACTED:secret]".len();
             if start >= result.len() {
                 break;
             }

--- a/egopulse/src/tools/sanitizer.rs
+++ b/egopulse/src/tools/sanitizer.rs
@@ -1,0 +1,498 @@
+//! 出力サニタイズユーティリティ。
+//!
+//! Config 由来のシークレット値と well-known パターンの二層リダクションにより、
+//! ツール出力に秘密情報が漏洩しないようマスクする。
+
+use crate::config::Config;
+use crate::tools::ToolResult;
+
+/// Well-known secret パターン。出力に含まれる場合 [REDACTED] に置換する。
+pub(crate) const SECRET_PATTERNS: &[&str] = &[
+    // OpenAI
+    "sk-",
+    // OpenRouter
+    "sk-or-",
+    // Anthropic
+    "sk-ant-",
+    // Slack
+    "xoxb-",
+    "xapp-",
+    // GitHub
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "github_pat_",
+    // GitLab
+    "glpat-",
+    // AWS Access Key ID
+    "AKIA",
+    "ASIA",
+    // Google API Key / OAuth
+    "AIza",
+    // Stripe
+    "sk_live_",
+    "sk_test_",
+    "rk_live_",
+];
+
+/// Config から収集したシークレット値で出力をリダクションする。
+pub(crate) fn redact_secrets(output: &str, secrets: &[(String, String)]) -> String {
+    if secrets.is_empty() {
+        return output.to_string();
+    }
+    let mut sorted: Vec<_> = secrets
+        .iter()
+        .filter(|(_, value)| !value.is_empty())
+        .collect();
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
+    let mut redacted = output.to_string();
+    for (key, value) in &sorted {
+        redacted = redacted.replace(value, &format!("[REDACTED:{key}]"));
+    }
+    redacted
+}
+
+/// Well-known secret プレフィックスに基づくパターンリダクション。
+pub(crate) fn redact_known_secret_patterns(output: &str) -> String {
+    let mut result = output.to_string();
+    for prefix in SECRET_PATTERNS {
+        let mut start = 0usize;
+        while let Some(offset) = result[start..].find(prefix) {
+            let abs_offset = start + offset;
+            let preceded_by_boundary = abs_offset == 0
+                || result[..abs_offset]
+                    .chars()
+                    .last()
+                    .is_some_and(|c| !c.is_alphanumeric() && c != '_');
+            if !preceded_by_boundary {
+                start = abs_offset + 1;
+                continue;
+            }
+            let prefix_end = abs_offset + prefix.len();
+            let secret_end = result[prefix_end..]
+                .find(|c: char| c.is_whitespace() || c == '\'' || c == '"' || c == '\n' || c == ';')
+                .map(|i| prefix_end + i)
+                .unwrap_or(result.len());
+            if secret_end > prefix_end {
+                result = format!(
+                    "{}[REDACTED:secret]{}",
+                    &result[..abs_offset],
+                    &result[secret_end..]
+                );
+            }
+            start = abs_offset + "[REDACTED:secret]".len();
+            if start >= result.len() {
+                break;
+            }
+        }
+    }
+    result
+}
+
+pub(crate) fn sanitize_output_string(output: &str, secrets: &[(String, String)]) -> String {
+    let redacted = redact_secrets(output, secrets);
+    redact_known_secret_patterns(&redacted)
+}
+
+pub(crate) fn sanitize_message_content(
+    content: crate::llm::MessageContent,
+    secrets: &[(String, String)],
+) -> crate::llm::MessageContent {
+    use crate::llm::{MessageContent, MessageContentPart};
+
+    match content {
+        MessageContent::Text(text) => MessageContent::Text(sanitize_output_string(&text, secrets)),
+        MessageContent::Parts(parts) => MessageContent::Parts(
+            parts
+                .into_iter()
+                .map(|part| match part {
+                    MessageContentPart::InputText { text } => MessageContentPart::InputText {
+                        text: sanitize_output_string(&text, secrets),
+                    },
+                    MessageContentPart::InputImage { image_url, detail } => {
+                        MessageContentPart::InputImage {
+                            image_url: sanitize_output_string(&image_url, secrets),
+                            detail: detail.map(|value| sanitize_output_string(&value, secrets)),
+                        }
+                    }
+                })
+                .collect(),
+        ),
+    }
+}
+
+pub(crate) fn sanitize_json_value(
+    value: serde_json::Value,
+    secrets: &[(String, String)],
+) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(text) => {
+            serde_json::Value::String(sanitize_output_string(&text, secrets))
+        }
+        serde_json::Value::Array(values) => serde_json::Value::Array(
+            values
+                .into_iter()
+                .map(|item| sanitize_json_value(item, secrets))
+                .collect(),
+        ),
+        serde_json::Value::Object(map) => serde_json::Value::Object(
+            map.into_iter()
+                .map(|(key, value)| (key, sanitize_json_value(value, secrets)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+pub(crate) fn sanitize_tool_result(
+    mut result: ToolResult,
+    secrets: &[(String, String)],
+) -> ToolResult {
+    result.content = sanitize_output_string(&result.content, secrets);
+    result.llm_content = sanitize_message_content(result.llm_content, secrets);
+    result.details = result
+        .details
+        .take()
+        .map(|details| sanitize_json_value(details, secrets));
+    result
+}
+
+/// Config から抽出したシークレット値のリストを構築する。
+pub(crate) fn collect_config_secrets(config: &Config) -> Vec<(String, String)> {
+    let mut secrets = Vec::new();
+    use secrecy::ExposeSecret;
+    for (name, provider) in &config.providers {
+        if let Some(key) = &provider.api_key {
+            let value = ExposeSecret::expose_secret(key).to_string();
+            secrets.push((format!("provider.{name}.api_key"), value));
+        }
+    }
+    for (name, channel) in &config.channels {
+        if let Some(token) = &channel.auth_token {
+            secrets.push((format!("channel.{name}.auth_token"), token.clone()));
+        }
+        if let Some(token) = &channel.file_auth_token {
+            secrets.push((format!("channel.{name}.file_auth_token"), token.clone()));
+        }
+        if let Some(token) = &channel.bot_token {
+            secrets.push((format!("channel.{name}.bot_token"), token.clone()));
+        }
+        if let Some(token) = &channel.file_bot_token {
+            secrets.push((format!("channel.{name}.file_bot_token"), token.clone()));
+        }
+    }
+    secrets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ChannelConfig, Config, ProviderConfig};
+    use crate::llm::{MessageContent, MessageContentPart};
+    use crate::test_env::EnvVarGuard;
+    use secrecy::SecretString;
+    use serde_json::json;
+
+    /// redact_secrets: Config 由来のシークレット値を [REDACTED:key] に置換する。
+    #[test]
+    fn test_redact_secrets_replaces_config_values() {
+        // Arrange
+        let secrets = vec![(
+            "provider.openai.api_key".to_string(),
+            "sk-abc123".to_string(),
+        )];
+        let input = "The key is sk-abc123 and it should be hidden";
+
+        // Act
+        let result = redact_secrets(input, &secrets);
+
+        // Assert
+        assert!(result.contains("[REDACTED:provider.openai.api_key]"));
+        assert!(!result.contains("sk-abc123"));
+    }
+
+    /// redact_secrets: 空のシークレットリストでは入力が変更されない。
+    #[test]
+    fn test_redact_secrets_empty_list_noop() {
+        // Arrange
+        let secrets: Vec<(String, String)> = vec![];
+        let input = "no secrets here";
+
+        // Act
+        let result = redact_secrets(input, &secrets);
+
+        // Assert
+        assert_eq!(result, input);
+    }
+
+    /// redact_secrets: 長いシークレットから先に置換し、部分一致による漏洩を防ぐ。
+    #[test]
+    fn test_redact_secrets_longer_first() {
+        // Arrange
+        // "sk-long-secret-key" と "sk-long" が重なる場合、長い方が先に置換される
+        let secrets = vec![
+            ("short".to_string(), "sk-long".to_string()),
+            ("long".to_string(), "sk-long-secret-key".to_string()),
+        ];
+        let input = "found sk-long-secret-key and also sk-long";
+
+        // Act
+        let result = redact_secrets(input, &secrets);
+
+        // Assert
+        assert!(result.contains("[REDACTED:long]"));
+        assert!(result.contains("[REDACTED:short]"));
+        assert!(!result.contains("sk-long"));
+    }
+
+    /// redact_known_secret_patterns: OpenAI sk- プレフィックスがマスクされる。
+    #[test]
+    fn test_redact_known_patterns_openai() {
+        // Arrange
+        let input = "key=sk-proj-abc123def456 end";
+
+        // Act
+        let result = redact_known_secret_patterns(input);
+
+        // Assert
+        assert!(result.contains("[REDACTED:secret]"));
+        assert!(!result.contains("sk-proj-abc123def456"));
+    }
+
+    /// redact_known_secret_patterns: 1行に複数シークレットがあっても全てマスクされる。
+    #[test]
+    fn test_redact_known_patterns_multiple() {
+        // Arrange
+        let input = "key1=sk-aaa111 key2=ghp_bbb222";
+
+        // Act
+        let result = redact_known_secret_patterns(input);
+
+        // Assert
+        // sk- と ghp_ の両方がマスクされる
+        let redacted_count = result.matches("[REDACTED:secret]").count();
+        assert_eq!(redacted_count, 2);
+    }
+
+    /// redact_known_secret_patterns: 単語途中の sk- はマスクされない。
+    #[test]
+    fn test_redact_known_patterns_no_false_positive() {
+        // Arrange
+        // "task-name" の "sk-" は単語途中なのでマスク対象外
+        let input = "task-name is valid";
+
+        // Act
+        let result = redact_known_secret_patterns(input);
+
+        // Assert
+        assert_eq!(result, input);
+    }
+
+    /// sanitize_output_string: Config シークレットと known パターンの二層が両方適用される。
+    #[test]
+    fn test_sanitize_output_string_both_layers() {
+        // Arrange
+        let secrets = vec![("my.key".to_string(), "my-secret-value".to_string())];
+        let input = "config=my-secret-value and known=sk-abc123";
+
+        // Act
+        let result = sanitize_output_string(input, &secrets);
+
+        // Assert
+        assert!(result.contains("[REDACTED:my.key]"));
+        assert!(result.contains("[REDACTED:secret]"));
+        assert!(!result.contains("my-secret-value"));
+        assert!(!result.contains("sk-abc123"));
+    }
+
+    /// sanitize_json_value: ネストされた JSON 文字列値もマスクされる。
+    #[test]
+    fn test_sanitize_json_value_nested() {
+        // Arrange
+        let secrets = vec![("token".to_string(), "sk-hidden-token".to_string())];
+        let value = json!({
+            "level1": {
+                "level2": "sk-hidden-token is here",
+                "number": 42,
+                "list": ["sk-hidden-token in array"]
+            }
+        });
+
+        // Act
+        let result = sanitize_json_value(value, &secrets);
+
+        // Assert
+        let level2 = result.get("level1").unwrap().get("level2").unwrap();
+        assert!(level2.as_str().unwrap().contains("[REDACTED:token]"));
+        assert!(
+            result
+                .get("level1")
+                .unwrap()
+                .get("list")
+                .unwrap()
+                .get(0)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .contains("[REDACTED:token]")
+        );
+        // 数値はそのまま
+        assert_eq!(result.get("level1").unwrap().get("number").unwrap(), 42);
+    }
+
+    /// sanitize_tool_result: content / llm_content / details の全フィールドがサニタイズされる。
+    #[test]
+    fn test_sanitize_tool_result_applies_to_all_fields() {
+        // Arrange
+        let secrets = vec![("key".to_string(), "leaked-key".to_string())];
+        let result = ToolResult {
+            content: "contains leaked-key here".to_string(),
+            is_error: false,
+            details: Some(json!({"trace": "leaked-key in trace"})),
+            llm_content: MessageContent::text("leaked-key in llm".to_string()),
+        };
+
+        // Act
+        let sanitized = sanitize_tool_result(result, &secrets);
+
+        // Assert
+        assert!(sanitized.content.contains("[REDACTED:key]"));
+        assert!(!sanitized.content.contains("leaked-key"));
+        match &sanitized.llm_content {
+            MessageContent::Text(text) => {
+                assert!(text.contains("[REDACTED:key]"));
+                assert!(!text.contains("leaked-key"));
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+        let trace = sanitized
+            .details
+            .as_ref()
+            .and_then(|d| d.get("trace"))
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert!(trace.contains("[REDACTED:key]"));
+    }
+
+    /// sanitize_message_content: MessageContent::Parts 内の InputText/InputImage もサニタイズされる。
+    #[test]
+    fn test_sanitize_message_content_parts() {
+        // Arrange
+        let secrets = vec![("secret".to_string(), "SECRET123".to_string())];
+        let content = MessageContent::parts(vec![
+            MessageContentPart::InputText {
+                text: "payload SECRET123".to_string(),
+            },
+            MessageContentPart::InputImage {
+                image_url: "https://example.com/img?token=SECRET123".to_string(),
+                detail: Some("detail SECRET123".to_string()),
+            },
+        ]);
+
+        // Act
+        let sanitized = sanitize_message_content(content, &secrets);
+
+        // Assert
+        match sanitized {
+            MessageContent::Parts(parts) => {
+                assert_eq!(parts.len(), 2);
+                match &parts[0] {
+                    MessageContentPart::InputText { text } => {
+                        assert!(!text.contains("SECRET123"));
+                        assert!(text.contains("[REDACTED:secret]"));
+                    }
+                    other => panic!("expected InputText, got {other:?}"),
+                }
+                match &parts[1] {
+                    MessageContentPart::InputImage { image_url, detail } => {
+                        assert!(!image_url.contains("SECRET123"));
+                        assert!(detail.as_deref().is_some_and(|d| !d.contains("SECRET123")));
+                    }
+                    other => panic!("expected InputImage, got {other:?}"),
+                }
+            }
+            other => panic!("expected Parts, got {other:?}"),
+        }
+    }
+
+    /// collect_config_secrets: Provider API キーが抽出される。
+    #[test]
+    fn test_collect_config_secrets_extracts_api_keys() {
+        // Arrange
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", dir.path());
+        let config = Config {
+            default_provider: "openai".to_string(),
+            default_model: None,
+            providers: std::collections::HashMap::from([(
+                "openai".to_string(),
+                ProviderConfig {
+                    label: "OpenAI".to_string(),
+                    base_url: "https://api.openai.com/v1".to_string(),
+                    api_key: Some(SecretString::new(
+                        "sk-test-key-123".to_string().into_boxed_str(),
+                    )),
+                    default_model: "gpt-4o".to_string(),
+                    models: vec!["gpt-4o".to_string()],
+                },
+            )]),
+            state_root: dir.path().to_str().expect("path").to_string(),
+            log_level: "info".to_string(),
+            compaction_timeout_secs: 180,
+            max_history_messages: 50,
+            max_session_messages: 40,
+            compact_keep_recent: 20,
+            channels: std::collections::HashMap::new(),
+        };
+
+        // Act
+        let secrets = collect_config_secrets(&config);
+
+        // Assert
+        assert_eq!(secrets.len(), 1);
+        assert_eq!(secrets[0].0, "provider.openai.api_key");
+        assert_eq!(secrets[0].1, "sk-test-key-123");
+    }
+
+    /// collect_config_secrets: Channel の auth_token / bot_token が抽出される。
+    #[test]
+    fn test_collect_config_secrets_extracts_auth_tokens() {
+        // Arrange
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", dir.path());
+        let config = Config {
+            default_provider: "local".to_string(),
+            default_model: None,
+            providers: std::collections::HashMap::new(),
+            state_root: dir.path().to_str().expect("path").to_string(),
+            log_level: "info".to_string(),
+            compaction_timeout_secs: 180,
+            max_history_messages: 50,
+            max_session_messages: 40,
+            compact_keep_recent: 20,
+            channels: std::collections::HashMap::from([(
+                "discord".to_string(),
+                ChannelConfig {
+                    enabled: Some(true),
+                    auth_token: Some("auth-token-value".to_string()),
+                    file_auth_token: Some("file-auth-token-value".to_string()),
+                    bot_token: Some("bot-token-value".to_string()),
+                    file_bot_token: Some("file-bot-token-value".to_string()),
+                    ..Default::default()
+                },
+            )]),
+        };
+
+        // Act
+        let secrets = collect_config_secrets(&config);
+
+        // Assert
+        let keys: Vec<&str> = secrets.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(keys.contains(&"channel.discord.auth_token"));
+        assert!(keys.contains(&"channel.discord.file_auth_token"));
+        assert!(keys.contains(&"channel.discord.bot_token"));
+        assert!(keys.contains(&"channel.discord.file_bot_token"));
+        assert_eq!(secrets.len(), 4);
+    }
+}


### PR DESCRIPTION
## Summary

- `ToolRegistry` が抱えていた MCP 依存を除去し、Provider Trait 抽象化で built-in / MCP を統一的に扱うようリファクタリング
- `McpToolAdapter` を導入し、MCP tool を `Tool` trait 実装として Registry に登録。Registry は MCP の存在を意識しない
- Sanitizer を独立モジュール (`tools/sanitizer.rs`) に分離し、単独テスト可能に
- `McpManager` への参照を `AppState` が直接保持し、status snapshot 用にアクセス

Close endo-ly/egopulse#13

## 変更内容

### 新規ファイル
- `egopulse/src/tools/sanitizer.rs` — 秘匿情報マスキング (SECRET_PATTERNS, redact_secrets, sanitize_tool_result 等)
- `egopulse/src/tools/mcp_adapter.rs` — MCP tool → Tool trait の Adapter (McpToolAdapter)

### 主要変更
| ファイル | 変更 |
|---|---|
| `tools/mod.rs` | mcp_manager フィールド・set_mcp_manager・MCP 分岐ロジックを削除。definitions_async/execute は全 tool を一様に iterate |
| `mcp.rs` | create_tool_adapters() 追加。is_mcp_tool() 削除。tool_name_map を inline HashSet に簡素化 |
| `runtime.rs` | AppState に mcp_manager フィールド追加。初期化時に create_tool_adapters → register_tool で登録 |
| `session.rs` / `turn.rs` | テストヘルパーに mcp_manager: None 追加 |

### ドキュメント
- `docs/30.egopulse/tools.md` — Tool Registry セクション更新 (Adapter 経由の登録フロー)
- `docs/30.egopulse/mcp.md` — §3 関連コンポーネント、§9 起動時初期化、§10 Tool 公開を更新

## 設計方針

- **Adapter パターン**: McpToolAdapter が Tool trait を実装し、Registry は MCP を特別扱いしない
- **Sanitizer 独立**: 秘匿情報マスキングを tools/sanitizer.rs に分離
- **AppState 直接保持**: McpManager は ToolRegistry 経由ではなく AppState が直接参照
- **後方互換ハックなし**: 旧 set_mcp_manager / mcp_manager は削除

## Test plan

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test -p egopulse` 242 テスト全通過
- [x] sanitizer 単体テスト 12 件追加 (正常系・空状態・境界値・エッジケース)
- [x] mcp_adapter 単体テスト 6 件追加 (名前・定義・dyn Tool 互換性)
- [x] 既存テスト regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ツール出力からシークレット情報を自動的にマスキングするセキュリティ機能を追加しました

* **改善**
  * ツール管理の仕組みを再構築し、統一された登録・実行フローを実装しました
  * MCP ツール統合のアーキテクチャを最適化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->