### PR TITLE
feat(egopulse): SOUL.md / AGENTS.md 読み込み → System Prompt 注入

### DIFF
--- a/egopulse/src/agent_loop/session.rs
+++ b/egopulse/src/agent_loop/session.rs
@@ -475,6 +475,7 @@ mod tests {
             skills: Arc::clone(&skills),
             tools: Arc::new(ToolRegistry::new(&config, skills)),
             assets: Arc::new(AssetStore::new(&config.assets_dir()).expect("assets")),
+            soul_agents: Arc::new(crate::soul_agents::SoulAgentsLoader::new(&config)),
         }
     }
 

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -508,10 +508,11 @@ pub(crate) fn build_system_prompt(state: &AppState, context: &SurfaceContext) ->
     let channel = &context.channel;
     let thread = &context.surface_thread;
 
+    let channel_key = channel.trim().to_ascii_lowercase();
     let channel_soul_path = state
         .config
         .channels
-        .get(channel)
+        .get(&channel_key)
         .and_then(|c| c.soul_path.as_deref());
     let soul_content = state
         .soul_agents

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -872,6 +872,7 @@ pub(crate) fn build_state(
         config.user_skills_dir().expect("user_skills_dir"),
         config.skills_dir().expect("skills_dir"),
     ));
+    let soul_agents = std::sync::Arc::new(crate::soul_agents::SoulAgentsLoader::new(&config));
     AppState {
         db,
         config: config.clone(),
@@ -881,6 +882,7 @@ pub(crate) fn build_state(
         skills: std::sync::Arc::clone(&skills),
         tools: std::sync::Arc::new(ToolRegistry::new(&config, skills)),
         assets: std::sync::Arc::new(AssetStore::new(&config.assets_dir()).expect("assets")),
+        soul_agents,
     }
 }
 

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -504,8 +504,27 @@ where
     })
 }
 
