### PR TITLE
fix: ヘッドレス環境での systemd user service 起動を自動修復

### DIFF
--- a/docs/30.egopulse/system-prompt.md
+++ b/docs/30.egopulse/system-prompt.md
@@ -1,0 +1,251 @@
+# EgoPulse System Prompt 構築仕様
+
+LLM に送信される system prompt がどのように構築されるかを定義する。SOUL.md（人格定義）・AGENTS.md（ルール）・スキルカタログの読み込み、注入フォーマット、セクション順序を対象とする。
+
+## 目次
+
+1. [スコープ](#1-スコープ)
+2. [System Prompt セクション構成](#2-system-prompt-セクション構成)
+3. [Soul 選択フォールバックチェーン](#3-soul-選択フォールバックチェーン)
+4. [AGENTS.md 読み込み](#4-agentsmd-読み込み)
+5. [設定連携](#5-設定連携)
+6. [デフォルト SOUL.md プロビジョニング](#6-デフォルト-soulmd-プロビジョニング)
+
+---
+
+## 1. スコープ
+
+### 含むもの
+
+- system prompt のセクション構築順序
+- SOUL.md の3層フォールバックチェーン（account → channel → global → chat-specific）
+- AGENTS.md の2層読み込み（global + per-chat）
+- `ChannelConfig.soul_path` によるチャネル別人格紐付け
+- デフォルト SOUL.md の初回プロビジョニング
+
+### 含まないもの
+
+- 会話履歴の保存・復元（→ `session-lifecycle.md`）
+- スキルの発見・読み込み（→ `tools.md`）
+- ツール定義の LLM への渡し方
+- compaction 処理
+
+---
+
+## 2. System Prompt セクション構成
+
+`build_system_prompt()` が構築する system prompt は、常に以下の順序でセクションを並べる。
+
+```
+┌─────────────────────────────────────────────┐
+│ 1. <soul> セクション      （SOUL.md が存在する場合のみ）      │
+│ 2. Identity + Capabilities （固定テキスト）                   │
+│ 3. # Memories セクション   （AGENTS.md が存在する場合のみ）    │
+│ 4. # Agent Skills セクション（スキルが存在する場合のみ）       │
+└─────────────────────────────────────────────┘
+```
+
+各セクションの詳細:
+
+### 2.1 Soul セクション
+
+SOUL.md が存在する場合、system prompt の先頭に配置される。
+
+```
+<soul>
+{SOUL.md の内容}
+</soul>
+
+Your name is EgoPulse. Current channel: {channel}.
+```
+
+- SOUL.md が存在しない場合、このセクションは出力されない
+- `<soul>` タグによるラップは Microclaw の `build_system_prompt()` と同じフォーマット
+- identity line は SOUL セクションの一部として付与される
+
+### 2.2 Identity + Capabilities セクション
+
+常に出力される固定テキスト。LLM の基本身份、利用可能ツール、実行ルールを定義する。
+
+主要な内容:
+- エージェント名とチャネル情報
+- Identity rules（名前の宣言、否定禁止）
+- セッション情報（session ID、type）
+- 利用可能ツール一覧（bash, read, write, edit, find, grep, ls, activate_skill）
+- ツール呼び出しフォーマットの説明
+- 実行プレイブック（プロアクティブなツール使用、ワークスペースパスの扱い）
+- 実行信頼性要件（副作用の完了確認、エラー報告）
+
+### 2.3 Memories セクション
+
+グローバル AGENTS.md またはチャット別 AGENTS.md が存在する場合、Identity セクションの直後（Skills の直前）に配置される。
+
+```
+# Memories
+
+<agents>
+{グローバル AGENTS.md の内容}
+</agents>
+
+<chat-agents>
+{チャット別 AGENTS.md の内容}
+</chat-agents>
+```
+
+- グローバル・チャット別いずれかが存在する場合のみ出力
+- 両方存在する場合は両方を出力
+- いずれも存在しない場合はセクション全体が省略される
+
+### 2.4 Skills セクション
+
+`SkillManager` が発見したスキルがある場合、最後に配置される。
+
+```
+# Agent Skills
+
+The following skills are available. When a task matches a skill, use the `activate_skill` tool to load its full instructions before proceeding.
+
+<available_skills>
+- skill_name: Description
+- another_skill: Description
+</available_skills>
+```
+
+- スキル数が閾値を超えると compact mode（名前のみ表示）に切り替わる
+- スキルが0件の場合はセクション全体が省略される
+
+---
+
+## 3. Soul 選択フォールバックチェーン
+
+SOUL.md の読み込みは4段階のフォールバックチェーンで行う。**最初に見つかったもの**を使用する。
+
+```
+優先度:
+  1 (最高)  account_id 固有 soul_path   ← 将来用（現状はスキップ）
+  2         チャネル別 soul_path         ← ChannelConfig.soul_path
+  3         state_root/SOUL.md           ← デフォルト人格
+  4 (上書き) チャット別 SOUL.md           ← 完全上書き
+```
+
+### 3.1 優先度 1: アカウント別（将来用）
+
+`account_id` パラメータが `Some` の場合に参照される。現在の EgoPulse には multi-account 機構がないため、`build_system_prompt()` からは常に `None` が渡される。
+
+将来 `ChannelConfig` に `accounts` サブ構造と `SurfaceContext` に `account_id` を追加すれば自動的に有効になる。インターフェースは既に3層対応済み。
+
+### 3.2 優先度 2: チャネル別 soul_path
+
+`ChannelConfig.soul_path` に設定されたパスから読み込む。
+
+```yaml
+channels:
+  discord:
+    enabled: true
+    bot_token: "..."
+    soul_path: work        # → souls/work.md を探す
+```
+
+パス解決ルール:
+
+| パスの種類 | 解決方法 |
+|---|---|
+| 絶対パス（`/`で始まる） | そのまま使用 |
+| 相対パス | 以下の候補順に探索 |
+
+相対パスの候補リスト:
+
+1. `state_root/souls/{path}.md`
+2. `state_root/souls/{path}`
+3. `state_root/{path}.md`
+4. `state_root/{path}`
+
+最初に存在したファイルを使用。いずれも存在しなければ次の優先度へフォールバック。
+
+### 3.3 優先度 3: デフォルト SOUL.md
+
+`state_root/SOUL.md`（通常は `~/.egopulse/SOUL.md`）から読み込む。
+
+### 3.4 優先度 4: チャット別 SOUL.md（完全上書き）
+
+`runtime/groups/{channel}/{thread}/SOUL.md` が存在する場合、優先度 1〜3 で決定した内容を**完全に上書き**する。累積（マージ）ではなく置き換え。
+
+この仕様により、特定のチャット（例: Discord の特定チャンネル）だけ別の人格を使用できる。
+
+### 3.5 ファイル内容の判定
+
+- ファイルが存在しない → `None`（次の候補へ）
+- ファイルが存在し、trim 後が空文字 → `None`（次の候補へ）
+- ファイルが存在し、trim 後が非空 → その内容を使用
+
+---
+
+## 4. AGENTS.md 読み込み
+
+AGENTS.md は SOUL とは異なり、フォールバックチェーンではなく**2層の累積構造**で読み込む。
+
+| 層 | パス | 性質 |
+|---|---|---|
+| グローバル | `state_root/AGENTS.md` | 全チャットで共有 |
+| チャット別 | `runtime/groups/{channel}/{thread}/AGENTS.md` | そのチャット固有 |
+
+両方存在する場合は両方を `<agents>` / `<chat-agents>` タグで区別して出力する。チャット別がグローバルを上書きするのではなく、**追加**される点が SOUL との違い。
+
+---
+
+## 5. 設定連携
+
+### 5.1 ChannelConfig.soul_path
+
+`egopulse.config.yaml` のチャネル設定に `soul_path` を追加することで、チャネルごとに人格を紐付けられる。
+
+```yaml
+channels:
+  discord:
+    enabled: true
+    bot_token: "..."
+    soul_path: friendly     # souls/friendly.md を使用
+  telegram:
+    enabled: true
+    bot_token: "..."
+    soul_path: professional  # souls/professional.md を使用
+  web:
+    enabled: true
+    auth_token: "..."
+    # soul_path 未設定 → デフォルト SOUL.md を使用
+```
+
+### 5.2 souls/ ディレクトリ
+
+複数人格ファイルを配置するディレクトリ。パスは `state_root/souls/` で固定。
+
+```
+~/.egopulse/souls/
+├── friendly.md       # channels.web.soul_path: friendly
+├── professional.md   # channels.telegram.soul_path: professional
+└── work.md           # channels.discord.soul_path: work
+```
+
+- ファイル名から `.md` 拡張子は省略可能（`soul_path: work` → `souls/work.md`）
+- ユーザーが自由に追加・編集可能
+- Config に `souls_dir` フィールドはなく、パスは固定
+
+### 5.3 現在の動作まとめ
+
+| シナリオ | 使用される SOUL |
+|---|---|
+| `soul_path` 未設定、SOUL.md なし | セクションなし（Identity のみ） |
+| `soul_path` 未設定、SOUL.md あり | `~/.egopulse/SOUL.md` |
+| `soul_path: work`、`souls/work.md` あり | `~/.egopulse/souls/work.md` |
+| `soul_path: work`、`souls/work.md` なし | `~/.egopulse/SOUL.md`（フォールバック） |
+| チャット別 SOUL.md が存在 | チャット別が常に勝つ（完全上書き） |
+
+---
+
+## 6. デフォルト SOUL.md プロビジョニング
+
+初回起動時、`~/.egopulse/SOUL.md` が存在しない場合、バイナリに埋め込まれたデフォルト内容を自動書き出しする。
+
+- タイミング: `build_app_state_with_path()` 内で `SoulAgentsLoader` 初期化直後
+- 既存ファイルがある場合は上書きしない
+- 書き出しに失敗した場合は warning ログを出力し、起動は継続する

--- a/egopulse/src/gateway.rs
+++ b/egopulse/src/gateway.rs
@@ -3,6 +3,7 @@
 //! `egopulse gateway` サブコマンド向けに unit file の生成・systemctl 実行・
 //! 最新リリースへの更新処理をまとめる。
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
 
@@ -14,7 +15,6 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const SERVICE_NAME: &str = "egopulse.service";
 
-/// systemd ユーザーサービスのユニットファイルパスを返す。
 fn unit_path() -> Result<PathBuf, EgoPulseError> {
     let home = dirs::home_dir()
         .ok_or_else(|| EgoPulseError::Internal("HOME directory could not be resolved".into()))?;
@@ -25,7 +25,123 @@ fn unit_path() -> Result<PathBuf, EgoPulseError> {
         .join(SERVICE_NAME))
 }
 
-/// Supported systemd service management actions for `egopulse gateway`.
+fn build_service_env() -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.trim().is_empty() {
+            env.insert("HOME".to_string(), home.clone());
+
+            let parts: Vec<String> = vec![
+                format!("{home}/.local/bin"),
+                "/usr/local/bin".to_string(),
+                "/usr/bin".to_string(),
+                "/bin".to_string(),
+            ];
+            let mut dedup = Vec::new();
+            for p in parts {
+                if !dedup.iter().any(|v| v == &p) {
+                    dedup.push(p);
+                }
+            }
+            env.insert("PATH".to_string(), dedup.join(":"));
+        }
+    }
+
+    env
+}
+
+/// systemd user session が利用可能か検証する。
+///
+/// `systemctl --user status` が成功するか確認し、失敗時は
+/// 原因を含むエラーメッセージを返す。
+fn assert_systemd_user_available() -> Result<(), EgoPulseError> {
+    assert_command_exists("systemctl")?;
+
+    let output = systemctl_cmd(&["status"])?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let detail = format!(
+        "{} {}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    )
+    .trim()
+    .to_string();
+
+    if detail.to_lowercase().contains("not found") {
+        return Err(EgoPulseError::Internal(
+            "systemctl is not available; systemd user services are required".into(),
+        ));
+    }
+
+    Err(EgoPulseError::Internal(format!(
+        "systemctl --user unavailable: {detail}"
+    )))
+}
+
+fn ensure_user_session() -> Result<(), EgoPulseError> {
+    if systemctl_cmd(&["status"]).is_ok() {
+        return Ok(());
+    }
+
+    let uid = std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .trim()
+                .parse::<u32>()
+                .ok()
+        })
+        .unwrap_or(0);
+
+    if std::env::var("XDG_RUNTIME_DIR").is_err() {
+        let runtime_dir = format!("/run/user/{uid}");
+        if !std::path::Path::new(&runtime_dir).exists() {
+            let linger_output = ProcessCommand::new("loginctl")
+                .args(["enable-linger", &uid.to_string()])
+                .output()
+                .map_err(|e| {
+                    EgoPulseError::Internal(format!("failed to run loginctl enable-linger: {e}"))
+                })?;
+            if !linger_output.status.success() {
+                let stderr = String::from_utf8_lossy(&linger_output.stderr)
+                    .trim()
+                    .to_string();
+                return Err(EgoPulseError::Internal(format!(
+                    "loginctl enable-linger failed: {stderr}"
+                )));
+            }
+            println!("Enabled lingering for uid {uid}");
+        }
+        // SAFETY: XDG_RUNTIME_DIR の設定はプロセス内で安全。
+        // 他スレッドへの影響はない（gateway コマンドはシングルスレッド）。
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", &runtime_dir);
+        }
+    }
+
+    assert_systemd_user_available()
+}
+
+fn assert_command_exists(cmd: &str) -> Result<(), EgoPulseError> {
+    let output = ProcessCommand::new("which")
+        .arg(cmd)
+        .output()
+        .map_err(|e| EgoPulseError::Internal(format!("failed to run which: {e}")))?;
+    if !output.status.success() {
+        return Err(EgoPulseError::Internal(format!(
+            "'{cmd}' not found in PATH"
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Subcommand)]
 pub enum GatewayAction {
     /// Install and enable the systemd service
@@ -66,7 +182,26 @@ pub fn resolve_cli_config_path(path: &std::path::Path) -> PathBuf {
     }
 }
 
-fn render_systemd_unit(exe_path: &str, config_path: &std::path::Path) -> String {
+fn systemd_escape_env(value: &str) -> String {
+    assert!(
+        !value.contains('\n'),
+        "environment variable must not contain newlines"
+    );
+    let needs_quoting = value.is_empty()
+        || value.contains(|c: char| c.is_whitespace() || c == '"' || c == '\\' || c == '\'');
+    if !needs_quoting {
+        return value.to_string();
+    }
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+/// systemd ユニットファイルの内容を生成する。
+fn render_systemd_unit(
+    exe_path: &str,
+    config_path: &std::path::Path,
+    service_env: &BTreeMap<String, String>,
+) -> String {
     let config_arg = config_path.to_string_lossy();
     let escaped_config = config_arg.replace('\\', "\\\\").replace('"', "\\\"");
     let working_dir = config_path
@@ -78,6 +213,12 @@ fn render_systemd_unit(exe_path: &str, config_path: &std::path::Path) -> String 
                 .unwrap_or_else(|| ".".to_string())
         });
 
+    let mut env_lines = String::new();
+    for (key, value) in service_env {
+        let kv = format!("{key}={}", systemd_escape_env(value));
+        env_lines.push_str(&format!("Environment={kv}\n"));
+    }
+
     format!(
         "[Unit]
 Description=EgoPulse Agent Runtime
@@ -88,6 +229,7 @@ Wants=network-online.target
 Type=simple
 WorkingDirectory={working_dir}
 ExecStart={exe_path} --config \"{escaped_config}\" run
+{env_lines}\
 Restart=always
 RestartSec=10
 KillMode=process
@@ -162,6 +304,8 @@ ACTIONS:
 
     match action {
         GatewayAction::Install => {
+            ensure_user_session()?;
+
             let exe_path = std::env::current_exe().map_err(|e| {
                 EgoPulseError::Internal(format!("failed to resolve binary path: {e}"))
             })?;
@@ -173,6 +317,8 @@ ACTIONS:
                 )));
             }
 
+            let service_env = build_service_env();
+
             let unit = unit_path()?;
             let unit_dir = unit
                 .parent()
@@ -182,7 +328,8 @@ ACTIONS:
             })?;
 
             let already_installed = unit.exists();
-            let unit_content = render_systemd_unit(&exe_path.to_string_lossy(), &config_path);
+            let unit_content =
+                render_systemd_unit(&exe_path.to_string_lossy(), &config_path, &service_env);
             std::fs::write(&unit, &unit_content)
                 .map_err(|e| EgoPulseError::Internal(format!("failed to write unit file: {e}")))?;
 
@@ -204,16 +351,19 @@ ACTIONS:
             Ok(())
         }
         GatewayAction::Start => {
+            ensure_user_session()?;
             ensure_success(systemctl_cmd(&["start", SERVICE_NAME])?, "start service")?;
             println!("egopulse service started");
             Ok(())
         }
         GatewayAction::Stop => {
+            ensure_user_session()?;
             ensure_success(systemctl_cmd(&["stop", SERVICE_NAME])?, "stop service")?;
             println!("egopulse service stopped");
             Ok(())
         }
         GatewayAction::Uninstall => {
+            ensure_user_session()?;
             let _ = systemctl_cmd(&["disable", "--now", SERVICE_NAME]);
             let _ = systemctl_cmd(&["daemon-reload"]);
 
@@ -229,6 +379,7 @@ ACTIONS:
             Ok(())
         }
         GatewayAction::Status => {
+            ensure_user_session()?;
             let output = systemctl_cmd(&["status", SERVICE_NAME, "--no-pager"])?;
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -243,6 +394,7 @@ ACTIONS:
             }
         }
         GatewayAction::Restart => {
+            ensure_user_session()?;
             let output = systemctl_cmd(&["restart", SERVICE_NAME])?;
             if output.status.success() {
                 println!("egopulse service restarted");
@@ -286,14 +438,20 @@ pub async fn run_update() -> Result<(), EgoPulseError> {
 
 #[cfg(test)]
 mod tests {
-    use super::render_systemd_unit;
+    use super::*;
     use std::path::PathBuf;
 
     #[test]
     fn render_systemd_unit_contains_expected_directives() {
         let config_path = PathBuf::from("/home/user/.egopulse/egopulse.config.yaml");
+        let mut service_env = BTreeMap::new();
+        service_env.insert("HOME".to_string(), "/home/user".to_string());
+        service_env.insert(
+            "PATH".to_string(),
+            "/home/user/.local/bin:/usr/local/bin:/usr/bin:/bin".to_string(),
+        );
 
-        let unit = render_systemd_unit("/usr/local/bin/egopulse", &config_path);
+        let unit = render_systemd_unit("/usr/local/bin/egopulse", &config_path, &service_env);
 
         assert!(unit.contains(
             "ExecStart=/usr/local/bin/egopulse --config \"/home/user/.egopulse/egopulse.config.yaml\" run"
@@ -302,20 +460,62 @@ mod tests {
         assert!(unit.contains("RestartSec=10"));
         assert!(unit.contains("KillMode=process"));
         assert!(unit.contains("WantedBy=default.target"));
-        assert!(!unit.contains("NoNewPrivileges"));
-        assert!(!unit.contains("ProtectSystem"));
-        assert!(!unit.contains("ReadWritePaths"));
-        assert!(!unit.contains("ProtectHome"));
-        assert!(!unit.contains("Environment=HOME"));
+        assert!(unit.contains("Environment=HOME=/home/user"));
+        assert!(unit.contains("Environment=PATH="));
     }
 
     #[test]
     fn render_systemd_unit_escapes_config_path_with_special_chars() {
         let config_path = PathBuf::from("/tmp/ego pulse/config dir/egopulse.config.yaml");
+        let service_env = BTreeMap::new();
 
-        let unit = render_systemd_unit("/usr/local/bin/egopulse", &config_path);
+        let unit = render_systemd_unit("/usr/local/bin/egopulse", &config_path, &service_env);
 
         assert!(unit.contains("/tmp/ego pulse/config dir/egopulse.config.yaml"));
         assert!(unit.contains("WantedBy=default.target"));
+    }
+
+    #[test]
+    fn render_systemd_unit_without_service_env() {
+        let config_path = PathBuf::from("/home/user/.egopulse/egopulse.config.yaml");
+        let service_env = BTreeMap::new();
+
+        let unit = render_systemd_unit("/usr/local/bin/egopulse", &config_path, &service_env);
+
+        assert!(!unit.contains("Environment="));
+    }
+
+    #[test]
+    fn systemd_escape_env_plain_value() {
+        assert_eq!(systemd_escape_env("/usr/bin"), "/usr/bin");
+    }
+
+    #[test]
+    fn systemd_escape_env_value_with_spaces() {
+        assert_eq!(
+            systemd_escape_env("/path with spaces"),
+            "\"/path with spaces\""
+        );
+    }
+
+    #[test]
+    fn systemd_escape_env_value_with_quotes() {
+        assert_eq!(systemd_escape_env("a\"b"), "\"a\\\"b\"");
+    }
+
+    #[test]
+    fn build_service_env_contains_expected_keys() {
+        let env = build_service_env();
+
+        assert!(env.contains_key("HOME"));
+        assert!(env.contains_key("PATH"));
+        assert!(!env.contains_key("TMPDIR"));
+        assert!(!env.contains_key("EGOPULSE_CONFIG"));
+    }
+
+    #[test]
+    #[should_panic(expected = "must not contain newlines")]
+    fn systemd_escape_env_rejects_newlines() {
+        systemd_escape_env("line1\nline2");
     }
 }

--- a/egopulse/src/gateway.rs
+++ b/egopulse/src/gateway.rs
@@ -32,12 +32,17 @@ fn build_service_env() -> BTreeMap<String, String> {
         if !home.trim().is_empty() {
             env.insert("HOME".to_string(), home.clone());
 
-            let parts: Vec<String> = vec![
-                format!("{home}/.local/bin"),
+            let mut parts = vec![format!("{home}/.local/bin")];
+            if let Some(current_path) = std::env::var_os("PATH") {
+                parts.extend(
+                    std::env::split_paths(&current_path).map(|p| p.to_string_lossy().into_owned()),
+                );
+            }
+            parts.extend([
                 "/usr/local/bin".to_string(),
                 "/usr/bin".to_string(),
                 "/bin".to_string(),
-            ];
+            ]);
             let mut dedup = Vec::new();
             for p in parts {
                 if !dedup.iter().any(|v| v == &p) {
@@ -83,21 +88,28 @@ fn assert_systemd_user_available() -> Result<(), EgoPulseError> {
 }
 
 fn ensure_user_session() -> Result<(), EgoPulseError> {
-    if systemctl_cmd(&["status"]).is_ok() {
-        return Ok(());
+    if let Ok(output) = systemctl_cmd(&["status"]) {
+        if output.status.success() {
+            return Ok(());
+        }
     }
 
-    let uid = std::process::Command::new("id")
+    let uid_output = std::process::Command::new("id")
         .arg("-u")
         .output()
-        .ok()
-        .and_then(|o| {
-            String::from_utf8_lossy(&o.stdout)
-                .trim()
-                .parse::<u32>()
-                .ok()
-        })
-        .unwrap_or(0);
+        .map_err(|e| EgoPulseError::Internal(format!("failed to run id -u: {e}")))?;
+    if !uid_output.status.success() {
+        let stderr = String::from_utf8_lossy(&uid_output.stderr)
+            .trim()
+            .to_string();
+        return Err(EgoPulseError::Internal(format!(
+            "failed to resolve uid: {stderr}"
+        )));
+    }
+    let uid = String::from_utf8_lossy(&uid_output.stdout)
+        .trim()
+        .parse::<u32>()
+        .map_err(|e| EgoPulseError::Internal(format!("failed to parse uid: {e}")))?;
 
     if std::env::var("XDG_RUNTIME_DIR").is_err() {
         let runtime_dir = format!("/run/user/{uid}");

--- a/egopulse/src/gateway.rs
+++ b/egopulse/src/gateway.rs
@@ -60,10 +60,10 @@ fn build_service_env() -> BTreeMap<String, String> {
 ///
 /// `systemctl --user status` が成功するか確認し、失敗時は
 /// 原因を含むエラーメッセージを返す。
-fn assert_systemd_user_available() -> Result<(), EgoPulseError> {
+fn assert_systemd_user_available(runtime_dir: Option<&str>) -> Result<(), EgoPulseError> {
     assert_command_exists("systemctl")?;
 
-    let output = systemctl_cmd(&["status"])?;
+    let output = systemctl_cmd(&["status"], runtime_dir)?;
     if output.status.success() {
         return Ok(());
     }
@@ -87,10 +87,10 @@ fn assert_systemd_user_available() -> Result<(), EgoPulseError> {
     )))
 }
 
-fn ensure_user_session() -> Result<(), EgoPulseError> {
-    if let Ok(output) = systemctl_cmd(&["status"]) {
+fn ensure_user_session() -> Result<Option<String>, EgoPulseError> {
+    if let Ok(output) = systemctl_cmd(&["status"], None) {
         if output.status.success() {
-            return Ok(());
+            return Ok(None);
         }
     }
 
@@ -130,15 +130,12 @@ fn ensure_user_session() -> Result<(), EgoPulseError> {
             }
             println!("Enabled lingering for uid {uid}");
         }
-        // SAFETY: XDG_RUNTIME_DIR の設定はプロセス内で安全。
-        // 他スレッドへの影響はない（gateway コマンドはシングルスレッド）。
-        #[allow(unsafe_code)]
-        unsafe {
-            std::env::set_var("XDG_RUNTIME_DIR", &runtime_dir);
-        }
+        assert_systemd_user_available(Some(&runtime_dir))?;
+        return Ok(Some(runtime_dir));
     }
 
-    assert_systemd_user_available()
+    assert_systemd_user_available(None)?;
+    Ok(None)
 }
 
 fn assert_command_exists(cmd: &str) -> Result<(), EgoPulseError> {
@@ -252,10 +249,20 @@ WantedBy=default.target
     )
 }
 
-fn systemctl_cmd(args: &[&str]) -> Result<std::process::Output, EgoPulseError> {
-    ProcessCommand::new("systemctl")
-        .arg("--user")
-        .args(args)
+fn build_systemctl_command(args: &[&str], runtime_dir: Option<&str>) -> ProcessCommand {
+    let mut command = ProcessCommand::new("systemctl");
+    command.arg("--user").args(args);
+    if let Some(runtime_dir) = runtime_dir {
+        command.env("XDG_RUNTIME_DIR", runtime_dir);
+    }
+    command
+}
+
+fn systemctl_cmd(
+    args: &[&str],
+    runtime_dir: Option<&str>,
+) -> Result<std::process::Output, EgoPulseError> {
+    build_systemctl_command(args, runtime_dir)
         .output()
         .map_err(|e| EgoPulseError::Internal(format!("failed to run systemctl --user: {e}")))
 }
@@ -278,7 +285,8 @@ fn restart_service() -> Result<(), EgoPulseError> {
         return Ok(());
     }
 
-    let output = systemctl_cmd(&["restart", SERVICE_NAME])?;
+    let runtime_dir = ensure_user_session()?;
+    let output = systemctl_cmd(&["restart", SERVICE_NAME], runtime_dir.as_deref())?;
     if output.status.success() {
         println!("egopulse service restarted");
         Ok(())
@@ -316,7 +324,7 @@ ACTIONS:
 
     match action {
         GatewayAction::Install => {
-            ensure_user_session()?;
+            let runtime_dir = ensure_user_session()?;
 
             let exe_path = std::env::current_exe().map_err(|e| {
                 EgoPulseError::Internal(format!("failed to resolve binary path: {e}"))
@@ -345,17 +353,20 @@ ACTIONS:
             std::fs::write(&unit, &unit_content)
                 .map_err(|e| EgoPulseError::Internal(format!("failed to write unit file: {e}")))?;
 
-            ensure_success(systemctl_cmd(&["daemon-reload"])?, "daemon-reload")?;
+            ensure_success(
+                systemctl_cmd(&["daemon-reload"], runtime_dir.as_deref())?,
+                "daemon-reload",
+            )?;
 
             if already_installed {
                 ensure_success(
-                    systemctl_cmd(&["restart", SERVICE_NAME])?,
+                    systemctl_cmd(&["restart", SERVICE_NAME], runtime_dir.as_deref())?,
                     "restart service",
                 )?;
                 println!("Updated and restarted egopulse service: {}", unit.display());
             } else {
                 ensure_success(
-                    systemctl_cmd(&["enable", "--now", SERVICE_NAME])?,
+                    systemctl_cmd(&["enable", "--now", SERVICE_NAME], runtime_dir.as_deref())?,
                     "enable service",
                 )?;
                 println!("Installed and started egopulse service: {}", unit.display());
@@ -363,21 +374,27 @@ ACTIONS:
             Ok(())
         }
         GatewayAction::Start => {
-            ensure_user_session()?;
-            ensure_success(systemctl_cmd(&["start", SERVICE_NAME])?, "start service")?;
+            let runtime_dir = ensure_user_session()?;
+            ensure_success(
+                systemctl_cmd(&["start", SERVICE_NAME], runtime_dir.as_deref())?,
+                "start service",
+            )?;
             println!("egopulse service started");
             Ok(())
         }
         GatewayAction::Stop => {
-            ensure_user_session()?;
-            ensure_success(systemctl_cmd(&["stop", SERVICE_NAME])?, "stop service")?;
+            let runtime_dir = ensure_user_session()?;
+            ensure_success(
+                systemctl_cmd(&["stop", SERVICE_NAME], runtime_dir.as_deref())?,
+                "stop service",
+            )?;
             println!("egopulse service stopped");
             Ok(())
         }
         GatewayAction::Uninstall => {
-            ensure_user_session()?;
-            let _ = systemctl_cmd(&["disable", "--now", SERVICE_NAME]);
-            let _ = systemctl_cmd(&["daemon-reload"]);
+            let runtime_dir = ensure_user_session()?;
+            let _ = systemctl_cmd(&["disable", "--now", SERVICE_NAME], runtime_dir.as_deref());
+            let _ = systemctl_cmd(&["daemon-reload"], runtime_dir.as_deref());
 
             let unit = unit_path()?;
             if unit.exists() {
@@ -385,14 +402,20 @@ ACTIONS:
                     EgoPulseError::Internal(format!("failed to remove unit file: {e}"))
                 })?;
             }
-            ensure_success(systemctl_cmd(&["daemon-reload"])?, "daemon-reload")?;
+            ensure_success(
+                systemctl_cmd(&["daemon-reload"], runtime_dir.as_deref())?,
+                "daemon-reload",
+            )?;
 
             println!("Uninstalled egopulse service");
             Ok(())
         }
         GatewayAction::Status => {
-            ensure_user_session()?;
-            let output = systemctl_cmd(&["status", SERVICE_NAME, "--no-pager"])?;
+            let runtime_dir = ensure_user_session()?;
+            let output = systemctl_cmd(
+                &["status", SERVICE_NAME, "--no-pager"],
+                runtime_dir.as_deref(),
+            )?;
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             print!("{stdout}{stderr}");
@@ -406,8 +429,8 @@ ACTIONS:
             }
         }
         GatewayAction::Restart => {
-            ensure_user_session()?;
-            let output = systemctl_cmd(&["restart", SERVICE_NAME])?;
+            let runtime_dir = ensure_user_session()?;
+            let output = systemctl_cmd(&["restart", SERVICE_NAME], runtime_dir.as_deref())?;
             if output.status.success() {
                 println!("egopulse service restarted");
                 Ok(())
@@ -451,6 +474,7 @@ pub async fn run_update() -> Result<(), EgoPulseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
     use std::path::PathBuf;
 
     #[test]
@@ -523,6 +547,28 @@ mod tests {
         assert!(env.contains_key("PATH"));
         assert!(!env.contains_key("TMPDIR"));
         assert!(!env.contains_key("EGOPULSE_CONFIG"));
+    }
+
+    #[test]
+    fn build_systemctl_command_sets_runtime_dir_only_when_present() {
+        let command = build_systemctl_command(&["status"], Some("/run/user/1000"));
+        let envs: Vec<_> = command.get_envs().collect();
+
+        assert!(envs.iter().any(|(key, value)| {
+            *key == OsStr::new("XDG_RUNTIME_DIR") && *value == Some(OsStr::new("/run/user/1000"))
+        }));
+    }
+
+    #[test]
+    fn build_systemctl_command_omits_runtime_dir_when_absent() {
+        let command = build_systemctl_command(&["status"], None);
+        let envs: Vec<_> = command.get_envs().collect();
+
+        assert!(
+            !envs
+                .iter()
+                .any(|(key, _)| *key == OsStr::new("XDG_RUNTIME_DIR"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`egopulse gateway status` 等のコマンドが、ヘッドレス環境（SSH / root / コンテナ）で `Failed to get properties: Process org.freedesktop.systemd1 exited with status 1` で失敗する問題を修正する。

## 原因

`systemctl --user` は D-Bus user session 経由で systemd と通信するが、ヘッドレス環境では以下が未設定の場合がある：
- `XDG_RUNTIME_DIR` が未設定（systemd との通信パスが分からない）
- `loginctl enable-linger` が未設定（ユーザーの systemd インスタンスが常駐していない）

## 変更内容

### 1. ヘッドレス環境の自動セットアップ（`ensure_user_session`）

全 gateway アクションの冒頭で `systemctl --user` が通るか確認し、通らない場合：
1. `loginctl enable-linger` でユーザーの systemd インスタンスを常駐化
2. `XDG_RUNTIME_DIR=/run/user/{uid}` を設定
3. `assert_systemd_user_available()` で再検証

デスクトップ環境では既に通るため no-op。

### 2. unit file への環境変数埋め込み（`build_service_env`）

systemd user service のプロセスにはシェル profile が読まれず、最小限の環境変数のみが設定される。以下を `Environment=` 行として明示的に埋め込む：

| 変数 | 理由 |
|---|---|
| `HOME` | `dirs::home_dir()` → `~/.egopulse/` 解決に必要。多くの環境では systemd が設定するが、WSL / コンテナ / NSS 環境では未設定の可能性があるため保険として明示 |
| `PATH` | systemd デフォルトは `/usr/bin:/bin` のみ。`~/.local/bin`（cargo install 等の配置先）を含めることで MCP ツール等の子プロセス呼び出しに対応 |

### 3. 事前検証（`assert_systemd_user_available`）

microclaw パターン。`systemctl --user status` が通らない場合、原因を含むエラーメッセージを返す。

## テスト

- `render_systemd_unit` の Environment 行出力を検証（あり/なし両パターン）
- `systemd_escape_env` のエスケープ処理を検証（plain / spaces / quotes / newlines）
- `build_service_env` のキー構成を検証

## 参照

- microclaw `src/gateway.rs` の `build_service_env` / `assert_systemd_user_available` パターン

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * EgoPulse のシステムプロンプト構築仕様の詳細なドキュメントを追加しました。

* **改善**
  * systemd サービス設定で環境変数のサポートを強化しました。
  * systemd ユーザーセッションの互換性チェックを改善し、サービスの起動信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->