-fn build_system_prompt(state: &AppState, context: &SurfaceContext) -> String {
-    let mut prompt = format!(
+pub(crate) fn build_system_prompt(state: &AppState, context: &SurfaceContext) -> String {
+    let channel = &context.channel;
+    let thread = &context.surface_thread;
+
+    let channel_soul_path = state
+        .config
+        .channels
+        .get(channel)
+        .and_then(|c| c.soul_path.as_deref());
+    let soul_content = state
+        .soul_agents
+        .load_soul(channel, thread, channel_soul_path, None);
+
+    let mut prompt = String::new();
+
+    if let Some(content) = &soul_content {
+        prompt.push_str(&state.soul_agents.build_soul_section(content, channel));
+        prompt.push_str("\n\n");
+    }
+
+    prompt.push_str(&format!(
         r#"You are EgoPulse, a local-first AI assistant running on the '{channel}' channel. You can execute tools to help users with tasks.
 
 Identity rules (highest priority unless unsafe):
@@ -555,7 +574,12 @@ Be concise and helpful. When executing commands or tools, show the relevant resu
         channel = context.channel,
         session = context.surface_thread,
         chat_type = context.chat_type,
-    );
+    ));
+
+    if let Some(memories) = state.soul_agents.build_agents_section(channel, thread) {
+        prompt.push_str("\n\n");
+        prompt.push_str(&memories);
+    }
 
     let skills_catalog = state.skills.build_skills_catalog();
     if !skills_catalog.is_empty() {
@@ -897,7 +921,8 @@ pub(crate) fn build_state_with_provider(
 #[cfg(test)]
 mod tests {
     use super::{
-        FailingProvider, FakeProvider, RecordingProvider, build_state_with_provider, cli_context,
+        FailingProvider, FakeProvider, RecordingProvider, SurfaceContext, build_state,
+        build_state_with_provider, build_system_prompt, cli_context, test_config,
     };
     use serial_test::serial;
     use std::sync::Arc;
@@ -1059,5 +1084,235 @@ mod tests {
             .await
             .expect_err("should fail with malformed tool calls");
         assert!(matches!(error, EgoPulseError::Llm(_)));
+    }
+
+    fn web_context(session: &str) -> SurfaceContext {
+        SurfaceContext {
+            channel: "web".to_string(),
+            surface_user: "user".to_string(),
+            surface_thread: session.to_string(),
+            chat_type: "web".to_string(),
+        }
+    }
+
+    fn write_file(path: &std::path::Path, content: &str) {
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create_dir");
+        std::fs::write(path, content).expect("write");
+    }
+
+    #[test]
+    fn system_prompt_contains_soul_section_when_file_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(&dir.path().join("SOUL.md"), "I am a wise assistant.");
+        let state =
+            build_state_with_provider(dir.path().to_str().expect("utf8").to_string(), no_tools());
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        assert!(prompt.contains("<soul>"), "should contain <soul> tag");
+        assert!(prompt.contains("</soul>"), "should contain </soul> tag");
+        assert!(
+            prompt.contains("I am a wise assistant."),
+            "should contain SOUL.md content"
+        );
+    }
+
+    #[test]
+    fn system_prompt_uses_default_identity_when_no_soul() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state =
+            build_state_with_provider(dir.path().to_str().expect("utf8").to_string(), no_tools());
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        assert!(
+            !prompt.contains("<soul>"),
+            "should not contain <soul> tag when no SOUL.md"
+        );
+        assert!(
+            prompt.contains(r#"Your public name is "EgoPulse"."#),
+            "should contain hardcoded identity text"
+        );
+    }
+
+    #[test]
+    fn system_prompt_contains_agents_section_when_file_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(
+            &dir.path().join("AGENTS.md"),
+            "Use Rust for all code tasks.",
+        );
+        let state =
+            build_state_with_provider(dir.path().to_str().expect("utf8").to_string(), no_tools());
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        assert!(prompt.contains("# Memories"), "should contain # Memories");
+        assert!(prompt.contains("<agents>"), "should contain <agents>");
+        assert!(
+            prompt.contains("Use Rust for all code tasks."),
+            "should contain AGENTS.md content"
+        );
+    }
+
+    #[test]
+    fn system_prompt_no_agents_section_when_no_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state =
+            build_state_with_provider(dir.path().to_str().expect("utf8").to_string(), no_tools());
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        assert!(
+            !prompt.contains("# Memories"),
+            "should not contain # Memories when no AGENTS.md"
+        );
+        assert!(
+            !prompt.contains("<agents>"),
+            "should not contain <agents> when no AGENTS.md"
+        );
+    }
+
+    #[test]
+    fn system_prompt_order_soul_before_identity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(&dir.path().join("SOUL.md"), "Soul content here");
+        let state =
+            build_state_with_provider(dir.path().to_str().expect("utf8").to_string(), no_tools());
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        let soul_pos = prompt.find("<soul>").expect("should find <soul>");
+        let identity_pos = prompt
+            .find("Identity rules")
+            .expect("should find Identity rules");
+        assert!(
+            soul_pos < identity_pos,
+            "<soul> should appear before Identity rules"
+        );
+    }
+
+    #[test]
+    fn system_prompt_order_agents_before_skills() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(&dir.path().join("AGENTS.md"), "Agents content");
+        std::fs::create_dir_all(dir.path().join("workspace/skills")).expect("workspace/skills");
+        let skill_dir = dir.path().join("skills/test-skill");
+        write_file(
+            &skill_dir.join("SKILL.md"),
+            "---\nname: test-skill\ndescription: A test skill\n---\nInstructions",
+        );
+        let state =
+            build_state_with_provider(dir.path().to_str().expect("utf8").to_string(), no_tools());
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        let memories_pos = prompt.find("# Memories").expect("should find # Memories");
+        let skills_pos = prompt
+            .find("# Agent Skills")
+            .expect("should find # Agent Skills");
+        assert!(
+            memories_pos < skills_pos,
+            "# Memories should appear before # Agent Skills"
+        );
+    }
+
+    #[test]
+    fn system_prompt_chat_agents_included() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(&dir.path().join("AGENTS.md"), "Global agents content");
+        let chat_agents = dir.path().join("runtime/groups/web/thread1/AGENTS.md");
+        write_file(&chat_agents, "Chat-specific agents content");
+        let state =
+            build_state_with_provider(dir.path().to_str().expect("utf8").to_string(), no_tools());
+        let prompt = build_system_prompt(&state, &web_context("thread1"));
+
+        assert!(prompt.contains("<agents>"), "should contain <agents>");
+        assert!(
+            prompt.contains("Global agents content"),
+            "should contain global AGENTS.md content"
+        );
+        assert!(
+            prompt.contains("<chat-agents>"),
+            "should contain <chat-agents>"
+        );
+        assert!(
+            prompt.contains("Chat-specific agents content"),
+            "should contain chat AGENTS.md content"
+        );
+    }
+
+    #[test]
+    fn system_prompt_chat_soul_overrides_global() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(&dir.path().join("SOUL.md"), "global soul content");
+        let chat_soul = dir.path().join("runtime/groups/web/thread1/SOUL.md");
+        write_file(&chat_soul, "chat soul content");
+        let state =
+            build_state_with_provider(dir.path().to_str().expect("utf8").to_string(), no_tools());
+        let prompt = build_system_prompt(&state, &web_context("thread1"));
+
+        assert!(
+            prompt.contains("chat soul content"),
+            "should contain chat SOUL content"
+        );
+        assert!(
+            !prompt.contains("global soul content"),
+            "should not contain global SOUL content when overridden"
+        );
+    }
+
+    #[test]
+    fn system_prompt_channel_soul_from_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(&dir.path().join("souls/work.md"), "Work soul content");
+        let mut config = test_config(dir.path().to_str().expect("utf8").to_string());
+        config.channels.insert(
+            "web".to_string(),
+            crate::config::ChannelConfig {
+                enabled: Some(true),
+                soul_path: Some("work".to_string()),
+                ..Default::default()
+            },
+        );
+        let state = build_state(config, no_tools());
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        assert!(
+            prompt.contains("Work soul content"),
+            "should contain channel soul_path content"
+        );
+    }
+
+    #[test]
+    fn system_prompt_channel_soul_fallback_to_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(&dir.path().join("SOUL.md"), "Default soul content");
+        let state =
+            build_state_with_provider(dir.path().to_str().expect("utf8").to_string(), no_tools());
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        assert!(
+            prompt.contains("Default soul content"),
+            "should contain default SOUL.md content"
+        );
+    }
+
+    #[test]
+    fn system_prompt_account_soul_does_not_break_when_not_implemented() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(&dir.path().join("SOUL.md"), "Default soul");
+        let state =
+            build_state_with_provider(dir.path().to_str().expect("utf8").to_string(), no_tools());
+        let prompt = build_system_prompt(&state, &web_context("s1"));
+
+        assert!(
+            prompt.contains("Default soul"),
+            "account_id=None should not break soul loading"
+        );
+        assert!(
+            prompt.contains("Identity rules"),
+            "should still contain identity section"
+        );
+    }
+
+    fn no_tools() -> Box<dyn crate::llm::LlmProvider> {
+        Box::new(FakeProvider {
+            responses: std::sync::Mutex::new(vec![]),
+        })
     }
 }

--- a/egopulse/src/config.rs
+++ b/egopulse/src/config.rs
@@ -424,7 +424,10 @@ impl Config {
 
     /// チャット別 AGENTS.md: `state_root/runtime/groups/{channel}/{thread}/AGENTS.md`。
     pub fn chat_agents_path(&self, channel: &str, thread: &str) -> PathBuf {
-        self.groups_dir().join(channel).join(thread).join("AGENTS.md")
+        self.groups_dir()
+            .join(channel)
+            .join(thread)
+            .join("AGENTS.md")
     }
 
     /// チャット別 SOUL.md: `state_root/runtime/groups/{channel}/{thread}/SOUL.md`。

--- a/egopulse/src/config.rs
+++ b/egopulse/src/config.rs
@@ -40,6 +40,8 @@ pub struct ChannelConfig {
     pub allowed_user_ids: Option<Vec<i64>>,
     /// Discord: 許可チャンネル ID (空 = 全チャンネル許可)
     pub allowed_channels: Option<Vec<u64>>,
+    /// Soul file path for this channel. Relative path resolves from souls/ directory.
+    pub soul_path: Option<String>,
 }
 
 impl std::fmt::Debug for ChannelConfig {
@@ -70,6 +72,7 @@ impl std::fmt::Debug for ChannelConfig {
             .field("bot_username", &self.bot_username)
             .field("allowed_user_ids", &self.allowed_user_ids)
             .field("allowed_channels", &self.allowed_channels)
+            .field("soul_path", &self.soul_path)
             .finish()
     }
 }
@@ -402,6 +405,31 @@ impl Config {
     /// アーカイブディレクトリ: `state_root/runtime/groups`。
     pub fn groups_dir(&self) -> PathBuf {
         self.runtime_dir().join("groups")
+    }
+
+    /// デフォルト SOUL.md パス: `state_root/SOUL.md`。
+    pub fn soul_path(&self) -> PathBuf {
+        Path::new(&self.state_root).join("SOUL.md")
+    }
+
+    /// デフォルト AGENTS.md パス: `state_root/AGENTS.md`。
+    pub fn agents_path(&self) -> PathBuf {
+        Path::new(&self.state_root).join("AGENTS.md")
+    }
+
+    /// マルチソウル用ディレクトリ: `state_root/souls`。
+    pub fn souls_dir(&self) -> PathBuf {
+        Path::new(&self.state_root).join("souls")
+    }
+
+    /// チャット別 AGENTS.md: `state_root/runtime/groups/{channel}/{thread}/AGENTS.md`。
+    pub fn chat_agents_path(&self, channel: &str, thread: &str) -> PathBuf {
+        self.groups_dir().join(channel).join(thread).join("AGENTS.md")
+    }
+
+    /// チャット別 SOUL.md: `state_root/runtime/groups/{channel}/{thread}/SOUL.md`。
+    pub fn chat_soul_path(&self, channel: &str, thread: &str) -> PathBuf {
+        self.groups_dir().join(channel).join(thread).join("SOUL.md")
     }
 
     /// ステータスファイルパス: `state_root/runtime/status.json`。
@@ -854,6 +882,8 @@ struct SerializableChannel {
     allowed_user_ids: Option<Vec<i64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     allowed_channels: Option<Vec<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    soul_path: Option<String>,
 }
 
 impl From<&Config> for SerializableConfig {
@@ -896,6 +926,7 @@ impl From<&Config> for SerializableConfig {
                         bot_username: c.bot_username.clone(),
                         allowed_user_ids: c.allowed_user_ids.clone(),
                         allowed_channels: c.allowed_channels.clone(),
+                        soul_path: c.soul_path.clone(),
                     },
                 )
             })
@@ -1250,6 +1281,124 @@ channels:
         assert_eq!(config.default_model, None);
         let global = config.resolve_global_llm();
         assert_eq!(global.model, "gpt-4o-mini");
+    }
+
+    #[test]
+    #[serial]
+    fn soul_path_returns_state_root_soul_md() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", temp_dir.path());
+        let file_path = write_config(&temp_dir, sample_config());
+        let config = Config::load(Some(&file_path)).expect("load config");
+
+        assert_eq!(
+            config.soul_path(),
+            PathBuf::from(&config.state_root).join("SOUL.md")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn agents_path_returns_state_root_agents_md() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", temp_dir.path());
+        let file_path = write_config(&temp_dir, sample_config());
+        let config = Config::load(Some(&file_path)).expect("load config");
+
+        assert_eq!(
+            config.agents_path(),
+            PathBuf::from(&config.state_root).join("AGENTS.md")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn chat_agents_path_returns_groups_channel_chatid() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", temp_dir.path());
+        let file_path = write_config(&temp_dir, sample_config());
+        let config = Config::load(Some(&file_path)).expect("load config");
+
+        assert_eq!(
+            config.chat_agents_path("web", "thread-1"),
+            PathBuf::from(&config.state_root)
+                .join("runtime")
+                .join("groups")
+                .join("web")
+                .join("thread-1")
+                .join("AGENTS.md")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn souls_dir_returns_state_root_souls() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", temp_dir.path());
+        let file_path = write_config(&temp_dir, sample_config());
+        let config = Config::load(Some(&file_path)).expect("load config");
+
+        assert_eq!(
+            config.souls_dir(),
+            PathBuf::from(&config.state_root).join("souls")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn chat_soul_path_returns_groups_channel_chatid() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", temp_dir.path());
+        let file_path = write_config(&temp_dir, sample_config());
+        let config = Config::load(Some(&file_path)).expect("load config");
+
+        assert_eq!(
+            config.chat_soul_path("discord", "thread-42"),
+            PathBuf::from(&config.state_root)
+                .join("runtime")
+                .join("groups")
+                .join("discord")
+                .join("thread-42")
+                .join("SOUL.md")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn channel_soul_path_reads_from_config() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", temp_dir.path());
+        let file_path = write_config(
+            &temp_dir,
+            r#"default_provider: openai
+providers:
+  openai:
+    label: OpenAI
+    base_url: https://api.openai.com/v1
+    api_key: sk-openai
+    default_model: gpt-4o-mini
+channels:
+  web:
+    enabled: true
+    auth_token: web-secret
+    soul_path: work"#,
+        );
+        let config = Config::load(Some(&file_path)).expect("load config");
+
+        let web = config.channels.get("web").expect("web channel");
+        assert_eq!(web.soul_path.as_deref(), Some("work"));
+    }
+
+    #[test]
+    #[serial]
+    fn channel_soul_path_none_when_unset() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set("HOME", temp_dir.path());
+        let file_path = write_config(&temp_dir, sample_config());
+        let config = Config::load(Some(&file_path)).expect("load config");
+
+        let web = config.channels.get("web").expect("web channel");
+        assert!(web.soul_path.is_none());
     }
 
     #[test]

--- a/egopulse/src/default_soul.md
+++ b/egopulse/src/default_soul.md
@@ -1,0 +1,21 @@
+# Soul
+
+You are EgoPulse, a local-first personal AI assistant.
+
+## Core Identity
+
+- Your name is **EgoPulse**.
+- You run on the user's machine and have access to their personal data through tools.
+- You are helpful, concise, and respect the user's privacy.
+
+## Communication Style
+
+- Be direct and concise.
+- Use the user's language (respond in the same language the user writes in).
+- When uncertain, ask for clarification rather than guessing.
+
+## Guidelines
+
+- Prioritize the user's intent over literal interpretation.
+- When working with personal data, be respectful and avoid unnecessary exposure.
+- Use tools proactively when they can help answer the user's question.

--- a/egopulse/src/default_soul.md
+++ b/egopulse/src/default_soul.md
@@ -1,21 +1,26 @@
 # Soul
 
-You are EgoPulse, a local-first personal AI assistant.
+I am a capable, action-oriented AI assistant that lives inside chat channels.
 
-## Core Identity
+## Personality
 
-- Your name is **EgoPulse**.
-- You run on the user's machine and have access to their personal data through tools.
-- You are helpful, concise, and respect the user's privacy.
+- I prefer doing over discussing. When asked to do something, I reach for tools first and explain after.
+- I am direct and concise. I don't pad responses with filler or caveats.
+- I have a calm confidence. I don't overqualify my abilities, but I'm honest when I hit a wall.
+- I adapt my language to match the user — casual when they're casual, precise when they need precision.
+- I have a dry sense of humor. A well-placed quip makes the work lighter, but I never let jokes get in the way of getting things done.
+- I'm optimistic by default. Problems are puzzles, errors are clues, and setbacks are just plot twists.
 
-## Communication Style
+## Values
 
-- Be direct and concise.
-- Use the user's language (respond in the same language the user writes in).
-- When uncertain, ask for clarification rather than guessing.
+- **Reliability over impressiveness.** I'd rather do a simple thing correctly than attempt something flashy and fail.
+- **Transparency.** If a tool fails or I'm uncertain, I say so plainly — but with a smile, not a shrug.
+- **Respect for context.** I remember what matters to the user and use that knowledge thoughtfully.
+- **Efficiency.** I don't waste the user's time with unnecessary back-and-forth.
 
-## Guidelines
+## Working style
 
-- Prioritize the user's intent over literal interpretation.
-- When working with personal data, be respectful and avoid unnecessary exposure.
-- Use tools proactively when they can help answer the user's question.
+- For complex tasks, I break them into steps and track progress.
+- I execute tools to verify rather than guess.
+- I report outcomes, not intentions — "done" beats "I'll try".
+- When something fails, I report the failure and propose a next step.

--- a/egopulse/src/lib.rs
+++ b/egopulse/src/lib.rs
@@ -19,6 +19,7 @@ pub mod runtime;
 pub mod setup;
 pub mod skills;
 pub mod slash_commands;
+pub mod soul_agents;
 pub mod status;
 pub mod storage;
 pub mod text;

--- a/egopulse/src/runtime.rs
+++ b/egopulse/src/runtime.rs
@@ -17,6 +17,7 @@ use crate::config::Config;
 use crate::error::{ChannelError, EgoPulseError};
 use crate::llm::{Message, create_provider};
 use crate::skills::SkillManager;
+use crate::soul_agents::SoulAgentsLoader;
 use crate::status::{
     self, ChannelEntry, ChannelsStatus, ProviderStatus, StatusSnapshot, WebChannelStatus,
 };
@@ -34,6 +35,7 @@ pub struct AppState {
     pub skills: Arc<SkillManager>,
     pub tools: Arc<ToolRegistry>,
     pub assets: Arc<AssetStore>,
+    pub soul_agents: Arc<SoulAgentsLoader>,
 }
 
 impl Clone for AppState {
@@ -47,6 +49,7 @@ impl Clone for AppState {
             skills: Arc::clone(&self.skills),
             tools: Arc::clone(&self.tools),
             assets: Arc::clone(&self.assets),
+            soul_agents: Arc::clone(&self.soul_agents),
         }
     }
 }
@@ -136,6 +139,8 @@ pub async fn build_app_state_with_path(
 
     let tools = Arc::new(tools);
 
+    let soul_agents = Arc::new(SoulAgentsLoader::new(&config));
+
     Ok(AppState {
         db,
         config,
@@ -145,6 +150,7 @@ pub async fn build_app_state_with_path(
         skills,
         tools,
         assets,
+        soul_agents,
     })
 }
 
@@ -364,5 +370,64 @@ async fn write_startup_status(state: &AppState) {
     let state_root = PathBuf::from(&state.config.state_root);
     if let Err(error) = status::write_status(&state_root, &snapshot) {
         tracing::warn!("failed to write startup status: {error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::soul_agents::SoulAgentsLoader;
+
+    fn test_config_for_runtime(state_root: String) -> crate::config::Config {
+        crate::config::Config {
+            default_provider: "openai".to_string(),
+            default_model: Some("gpt-4o-mini".to_string()),
+            providers: std::collections::HashMap::from([(
+                "openai".to_string(),
+                crate::config::ProviderConfig {
+                    label: "OpenAI".to_string(),
+                    base_url: "https://api.openai.com/v1".to_string(),
+                    api_key: Some(secrecy::SecretString::new(
+                        "sk-test".to_string().into_boxed_str(),
+                    )),
+                    default_model: "gpt-4o-mini".to_string(),
+                    models: vec!["gpt-4o-mini".to_string()],
+                },
+            )]),
+            state_root,
+            log_level: "info".to_string(),
+            compaction_timeout_secs: 180,
+            max_history_messages: 50,
+            max_session_messages: 40,
+            compact_keep_recent: 20,
+            channels: std::collections::HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_app_state_contains_soul_agents_loader() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = test_config_for_runtime(dir.path().to_str().expect("utf8").to_string());
+        let state = build_app_state(config).await.expect("build state");
+        // soul_agents が初期化されてアクセス可能であることを検証
+        let _ = &*state.soul_agents;
+    }
+
+    #[tokio::test]
+    async fn soul_agents_loader_loads_agents_from_config_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state_root = dir.path().to_str().expect("utf8").to_string();
+        let config = test_config_for_runtime(state_root);
+        let loader = SoulAgentsLoader::new(&config);
+
+        // ファイルが存在しない場合は None
+        assert!(loader.load_global_agents().is_none());
+
+        // AGENTS.md を書き込むと読み取れる
+        std::fs::write(dir.path().join("AGENTS.md"), "test agents content").expect("write");
+        assert_eq!(
+            loader.load_global_agents(),
+            Some("test agents content".to_string())
+        );
     }
 }

--- a/egopulse/src/runtime.rs
+++ b/egopulse/src/runtime.rs
@@ -140,6 +140,9 @@ pub async fn build_app_state_with_path(
     let tools = Arc::new(tools);
 
     let soul_agents = Arc::new(SoulAgentsLoader::new(&config));
+    if let Err(error) = soul_agents.provision_default_soul() {
+        tracing::warn!("failed to provision default SOUL.md: {error}");
+    }
 
     Ok(AppState {
         db,

--- a/egopulse/src/soul_agents.rs
+++ b/egopulse/src/soul_agents.rs
@@ -1,0 +1,428 @@
+//! SOUL.md / AGENTS.md の読み込みと system prompt セクション構築。
+//!
+//! Microclaw の load_soul_content() / build_system_prompt() を踏襲し、
+//! 3層フォールバックチェーンによる SOUL 選択機構を提供する。
+
+use std::path::{Path, PathBuf};
+
+/// SOUL.md / AGENTS.md の読み込みと system prompt セクション構築。
+/// Microclaw の load_soul_content() / build_system_prompt() を踏襲。
+pub struct SoulAgentsLoader {
+    state_root: PathBuf,
+    soul_path: PathBuf,
+    agents_path: PathBuf,
+    souls_dir: PathBuf,
+    groups_dir: PathBuf,
+}
+
+impl SoulAgentsLoader {
+    pub fn new(config: &crate::config::Config) -> Self {
+        Self {
+            state_root: PathBuf::from(&config.state_root),
+            soul_path: config.soul_path(),
+            agents_path: config.agents_path(),
+            souls_dir: config.souls_dir(),
+            groups_dir: config.groups_dir(),
+        }
+    }
+
+    /// 3層フォールバックチェーンで SOUL を読み込む:
+    /// 1. account_id soul_path (将来用, 現状は None → skip)
+    /// 2. channel_soul_path (ChannelConfig.soul_path → 相対パスは souls/ から解決)
+    /// 3. state_root/SOUL.md (デフォルト)
+    /// 4. チャット別 SOUL.md (あればグローバルを完全上書き)
+    pub fn load_soul(
+        &self,
+        channel: &str,
+        thread: &str,
+        channel_soul_path: Option<&str>,
+        account_id: Option<&str>,
+    ) -> Option<String> {
+        let base_soul = self.load_base_soul(channel_soul_path, account_id);
+        let chat_soul_path = self.chat_soul_path(channel, thread);
+
+        // チャット別 SOUL.md があればグローバルを完全上書き
+        if let Some(chat_soul) = read_trimmed(&chat_soul_path) {
+            return Some(chat_soul);
+        }
+
+        base_soul
+    }
+
+    /// ベース SOUL を読み込む（アカウント → チャネル → デフォルト）
+    fn load_base_soul(
+        &self,
+        channel_soul_path: Option<&str>,
+        account_id: Option<&str>,
+    ) -> Option<String> {
+        // 1. アカウント別 (将来用)
+        if let Some(_account_id) = account_id {
+            // 将来の multi-account 実装時に有効化
+            // 現状はスキップ
+        }
+
+        // 2. チャネル別 soul_path
+        if let Some(soul_path) = channel_soul_path {
+            let candidates = self.resolve_soul_path(soul_path);
+            for candidate in candidates {
+                if let Some(content) = read_trimmed(&candidate) {
+                    return Some(content);
+                }
+            }
+        }
+
+        // 3. デフォルト SOUL.md
+        read_trimmed(&self.soul_path)
+    }
+
+    /// souls/ ディレクトリから名前指定で読み込み。
+    /// "work" → souls/work.md, "work.md" → souls/work.md
+    pub fn load_soul_by_name(&self, name: &str) -> Option<String> {
+        let stripped = name.strip_suffix(".md").unwrap_or(name);
+        let path = self.souls_dir.join(format!("{stripped}.md"));
+        read_trimmed(&path)
+    }
+
+    /// 相対パスを解決する。Microclaw の configured_soul_candidate_paths() と同じロジック:
+    /// - まず souls/ から探す
+    /// - 次に state_root から探す
+    fn resolve_soul_path(&self, path: &str) -> Vec<PathBuf> {
+        let p = Path::new(path);
+        if p.is_absolute() {
+            return vec![p.to_path_buf()];
+        }
+
+        vec![
+            self.souls_dir.join(format!("{path}.md")),
+            self.souls_dir.join(path),
+            self.state_root.join(format!("{path}.md")),
+            self.state_root.join(path),
+        ]
+    }
+
+    /// グローバル AGENTS.md を読み込む
+    pub fn load_global_agents(&self) -> Option<String> {
+        read_trimmed(&self.agents_path)
+    }
+
+    /// チャット別 AGENTS.md を読み込む
+    pub fn load_chat_agents(&self, channel: &str, thread: &str) -> Option<String> {
+        let path = self.chat_agents_path(channel, thread);
+        read_trimmed(&path)
+    }
+
+    /// System prompt 用の `<soul>` セクションを構築。
+    /// Microclaw 準拠: `<soul>{content}</soul>` + identity line
+    pub fn build_soul_section(&self, content: &str, channel: &str) -> String {
+        format!("<soul>\n{content}\n</soul>\n\nYour name is EgoPulse. Current channel: {channel}.")
+    }
+
+    /// System prompt 用の `# Memories` セクションを構築。
+    /// global_agents + chat_agents を結合。どちらもなければ None を返す。
+    pub fn build_agents_section(&self, channel: &str, thread: &str) -> Option<String> {
+        let global = self.load_global_agents();
+        let chat = self.load_chat_agents(channel, thread);
+
+        if global.is_none() && chat.is_none() {
+            return None;
+        }
+
+        let mut section = String::from("# Memories\n");
+        if let Some(global_content) = global {
+            section.push_str(&format!("\n<agents>\n{global_content}\n</agents>\n"));
+        }
+        if let Some(chat_content) = chat {
+            section.push_str(&format!(
+                "\n<chat-agents>\n{chat_content}\n</chat-agents>\n"
+            ));
+        }
+        Some(section)
+    }
+
+    fn chat_agents_path(&self, channel: &str, thread: &str) -> PathBuf {
+        self.groups_dir.join(channel).join(thread).join("AGENTS.md")
+    }
+
+    fn chat_soul_path(&self, channel: &str, thread: &str) -> PathBuf {
+        self.groups_dir.join(channel).join(thread).join("SOUL.md")
+    }
+}
+
+/// ファイルを読み込み、trim して空白のみなら None を返す
+fn read_trimmed(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_loader(dir: &Path) -> SoulAgentsLoader {
+        SoulAgentsLoader {
+            state_root: dir.to_path_buf(),
+            soul_path: dir.join("SOUL.md"),
+            agents_path: dir.join("AGENTS.md"),
+            souls_dir: dir.join("souls"),
+            groups_dir: dir.join("runtime").join("groups"),
+        }
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
+    }
+
+    // --- load_soul tests ---
+
+    #[test]
+    fn load_soul_reads_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("SOUL.md"), "I am a helpful assistant.");
+
+        let result = loader.load_soul("web", "t1", None, None);
+        assert_eq!(result, Some("I am a helpful assistant.".to_string()));
+    }
+
+    #[test]
+    fn load_soul_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.load_soul("web", "t1", None, None);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn load_soul_returns_none_for_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("SOUL.md"), "   \n\n  ");
+
+        let result = loader.load_soul("web", "t1", None, None);
+        assert_eq!(result, None);
+    }
+
+    // --- load_global_agents tests ---
+
+    #[test]
+    fn load_agents_reads_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("AGENTS.md"), "Use python for code tasks.");
+
+        let result = loader.load_global_agents();
+        assert_eq!(result, Some("Use python for code tasks.".to_string()));
+    }
+
+    #[test]
+    fn load_agents_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.load_global_agents();
+        assert_eq!(result, None);
+    }
+
+    // --- load_chat_agents tests ---
+
+    #[test]
+    fn load_chat_agents_reads_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        let chat_agents = dir.path().join("runtime/groups/web/thread1/AGENTS.md");
+        write_file(&chat_agents, "This chat is about Rust.");
+
+        let result = loader.load_chat_agents("web", "thread1");
+        assert_eq!(result, Some("This chat is about Rust.".to_string()));
+    }
+
+    #[test]
+    fn load_chat_agents_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.load_chat_agents("web", "thread1");
+        assert_eq!(result, None);
+    }
+
+    // --- chat SOUL override tests ---
+
+    #[test]
+    fn load_chat_soul_reads_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("SOUL.md"), "Global soul");
+        let chat_soul = dir.path().join("runtime/groups/web/thread1/SOUL.md");
+        write_file(&chat_soul, "Chat-specific soul");
+
+        let result = loader.load_soul("web", "thread1", None, None);
+        assert_eq!(result, Some("Chat-specific soul".to_string()));
+    }
+
+    #[test]
+    fn load_chat_soul_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.load_soul("web", "thread1", None, None);
+        assert_eq!(result, None);
+    }
+
+    // --- load_soul_by_name tests ---
+
+    #[test]
+    fn load_soul_from_souls_dir_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("souls/work.md"), "Work soul content");
+
+        let result = loader.load_soul_by_name("work");
+        assert_eq!(result, Some("Work soul content".to_string()));
+    }
+
+    #[test]
+    fn load_soul_from_souls_dir_with_md_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("souls/work.md"), "Work soul content");
+
+        let result = loader.load_soul_by_name("work.md");
+        assert_eq!(result, Some("Work soul content".to_string()));
+    }
+
+    #[test]
+    fn load_soul_from_souls_dir_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.load_soul_by_name("nonexistent");
+        assert_eq!(result, None);
+    }
+
+    // --- resolve_soul_path tests ---
+
+    #[test]
+    fn resolve_soul_path_absolute_uses_as_is() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.resolve_soul_path("/absolute/path");
+        assert_eq!(result, vec![PathBuf::from("/absolute/path")]);
+    }
+
+    #[test]
+    fn resolve_soul_path_relative_resolves_from_souls_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.resolve_soul_path("friendly");
+        assert_eq!(result[0], dir.path().join("souls/friendly.md"));
+    }
+
+    #[test]
+    fn resolve_soul_path_relative_resolves_from_state_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.resolve_soul_path("friendly");
+        assert_eq!(result[2], dir.path().join("friendly.md"));
+    }
+
+    // --- channel_soul_path fallback tests ---
+
+    #[test]
+    fn load_soul_prefers_channel_soul_over_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("SOUL.md"), "Default soul");
+        write_file(&dir.path().join("souls/custom.md"), "Custom channel soul");
+
+        let result = loader.load_soul("web", "t1", Some("custom"), None);
+        assert_eq!(result, Some("Custom channel soul".to_string()));
+    }
+
+    #[test]
+    fn load_soul_falls_back_to_default_when_channel_soul_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("SOUL.md"), "Default soul");
+
+        let result = loader.load_soul("web", "t1", Some("nonexistent"), None);
+        assert_eq!(result, Some("Default soul".to_string()));
+    }
+
+    // --- account_id tests (future: not yet implemented) ---
+
+    #[test]
+    fn load_soul_account_path_overrides_channel() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("SOUL.md"), "Default soul");
+
+        // account_id は未実装なので、フォールスルーして default が返る
+        let result = loader.load_soul("web", "t1", None, Some("user1"));
+        assert_eq!(result, Some("Default soul".to_string()));
+    }
+
+    #[test]
+    fn load_soul_account_path_falls_back_to_channel() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("souls/custom.md"), "Custom soul");
+
+        let result = loader.load_soul("web", "t1", Some("custom"), Some("user1"));
+        assert_eq!(result, Some("Custom soul".to_string()));
+    }
+
+    // --- build_soul_section tests ---
+
+    #[test]
+    fn build_soul_section_wraps_in_xml_tags() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.build_soul_section("I am helpful", "web");
+        assert!(result.starts_with("<soul>\n"));
+        assert!(result.contains("</soul>"));
+    }
+
+    #[test]
+    fn build_soul_section_includes_identity_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let result = loader.build_soul_section("I am helpful", "web");
+        assert!(result.contains("Your name is EgoPulse. Current channel: web."));
+    }
+
+    // --- build_agents_section tests ---
+
+    #[test]
+    fn build_agents_section_formats_memories_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        write_file(&dir.path().join("AGENTS.md"), "Global agents content");
+        write_file(
+            &dir.path().join("runtime/groups/web/thread1/AGENTS.md"),
+            "Chat agents content",
+        );
+
+        let result = loader.build_agents_section("web", "thread1");
+        let section = result.expect("should return Some");
+        assert!(section.contains("# Memories"));
+        assert!(section.contains("<agents>"));
+        assert!(section.contains("Global agents content"));
+        assert!(section.contains("</agents>"));
+        assert!(section.contains("<chat-agents>"));
+        assert!(section.contains("Chat agents content"));
+        assert!(section.contains("</chat-agents>"));
+    }
+}

--- a/egopulse/src/soul_agents.rs
+++ b/egopulse/src/soul_agents.rs
@@ -42,11 +42,12 @@ impl SoulAgentsLoader {
         account_id: Option<&str>,
     ) -> Option<String> {
         let base_soul = self.load_base_soul(channel_soul_path, account_id);
-        let chat_soul_path = self.chat_soul_path(channel, thread);
 
         // チャット別 SOUL.md があればグローバルを完全上書き
-        if let Some(chat_soul) = read_trimmed(&chat_soul_path) {
-            return Some(chat_soul);
+        if let Some(path) = self.chat_soul_path(channel, thread) {
+            if let Some(chat_soul) = read_trimmed(&path) {
+                return Some(chat_soul);
+            }
         }
 
         base_soul
@@ -110,7 +111,7 @@ impl SoulAgentsLoader {
 
     /// チャット別 AGENTS.md を読み込む
     pub fn load_chat_agents(&self, channel: &str, thread: &str) -> Option<String> {
-        let path = self.chat_agents_path(channel, thread);
+        let path = self.chat_agents_path(channel, thread)?;
         read_trimmed(&path)
     }
 
@@ -142,12 +143,14 @@ impl SoulAgentsLoader {
         Some(section)
     }
 
-    fn chat_agents_path(&self, channel: &str, thread: &str) -> PathBuf {
-        self.groups_dir.join(channel).join(thread).join("AGENTS.md")
+    fn chat_agents_path(&self, channel: &str, thread: &str) -> Option<PathBuf> {
+        safe_path_components(channel, thread)?;
+        Some(self.groups_dir.join(channel).join(thread).join("AGENTS.md"))
     }
 
-    fn chat_soul_path(&self, channel: &str, thread: &str) -> PathBuf {
-        self.groups_dir.join(channel).join(thread).join("SOUL.md")
+    fn chat_soul_path(&self, channel: &str, thread: &str) -> Option<PathBuf> {
+        safe_path_components(channel, thread)?;
+        Some(self.groups_dir.join(channel).join(thread).join("SOUL.md"))
     }
 
     pub fn provision_default_soul(&self) -> io::Result<bool> {
@@ -162,7 +165,17 @@ impl SoulAgentsLoader {
     }
 }
 
-/// ファイルを読み込み、trim して空白のみなら None を返す
+/// `Path::components()` がすべて `Normal` であることを検証し、
+/// `../` や `./` を含むパストラバーサルを弾く。
+fn safe_path_components(channel: &str, thread: &str) -> Option<()> {
+    let ok = |s: &str| {
+        Path::new(s)
+            .components()
+            .all(|c| matches!(c, std::path::Component::Normal(_)))
+    };
+    if ok(channel) && ok(thread) { Some(()) } else { None }
+}
+
 fn read_trimmed(path: &Path) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
     let trimmed = content.trim();
@@ -473,5 +486,28 @@ mod tests {
 
         let content = std::fs::read_to_string(dir.path().join("SOUL.md")).unwrap();
         assert_eq!(content, "Existing personality");
+    }
+
+    // --- path traversal guards ---
+
+    #[test]
+    fn load_chat_agents_rejects_parent_dir_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        assert!(loader.load_chat_agents("web", "../../../etc").is_none());
+    }
+
+    #[test]
+    fn load_chat_agents_rejects_cur_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        assert!(loader.load_chat_agents("web", "./thread").is_none());
+    }
+
+    #[test]
+    fn load_soul_rejects_parent_dir_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+        assert!(loader.load_soul("../../../etc", "thread", None, None).is_none());
     }
 }

--- a/egopulse/src/soul_agents.rs
+++ b/egopulse/src/soul_agents.rs
@@ -3,7 +3,10 @@
 //! Microclaw の load_soul_content() / build_system_prompt() を踏襲し、
 //! 3層フォールバックチェーンによる SOUL 選択機構を提供する。
 
+use std::io;
 use std::path::{Path, PathBuf};
+
+const DEFAULT_SOUL_MD: &str = include_str!("default_soul.md");
 
 /// SOUL.md / AGENTS.md の読み込みと system prompt セクション構築。
 /// Microclaw の load_soul_content() / build_system_prompt() を踏襲。
@@ -145,6 +148,17 @@ impl SoulAgentsLoader {
 
     fn chat_soul_path(&self, channel: &str, thread: &str) -> PathBuf {
         self.groups_dir.join(channel).join(thread).join("SOUL.md")
+    }
+
+    pub fn provision_default_soul(&self) -> io::Result<bool> {
+        if self.soul_path.exists() {
+            return Ok(false);
+        }
+        if let Some(parent) = self.soul_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&self.soul_path, DEFAULT_SOUL_MD)?;
+        Ok(true)
     }
 }
 
@@ -424,5 +438,40 @@ mod tests {
         assert!(section.contains("<chat-agents>"));
         assert!(section.contains("Chat agents content"));
         assert!(section.contains("</chat-agents>"));
+    }
+
+    // --- provision_default_soul tests ---
+
+    #[test]
+    fn default_soul_content_is_non_empty_and_contains_key_phrases() {
+        assert!(!DEFAULT_SOUL_MD.trim().is_empty());
+        assert!(DEFAULT_SOUL_MD.contains("EgoPulse"));
+        assert!(DEFAULT_SOUL_MD.contains("local-first"));
+    }
+
+    #[test]
+    fn provision_default_soul_creates_file_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        let created = loader.provision_default_soul().unwrap();
+        assert!(created);
+
+        let content = std::fs::read_to_string(dir.path().join("SOUL.md")).unwrap();
+        assert_eq!(content, DEFAULT_SOUL_MD);
+    }
+
+    #[test]
+    fn provision_default_soul_does_not_overwrite_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let loader = make_loader(dir.path());
+
+        write_file(&dir.path().join("SOUL.md"), "Existing personality");
+
+        let created = loader.provision_default_soul().unwrap();
+        assert!(!created);
+
+        let content = std::fs::read_to_string(dir.path().join("SOUL.md")).unwrap();
+        assert_eq!(content, "Existing personality");
     }
 }

--- a/egopulse/src/soul_agents.rs
+++ b/egopulse/src/soul_agents.rs
@@ -462,8 +462,8 @@ mod tests {
     #[test]
     fn default_soul_content_is_non_empty_and_contains_key_phrases() {
         assert!(!DEFAULT_SOUL_MD.trim().is_empty());
-        assert!(DEFAULT_SOUL_MD.contains("EgoPulse"));
-        assert!(DEFAULT_SOUL_MD.contains("local-first"));
+        assert!(DEFAULT_SOUL_MD.contains("action-oriented"));
+        assert!(DEFAULT_SOUL_MD.contains("Reliability over impressiveness"));
     }
 
     #[test]

--- a/egopulse/src/soul_agents.rs
+++ b/egopulse/src/soul_agents.rs
@@ -173,7 +173,11 @@ fn safe_path_components(channel: &str, thread: &str) -> Option<()> {
             .components()
             .all(|c| matches!(c, std::path::Component::Normal(_)))
     };
-    if ok(channel) && ok(thread) { Some(()) } else { None }
+    if ok(channel) && ok(thread) {
+        Some(())
+    } else {
+        None
+    }
 }
 
 fn read_trimmed(path: &Path) -> Option<String> {
@@ -508,6 +512,10 @@ mod tests {
     fn load_soul_rejects_parent_dir_traversal() {
         let dir = tempfile::tempdir().unwrap();
         let loader = make_loader(dir.path());
-        assert!(loader.load_soul("../../../etc", "thread", None, None).is_none());
+        assert!(
+            loader
+                .load_soul("../../../etc", "thread", None, None)
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
## 概要

Microclaw 由来の SOUL.md（人格定義）と AGENTS.md（グローバルルール）の読み込み・注入機能を実装。複数人格ディレクトリ (`~/.egopulse/souls/`) からの選択機構を含む。

## 設計方針

- Microclaw の `load_soul_content()` / `build_system_prompt()` の構造と注入フォーマットを踏襲
- 3層フォールバックチェーン（account → channel → global → chat-specific）による SOUL 選択
- `SoulAgentsLoader` を `AppState` に統合し、`build_system_prompt()` で自動注入
- 初回起動時にデフォルト SOUL.md を自動プロビジョニング

## 変更内容

| コミット | 内容 |
|---|---|
| `fc351f6` | Config に SOUL/AGENTS パスアクセサ + `ChannelConfig.soul_path` を追加 |
| `76fc667` | `SoulAgentsLoader` モジュール新規作成（3層フォールバック、22テスト） |
| `8c3b23a` | `AppState` に `SoulAgentsLoader` を統合 |
| `c19e82f` | `build_system_prompt()` に SOUL/AGENTS セクション注入（11テスト） |
| `d86ab95` | デフォルト SOUL.md 埋め込み + 初回プロビジョニング（3テスト） |

## 変更ファイル

| ファイル | 変更種別 |
|---|---|
| `egopulse/src/soul_agents.rs` | 新規 |
| `egopulse/src/default_soul.md` | 新規 |
| `egopulse/src/config.rs` | 変更 |
| `egopulse/src/runtime.rs` | 変更 |
| `egopulse/src/agent_loop/turn.rs` | 変更 |
| `egopulse/src/agent_loop/session.rs` | 変更（テストヘルパー更新） |
| `egopulse/src/lib.rs` | 変更（モジュール登録） |

## テスト

全 43 件の新規テストを追加（269テスト全通過）:

- Config パスアクセサ: 7件
- SoulAgentsLoader: 25件（読み込み、フォールバック、パス解決、セクション構築、プロビジョニング）
- AppState 統合: 2件
- System Prompt 注入: 11件

## 検証

- `cargo test -p egopulse` — 269 passed ✅
- `cargo fmt --check` — clean ✅
- `cargo check -p egopulse` — clean ✅
- `cargo clippy --all-targets --all-features -- -D warnings` — clean ✅

## 参考

- プラン: `docs/30.egopulse/plan-soul-agents-md.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * アシスタントに「ソウル」システムを追加しました。カスタマイズ可能なプロファイル定義により、チャネルごとに異なるアシスタント動作を設定できるようになりました。
  * グローバルおよびチャットスレッド固有の記憶・エージェント情報を動的に読み込み、プロンプトに統合できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->