### PR TITLE
feat: LLM使用量追跡（llm_usage_logs）

### DIFF
--- a/docs/30.egopulse/db.md
+++ b/docs/30.egopulse/db.md
@@ -11,15 +11,16 @@ egopulse.db (SQLite / WAL mode)
 ├── chats               — チャットメタデータ・チャンネルアイデンティティ
 ├── messages            — メッセージ履歴
 ├── sessions            — セッションスナップショット（シリアライズ済み会話）
-└── tool_calls          — ツール呼び出し記録
+├── tool_calls          — ツール呼び出し記録
+└── llm_usage_logs      — LLM API 使用量ログ
 ```
 
 | 項目 | 値 |
 |------|----|
-| テーブル数 | 6（データテーブル 4 + マイグレーション基盤テーブル 2） |
-| インデックス数 | 5 |
+| テーブル数 | 7（データテーブル 5 + マイグレーション基盤テーブル 2） |
+| インデックス数 | 7 |
 | 外部キー制約 | 1（tool_calls.chat_id → chats.chat_id） |
-| スキーマバージョン管理 | バージョンベース（`SCHEMA_VERSION` 定数、現行 v1） |
+| スキーマバージョン管理 | バージョンベース（`SCHEMA_VERSION` 定数、現行 v2） |
 | DBライブラリ | rusqlite 0.37（bundled） |
 | DBファイル | `{data_dir}/egopulse.db` |
 | 接続ラッパー | `Mutex<Connection>` |
@@ -59,6 +60,22 @@ egopulse.db (SQLite / WAL mode)
                 │ tool_input       │
                 │ tool_output      │
                 │ timestamp        │
+                └──────────────────┘
+
+        │1    *
+        │───────┌──────────────────┐
+        │       │  llm_usage_logs  │
+        │       │──────────────────│
+        └───────│ id (PK)          │
+                │ chat_id          │
+                │ caller_channel   │
+                │ provider         │
+                │ model            │
+                │ input_tokens     │
+                │ output_tokens    │
+                │ total_tokens     │
+                │ request_kind     │
+                │ created_at       │
                 └──────────────────┘
 
 ┌──────────────────┐       ┌──────────────────┐
@@ -214,6 +231,51 @@ CREATE INDEX IF NOT EXISTS idx_tool_calls_chat_message_id
 
 ---
 
+### llm_usage_logs
+
+LLM API の使用量ログ。トークン消費の追跡とコスト管理に使用。
+
+```sql
+CREATE TABLE IF NOT EXISTS llm_usage_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id INTEGER NOT NULL,
+    caller_channel TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL,
+    output_tokens INTEGER NOT NULL,
+    total_tokens INTEGER NOT NULL,
+    request_kind TEXT NOT NULL DEFAULT 'agent_loop',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_usage_chat_created
+    ON llm_usage_logs(chat_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_llm_usage_created
+    ON llm_usage_logs(created_at);
+```
+
+| カラム | 型 | 制約 | 説明 |
+|--------|----|------|------|
+| id | INTEGER | PK (auto) | 内部ID（AUTOINCREMENT） |
+| chat_id | INTEGER | NOT NULL | chats.chat_id への参照 |
+| caller_channel | TEXT | NOT NULL | 呼び出し元チャンネル（`cli`, `web`, `discord`, `telegram`） |
+| provider | TEXT | NOT NULL | LLM プロバイダ名（`openai`, `openrouter`, `ollama` 等） |
+| model | TEXT | NOT NULL | モデル名 |
+| input_tokens | INTEGER | NOT NULL | 入力トークン数 |
+| output_tokens | INTEGER | NOT NULL | 出力トークン数 |
+| total_tokens | INTEGER | NOT NULL | 合計トークン数（input + output） |
+| request_kind | TEXT | NOT NULL DEFAULT 'agent_loop' | リクエスト種別 |
+| created_at | TEXT | NOT NULL | RFC3339 タイムスタンプ |
+
+**操作**:
+- `log_llm_usage(chat_id, caller_channel, provider, model, input_tokens, output_tokens, request_kind)` — INSERT（total_tokens は自動計算）
+- `get_llm_usage_summary(chat_id, since)` — 集計サマリ（requests, input/output/total tokens, last_request_at）
+- `get_llm_usage_by_model(chat_id, since)` — モデル別集計（total_tokens 降順）
+
+---
+
 ### db_meta
 
 スキーマバージョンの key-value ストア。現在は `schema_version` のみ格納。
@@ -269,6 +331,8 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 | `SessionSummary` | chats + messages（JOIN） | chat_id, channel, surface_thread, chat_title, last_message_time, last_message_preview |
 | `SessionSnapshot` | sessions + messages | messages_json, updated_at, recent_messages: Vec\<StoredMessage\> |
 | `ToolCall` | tool_calls | id, chat_id, message_id, tool_name, tool_input, tool_output, timestamp |
+| `LlmUsageSummary` | llm_usage_logs（集計） | requests, input_tokens, output_tokens, total_tokens, last_request_at |
+| `LlmModelUsageSummary` | llm_usage_logs（モデル別集計） | model, requests, input_tokens, output_tokens, total_tokens |
 
 ---
 
@@ -283,7 +347,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 2. `schema_version(conn)` で `db_meta` テーブルから現在のバージョンを取得（未設定時は `0`）
 3. `if version < N` ブロックで未適用のマイグレーションを逐次実行
 4. 各マイグレーション適用後に `set_schema_version(conn, N, "note")` でバージョンを更新し `schema_migrations` に履歴を記録
-5. `SCHEMA_VERSION` 定数（現行 `1`）に到達したら完了。`debug_assert_eq!` で検証
+5. `SCHEMA_VERSION` 定数（現行 `2`）に到達したら完了。`debug_assert_eq!` で検証
 
 **新規マイグレーションの追加手順**:
 1. `SCHEMA_VERSION` 定数をインクリメント（例: `1` → `2`）
@@ -294,8 +358,27 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 ```rust
 // 既存のテンプレート（storage.rs 内）
 // if version < 2 {
-//     conn.execute_batch("...")?;
-//     set_schema_version(conn, 2, "...")?;
+//     conn.execute_batch(
+//         "CREATE TABLE IF NOT EXISTS llm_usage_logs (
+//             id INTEGER PRIMARY KEY AUTOINCREMENT,
+//             chat_id INTEGER NOT NULL,
+//             caller_channel TEXT NOT NULL,
+//             provider TEXT NOT NULL,
+//             model TEXT NOT NULL,
+//             input_tokens INTEGER NOT NULL,
+//             output_tokens INTEGER NOT NULL,
+//             total_tokens INTEGER NOT NULL,
+//             request_kind TEXT NOT NULL DEFAULT 'agent_loop',
+//             created_at TEXT NOT NULL
+//         );
+//
+//         CREATE INDEX IF NOT EXISTS idx_llm_usage_chat_created
+//             ON llm_usage_logs(chat_id, created_at);
+//
+//         CREATE INDEX IF NOT EXISTS idx_llm_usage_created
+//             ON llm_usage_logs(created_at);",
+//     )?;
+//     set_schema_version(conn, 2, "add llm_usage_logs table for LLM usage tracking")?;
 //     version = 2;
 // }
 ```
@@ -319,12 +402,12 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 
 | 観点 | EgoPulse（現状） | Microclaw（v19） |
 |------|------------------|------------------|
-| テーブル数 | 6（データ4 + マイグレーション基盤2） | 24 |
-| マイグレーション | バージョンベース（v1） | バージョンベース（v1→v19） |
+| テーブル数 | 7（データ5 + マイグレーション基盤2） | 24 |
+| マイグレーション | バージョンベース（v1→v2） | バージョンベース（v1→v19） |
 | セッション設定 | messages_json のみ | label, thinking_level, verbose_level, reasoning_level, skill_envs_json, fork |
 | メモリ/知識管理 | なし | memories + reflector/injection/supersede（5テーブル） |
 | タスクスケジューリング | なし | scheduled_tasks + run_logs + dlq（3テーブル） |
 | 認証・認可 | なし（静的トークンのみ） | auth + api_keys + scopes（4テーブル） |
-| オブザーバビリティ | なし | audit_logs + metrics + llm_usage（3テーブル） |
+| オブザーバビリティ | llm_usage_logs（1テーブル） | audit_logs + metrics + llm_usage（3テーブル） |
 | サブエージェント | なし | runs + announces + events + focus（4テーブル） |
 | ツール呼び出し記録 | tool_calls（独立テーブル） | sessions.messages_json 内に埋め込み |

--- a/docs/30.egopulse/db.md
+++ b/docs/30.egopulse/db.md
@@ -18,7 +18,7 @@ egopulse.db (SQLite / WAL mode)
 | 項目 | 値 |
 |------|----|
 | テーブル数 | 7（データテーブル 5 + マイグレーション基盤テーブル 2） |
-| インデックス数 | 7 |
+| インデックス数 | 6 |
 | 外部キー制約 | 1（tool_calls.chat_id → chats.chat_id） |
 | スキーマバージョン管理 | バージョンベース（`SCHEMA_VERSION` 定数、現行 v2） |
 | DBライブラリ | rusqlite 0.37（bundled） |

--- a/egopulse/src/agent_loop/compaction.rs
+++ b/egopulse/src/agent_loop/compaction.rs
@@ -83,7 +83,30 @@ async fn summarize_and_compact(
     .await;
 
     let summary = match summary_result {
-        Ok(Ok(response)) => strip_thinking(&response.content),
+        Ok(Ok(response)) => {
+            if let Some(usage) = &response.usage {
+                let db = std::sync::Arc::clone(&state.db);
+                let channel = context.channel.clone();
+                let provider = llm.provider_name().to_string();
+                let model = llm.model_name().to_string();
+                let input_tokens = usage.input_tokens;
+                let output_tokens = usage.output_tokens;
+                let _ = crate::storage::call_blocking(db, move |db| {
+                    db.log_llm_usage(&crate::storage::LlmUsageLogEntry {
+                        chat_id,
+                        caller_channel: &channel,
+                        provider: &provider,
+                        model: &model,
+                        input_tokens,
+                        output_tokens,
+                        request_kind: "summarize",
+                    })
+                })
+                .await
+                .inspect_err(|e| warn!(error = %e, "llm usage logging failed"));
+            }
+            strip_thinking(&response.content)
+        }
         Ok(Err(error)) => {
             warn!("{label} summarization failed: {error}; falling back to recent messages");
             return Ok(recent_messages.to_vec());
@@ -278,10 +301,12 @@ mod tests {
                 Ok(MessagesResponse {
                     content: "summary text".to_string(),
                     tool_calls: Vec::new(),
+                    usage: None,
                 }),
                 Ok(MessagesResponse {
                     content: "final answer".to_string(),
                     tool_calls: Vec::new(),
+                    usage: None,
                 }),
             ],
             vec![0, 0],
@@ -386,6 +411,7 @@ mod tests {
                 Ok(MessagesResponse {
                     content: "final answer".to_string(),
                     tool_calls: Vec::new(),
+                    usage: None,
                 }),
             ],
             vec![0, 0],
@@ -475,6 +501,7 @@ mod tests {
             vec![Ok(MessagesResponse {
                 content: "summary text".to_string(),
                 tool_calls: Vec::new(),
+                usage: None,
             })],
             vec![0],
         );
@@ -509,6 +536,7 @@ mod tests {
             vec![Ok(MessagesResponse {
                 content: "summary text".to_string(),
                 tool_calls: Vec::new(),
+                usage: None,
             })],
             vec![0],
         );
@@ -545,6 +573,7 @@ mod tests {
             vec![Ok(MessagesResponse {
                 content: "summary text".to_string(),
                 tool_calls: Vec::new(),
+                usage: None,
             })],
             vec![0],
         );
@@ -576,5 +605,74 @@ mod tests {
         assert_eq!(archives.len(), 1);
         let body = std::fs::read_to_string(archives[0].path()).expect("archive body");
         assert!(body.contains("msg-1"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn compaction_logs_llm_usage_as_summarize() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::new(
+            vec![
+                Ok(MessagesResponse {
+                    content: "summary text".to_string(),
+                    tool_calls: Vec::new(),
+                    usage: Some(crate::llm::LlmUsage {
+                        input_tokens: 100,
+                        output_tokens: 200,
+                    }),
+                }),
+                Ok(MessagesResponse {
+                    content: "final answer".to_string(),
+                    tool_calls: Vec::new(),
+                    usage: None,
+                }),
+            ],
+            vec![0, 0],
+        );
+        let config =
+            test_config_with_compaction(dir.path().to_str().expect("utf8").to_string(), 4, 2);
+        let state = build_state(config, Box::new(provider));
+        let context = cli_context("compaction-usage");
+        let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
+            db.resolve_or_create_chat_id(
+                "cli",
+                "cli:compaction-usage",
+                Some("compaction-usage"),
+                "cli",
+            )
+        })
+        .await
+        .expect("chat id");
+        let seeded = vec![
+            Message::text("user", "old-user-1"),
+            Message::text("assistant", "old-assistant-1"),
+            Message::text("user", "old-user-2"),
+            Message::text("assistant", "old-assistant-2"),
+        ];
+        let seeded_json = serde_json::to_string(&seeded).expect("seeded json");
+        call_blocking(Arc::clone(&state.db), move |db| {
+            db.save_session(chat_id, &seeded_json)
+        })
+        .await
+        .expect("save session");
+
+        let reply = process_turn(&state, &context, "fresh question")
+            .await
+            .expect("process turn");
+        assert_eq!(reply, "final answer");
+
+        let summary = call_blocking(Arc::clone(&state.db), move |db| {
+            db.get_llm_usage_summary(Some(chat_id), None)
+        })
+        .await
+        .expect("summary");
+
+        assert_eq!(
+            summary.requests, 1,
+            "compaction LLM call should be logged once"
+        );
+        assert_eq!(summary.input_tokens, 100);
+        assert_eq!(summary.output_tokens, 200);
+        assert_eq!(summary.total_tokens, 300);
     }
 }

--- a/egopulse/src/agent_loop/compaction.rs
+++ b/egopulse/src/agent_loop/compaction.rs
@@ -91,19 +91,21 @@ async fn summarize_and_compact(
                 let model = llm.model_name().to_string();
                 let input_tokens = usage.input_tokens;
                 let output_tokens = usage.output_tokens;
-                let _ = crate::storage::call_blocking(db, move |db| {
-                    db.log_llm_usage(&crate::storage::LlmUsageLogEntry {
-                        chat_id,
-                        caller_channel: &channel,
-                        provider: &provider,
-                        model: &model,
-                        input_tokens,
-                        output_tokens,
-                        request_kind: "summarize",
+                tokio::spawn(async move {
+                    let _ = crate::storage::call_blocking(db, move |db| {
+                        db.log_llm_usage(&crate::storage::LlmUsageLogEntry {
+                            chat_id,
+                            caller_channel: &channel,
+                            provider: &provider,
+                            model: &model,
+                            input_tokens,
+                            output_tokens,
+                            request_kind: "summarize",
+                        })
                     })
-                })
-                .await
-                .inspect_err(|e| warn!(error = %e, "llm usage logging failed"));
+                    .await
+                    .inspect_err(|e| warn!(error = %e, "llm usage logging failed"));
+                });
             }
             strip_thinking(&response.content)
         }
@@ -661,18 +663,24 @@ mod tests {
             .expect("process turn");
         assert_eq!(reply, "final answer");
 
-        let summary = call_blocking(Arc::clone(&state.db), move |db| {
-            db.get_llm_usage_summary(Some(chat_id), None)
-        })
-        .await
-        .expect("summary");
-
-        assert_eq!(
-            summary.requests, 1,
-            "compaction LLM call should be logged once"
-        );
-        assert_eq!(summary.input_tokens, 100);
-        assert_eq!(summary.output_tokens, 200);
-        assert_eq!(summary.total_tokens, 300);
+        for _ in 0..20 {
+            let summary = call_blocking(Arc::clone(&state.db), move |db| {
+                db.get_llm_usage_summary(Some(chat_id), None, None)
+            })
+            .await
+            .expect("summary");
+            if summary.requests > 0 {
+                assert_eq!(
+                    summary.requests, 1,
+                    "compaction LLM call should be logged once"
+                );
+                assert_eq!(summary.input_tokens, 100);
+                assert_eq!(summary.output_tokens, 200);
+                assert_eq!(summary.total_tokens, 300);
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!("compaction usage log was not written within the polling timeout");
     }
 }

--- a/egopulse/src/agent_loop/guards.rs
+++ b/egopulse/src/agent_loop/guards.rs
@@ -105,10 +105,12 @@ mod tests {
                     MessagesResponse {
                         content: String::new(),
                         tool_calls: Vec::new(),
+                        usage: None,
                     },
                     MessagesResponse {
                         content: String::new(),
                         tool_calls: Vec::new(),
+                        usage: None,
                     },
                 ]),
             }),
@@ -131,10 +133,12 @@ mod tests {
                     MessagesResponse {
                         content: "Sure, I'll help you with that.".to_string(),
                         tool_calls: Vec::new(),
+                        usage: None,
                     },
                     MessagesResponse {
                         content: "Here is the answer you need.".to_string(),
                         tool_calls: Vec::new(),
+                        usage: None,
                     },
                 ]),
             }),
@@ -181,10 +185,12 @@ mod tests {
                             name: String::new(),
                             arguments: serde_json::json!({}),
                         }],
+                        usage: None,
                     },
                     MessagesResponse {
                         content: "実行結果です。".to_string(),
                         tool_calls: Vec::new(),
+                        usage: None,
                     },
                 ]),
             }),

--- a/egopulse/src/agent_loop/session.rs
+++ b/egopulse/src/agent_loop/session.rs
@@ -400,6 +400,14 @@ mod tests {
 
     #[async_trait]
     impl LlmProvider for FakeProvider {
+        fn provider_name(&self) -> &str {
+            "test"
+        }
+
+        fn model_name(&self) -> &str {
+            "test-model"
+        }
+
         async fn send_message(
             &self,
             _system: &str,
@@ -414,6 +422,7 @@ mod tests {
             Ok(MessagesResponse {
                 content: format!("{} [{prompt}]", self.response),
                 tool_calls: Vec::new(),
+                usage: None,
             })
         }
     }

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -151,6 +151,28 @@ where
                 warn!(error = %e, iteration, "LLM send_message failed");
             })?;
 
+        if let Some(usage) = &response.usage {
+            let db = Arc::clone(&state.db);
+            let channel = context.channel.clone();
+            let provider = channel_llm.provider_name().to_string();
+            let model = channel_llm.model_name().to_string();
+            let input_tokens = usage.input_tokens;
+            let output_tokens = usage.output_tokens;
+            let _ = call_blocking(db, move |db| {
+                db.log_llm_usage(&crate::storage::LlmUsageLogEntry {
+                    chat_id,
+                    caller_channel: &channel,
+                    provider: &provider,
+                    model: &model,
+                    input_tokens,
+                    output_tokens,
+                    request_kind: "agent_loop",
+                })
+            })
+            .await
+            .inspect_err(|e| warn!(error = %e, "llm usage logging failed"));
+        }
+
         if response.tool_calls.is_empty() {
             if let Some(final_content) = run_turn_action(
                 evaluate_end_turn(
@@ -759,6 +781,14 @@ impl crate::llm::LlmProvider for FakeProvider {
         let mut locked = self.responses.lock().expect("responses");
         Ok(locked.remove(0))
     }
+
+    fn provider_name(&self) -> &str {
+        "test"
+    }
+
+    fn model_name(&self) -> &str {
+        "test-model"
+    }
 }
 
 #[cfg(test)]
@@ -771,6 +801,14 @@ impl crate::llm::LlmProvider for FailingProvider {
         _tools: Option<Vec<crate::llm::ToolDefinition>>,
     ) -> Result<crate::llm::MessagesResponse, crate::error::LlmError> {
         Err(crate::error::LlmError::InvalidResponse("boom".to_string()))
+    }
+
+    fn provider_name(&self) -> &str {
+        "test"
+    }
+
+    fn model_name(&self) -> &str {
+        "test-model"
     }
 }
 
@@ -793,6 +831,14 @@ impl crate::llm::LlmProvider for RecordingProvider {
             tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
         }
         self.responses.lock().expect("responses").remove(0)
+    }
+
+    fn provider_name(&self) -> &str {
+        "test"
+    }
+
+    fn model_name(&self) -> &str {
+        "test-model"
     }
 }
 
@@ -966,10 +1012,12 @@ mod tests {
                         name: "read".to_string(),
                         arguments: serde_json::json!({"path": relative_path}),
                     }],
+                    usage: None,
                 }),
                 Ok(MessagesResponse {
                     content: "All set".to_string(),
                     tool_calls: Vec::new(),
+                    usage: None,
                 }),
             ],
             vec![0, 0],
@@ -1058,10 +1106,12 @@ mod tests {
                             name: "read".to_string(),
                             arguments: serde_json::json!({"path": relative_path}),
                         }],
+                        usage: None,
                     },
                     MessagesResponse {
                         content: "Done reading. Final answer.".to_string(),
                         tool_calls: Vec::new(),
+                        usage: None,
                     },
                 ]),
             }),
@@ -1096,6 +1146,7 @@ mod tests {
                         name: String::new(),
                         arguments: serde_json::json!({}),
                     }],
+                    usage: None,
                 }]),
             }),
         );
@@ -1334,5 +1385,157 @@ mod tests {
         Box::new(FakeProvider {
             responses: std::sync::Mutex::new(vec![]),
         })
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn process_turn_logs_llm_usage_on_agent_loop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::new(
+            vec![Ok(MessagesResponse {
+                content: "hello world".to_string(),
+                tool_calls: vec![],
+                usage: Some(crate::llm::LlmUsage {
+                    input_tokens: 10,
+                    output_tokens: 20,
+                }),
+            })],
+            vec![0],
+        );
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(provider),
+        );
+
+        let reply = process_turn(&state, &cli_context("usage-log-single"), "hi")
+            .await
+            .expect("process turn");
+        assert_eq!(reply, "hello world");
+
+        let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
+            db.resolve_or_create_chat_id(
+                "cli",
+                "cli:usage-log-single",
+                Some("usage-log-single"),
+                "cli",
+            )
+        })
+        .await
+        .expect("chat id");
+
+        let summary = call_blocking(Arc::clone(&state.db), move |db| {
+            db.get_llm_usage_summary(Some(chat_id), None)
+        })
+        .await
+        .expect("summary");
+
+        assert_eq!(summary.requests, 1);
+        assert_eq!(summary.input_tokens, 10);
+        assert_eq!(summary.output_tokens, 20);
+        assert_eq!(summary.total_tokens, 30);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn process_turn_logs_each_iteration() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let relative_path = format!("tests/{}/data.txt", uuid::Uuid::new_v4());
+        let provider = RecordingProvider::new(
+            vec![
+                Ok(MessagesResponse {
+                    content: "checking".to_string(),
+                    tool_calls: vec![ToolCall {
+                        id: "call-iter-1".to_string(),
+                        name: "read".to_string(),
+                        arguments: serde_json::json!({"path": relative_path}),
+                    }],
+                    usage: Some(crate::llm::LlmUsage {
+                        input_tokens: 15,
+                        output_tokens: 25,
+                    }),
+                }),
+                Ok(MessagesResponse {
+                    content: "done".to_string(),
+                    tool_calls: vec![],
+                    usage: Some(crate::llm::LlmUsage {
+                        input_tokens: 30,
+                        output_tokens: 40,
+                    }),
+                }),
+            ],
+            vec![0, 0],
+        );
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(provider.clone()),
+        );
+        let workspace = state.config.workspace_dir().expect("workspace_dir");
+        let file_path = workspace.join(&relative_path);
+        std::fs::create_dir_all(file_path.parent().expect("parent")).expect("dirs");
+        std::fs::write(&file_path, "data").expect("file");
+
+        let reply = process_turn(&state, &cli_context("usage-log-multi"), "read the file")
+            .await
+            .expect("process turn");
+        assert_eq!(reply, "done");
+
+        let chat_id = call_blocking(Arc::clone(&state.db), move |db| {
+            db.resolve_or_create_chat_id(
+                "cli",
+                "cli:usage-log-multi",
+                Some("usage-log-multi"),
+                "cli",
+            )
+        })
+        .await
+        .expect("chat id");
+
+        let summary = call_blocking(Arc::clone(&state.db), move |db| {
+            db.get_llm_usage_summary(Some(chat_id), None)
+        })
+        .await
+        .expect("summary");
+
+        assert_eq!(
+            summary.requests, 2,
+            "should have 2 usage records (one per iteration)"
+        );
+        assert_eq!(summary.input_tokens, 45);
+        assert_eq!(summary.output_tokens, 65);
+        assert_eq!(summary.total_tokens, 110);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn usage_not_logged_when_response_has_no_usage() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::new(
+            vec![Ok(MessagesResponse {
+                content: "no usage info".to_string(),
+                tool_calls: vec![],
+                usage: None,
+            })],
+            vec![0],
+        );
+        let state = build_state_with_provider(
+            dir.path().to_str().expect("utf8").to_string(),
+            Box::new(provider),
+        );
+
+        let reply = process_turn(&state, &cli_context("no-usage"), "hi")
+            .await
+            .expect("process turn");
+        assert_eq!(reply, "no usage info");
+
+        let summary = call_blocking(Arc::clone(&state.db), move |db| {
+            db.get_llm_usage_summary(None, None)
+        })
+        .await
+        .expect("summary");
+
+        assert_eq!(
+            summary.requests, 0,
+            "no usage records should exist when response has no usage"
+        );
     }
 }

--- a/egopulse/src/agent_loop/turn.rs
+++ b/egopulse/src/agent_loop/turn.rs
@@ -158,19 +158,21 @@ where
             let model = channel_llm.model_name().to_string();
             let input_tokens = usage.input_tokens;
             let output_tokens = usage.output_tokens;
-            let _ = call_blocking(db, move |db| {
-                db.log_llm_usage(&crate::storage::LlmUsageLogEntry {
-                    chat_id,
-                    caller_channel: &channel,
-                    provider: &provider,
-                    model: &model,
-                    input_tokens,
-                    output_tokens,
-                    request_kind: "agent_loop",
+            tokio::spawn(async move {
+                let _ = call_blocking(db, move |db| {
+                    db.log_llm_usage(&crate::storage::LlmUsageLogEntry {
+                        chat_id,
+                        caller_channel: &channel,
+                        provider: &provider,
+                        model: &model,
+                        input_tokens,
+                        output_tokens,
+                        request_kind: "agent_loop",
+                    })
                 })
-            })
-            .await
-            .inspect_err(|e| warn!(error = %e, "llm usage logging failed"));
+                .await
+                .inspect_err(|e| warn!(error = %e, "llm usage logging failed"));
+            });
         }
 
         if response.tool_calls.is_empty() {
@@ -1423,16 +1425,23 @@ mod tests {
         .await
         .expect("chat id");
 
-        let summary = call_blocking(Arc::clone(&state.db), move |db| {
-            db.get_llm_usage_summary(Some(chat_id), None)
-        })
-        .await
-        .expect("summary");
-
-        assert_eq!(summary.requests, 1);
-        assert_eq!(summary.input_tokens, 10);
-        assert_eq!(summary.output_tokens, 20);
-        assert_eq!(summary.total_tokens, 30);
+        // Wait for the spawned logging task to complete
+        for _ in 0..20 {
+            let summary = call_blocking(Arc::clone(&state.db), move |db| {
+                db.get_llm_usage_summary(Some(chat_id), None, None)
+            })
+            .await
+            .expect("summary");
+            if summary.requests > 0 {
+                assert_eq!(summary.requests, 1);
+                assert_eq!(summary.input_tokens, 10);
+                assert_eq!(summary.output_tokens, 20);
+                assert_eq!(summary.total_tokens, 30);
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!("usage log was not written within the polling timeout");
     }
 
     #[tokio::test]
@@ -1490,19 +1499,25 @@ mod tests {
         .await
         .expect("chat id");
 
-        let summary = call_blocking(Arc::clone(&state.db), move |db| {
-            db.get_llm_usage_summary(Some(chat_id), None)
-        })
-        .await
-        .expect("summary");
-
-        assert_eq!(
-            summary.requests, 2,
-            "should have 2 usage records (one per iteration)"
-        );
-        assert_eq!(summary.input_tokens, 45);
-        assert_eq!(summary.output_tokens, 65);
-        assert_eq!(summary.total_tokens, 110);
+        for _ in 0..20 {
+            let summary = call_blocking(Arc::clone(&state.db), move |db| {
+                db.get_llm_usage_summary(Some(chat_id), None, None)
+            })
+            .await
+            .expect("summary");
+            if summary.requests >= 2 {
+                assert_eq!(
+                    summary.requests, 2,
+                    "should have 2 usage records (one per iteration)"
+                );
+                assert_eq!(summary.input_tokens, 45);
+                assert_eq!(summary.output_tokens, 65);
+                assert_eq!(summary.total_tokens, 110);
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!("usage logs were not written within the polling timeout");
     }
 
     #[tokio::test]
@@ -1527,8 +1542,10 @@ mod tests {
             .expect("process turn");
         assert_eq!(reply, "no usage info");
 
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
         let summary = call_blocking(Arc::clone(&state.db), move |db| {
-            db.get_llm_usage_summary(None, None)
+            db.get_llm_usage_summary(None, None, None)
         })
         .await
         .expect("summary");

--- a/egopulse/src/llm/mod.rs
+++ b/egopulse/src/llm/mod.rs
@@ -130,16 +130,27 @@ impl Message {
     }
 }
 
+/// LLM API レスポンスに含まれるトークン使用量。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LlmUsage {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+}
+
 /// Parsed response from the LLM containing text and/or tool calls.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MessagesResponse {
     pub content: String,
     pub tool_calls: Vec<ToolCall>,
+    pub usage: Option<LlmUsage>,
 }
 
 /// Trait for LLM providers supporting non-streaming and streaming message sending.
 #[async_trait]
 pub trait LlmProvider: Send + Sync {
+    fn provider_name(&self) -> &str;
+    fn model_name(&self) -> &str;
+
     async fn send_message(
         &self,
         system: &str,
@@ -494,5 +505,101 @@ mod tests {
         let blocks = extract_raw_tool_use_blocks(text).unwrap();
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].name, "bash");
+    }
+
+    #[test]
+    fn parse_openai_response_extracts_usage() {
+        let body: super::OpenAiResponse = serde_json::from_value(serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "hello",
+                    "tool_calls": null
+                }
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 20
+            }
+        }))
+        .unwrap();
+
+        let response = super::parse_openai_response(body).unwrap();
+        assert_eq!(
+            response.usage,
+            Some(super::LlmUsage {
+                input_tokens: 10,
+                output_tokens: 20,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_openai_response_handles_missing_usage() {
+        let body: super::OpenAiResponse = serde_json::from_value(serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "hello",
+                    "tool_calls": null
+                }
+            }]
+        }))
+        .unwrap();
+
+        let response = super::parse_openai_response(body).unwrap();
+        assert_eq!(response.usage, None);
+    }
+
+    #[test]
+    fn parse_responses_api_extracts_usage() {
+        let body: super::ResponsesApiResponse = serde_json::from_value(serde_json::json!({
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hi"}]
+            }],
+            "usage": {
+                "input_tokens": 15,
+                "output_tokens": 25
+            }
+        }))
+        .unwrap();
+
+        let response = super::parse_responses_response(body).unwrap();
+        assert_eq!(
+            response.usage,
+            Some(super::LlmUsage {
+                input_tokens: 15,
+                output_tokens: 25,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_responses_api_handles_missing_usage() {
+        let body: super::ResponsesApiResponse = serde_json::from_value(serde_json::json!({
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hi"}]
+            }]
+        }))
+        .unwrap();
+
+        let response = super::parse_responses_response(body).unwrap();
+        assert_eq!(response.usage, None);
+    }
+
+    #[tokio::test]
+    async fn llm_provider_metadata_returns_config() {
+        let server = wiremock::MockServer::start().await;
+        let provider = create_provider(&config(
+            "gpt-4o-mini",
+            format!("{}/v1", server.uri()),
+            Some("sk-test"),
+        ))
+        .expect("provider");
+
+        assert_eq!(provider.provider_name(), "openai");
+        assert_eq!(provider.model_name(), "gpt-4o-mini");
     }
 }

--- a/egopulse/src/llm/mod.rs
+++ b/egopulse/src/llm/mod.rs
@@ -589,6 +589,43 @@ mod tests {
         assert_eq!(response.usage, None);
     }
 
+    #[test]
+    fn parse_openai_response_handles_partial_usage() {
+        let body: super::OpenAiResponse = serde_json::from_value(serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "hello",
+                    "tool_calls": null
+                }
+            }],
+            "usage": {
+                "prompt_tokens": 10
+            }
+        }))
+        .unwrap();
+
+        let response = super::parse_openai_response(body).unwrap();
+        assert_eq!(response.usage, None);
+    }
+
+    #[test]
+    fn parse_responses_api_handles_partial_usage() {
+        let body: super::ResponsesApiResponse = serde_json::from_value(serde_json::json!({
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hi"}]
+            }],
+            "usage": {
+                "input_tokens": 15
+            }
+        }))
+        .unwrap();
+
+        let response = super::parse_responses_response(body).unwrap();
+        assert_eq!(response.usage, None);
+    }
+
     #[tokio::test]
     async fn llm_provider_metadata_returns_config() {
         let server = wiremock::MockServer::start().await;
@@ -599,7 +636,7 @@ mod tests {
         ))
         .expect("provider");
 
-        assert_eq!(provider.provider_name(), "openai");
+        assert_eq!(provider.provider_name(), "test");
         assert_eq!(provider.model_name(), "gpt-4o-mini");
     }
 }

--- a/egopulse/src/llm/openai.rs
+++ b/egopulse/src/llm/openai.rs
@@ -102,6 +102,14 @@ impl OpenAiProvider {
 
 #[async_trait]
 impl LlmProvider for OpenAiProvider {
+    fn provider_name(&self) -> &str {
+        "openai"
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+
     async fn send_message(
         &self,
         system: &str,
@@ -232,6 +240,7 @@ impl LlmProvider for OpenAiProvider {
         Ok(MessagesResponse {
             content: text,
             tool_calls: Vec::new(),
+            usage: None,
         })
     }
 }

--- a/egopulse/src/llm/openai.rs
+++ b/egopulse/src/llm/openai.rs
@@ -8,6 +8,7 @@ pub(crate) struct OpenAiProvider {
     api_key: Option<String>,
     model: String,
     base_url: String,
+    provider: String,
 }
 
 impl OpenAiProvider {
@@ -28,6 +29,7 @@ impl OpenAiProvider {
                 .map(|key| key.expose_secret().to_string()),
             model: config.model.clone(),
             base_url: config.base_url.clone(),
+            provider: config.provider.clone(),
         })
     }
 
@@ -103,7 +105,7 @@ impl OpenAiProvider {
 #[async_trait]
 impl LlmProvider for OpenAiProvider {
     fn provider_name(&self) -> &str {
-        "openai"
+        &self.provider
     }
 
     fn model_name(&self) -> &str {

--- a/egopulse/src/llm/responses.rs
+++ b/egopulse/src/llm/responses.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 pub(crate) fn parse_openai_response(body: OpenAiResponse) -> Result<MessagesResponse, LlmError> {
+    let usage = body.usage;
     let choice = body
         .choices
         .into_iter()
@@ -37,12 +38,17 @@ pub(crate) fn parse_openai_response(body: OpenAiResponse) -> Result<MessagesResp
     Ok(MessagesResponse {
         content,
         tool_calls,
+        usage: usage.map(|u| LlmUsage {
+            input_tokens: u.prompt_tokens,
+            output_tokens: u.completion_tokens,
+        }),
     })
 }
 
 pub(crate) fn parse_responses_response(
     body: ResponsesApiResponse,
 ) -> Result<MessagesResponse, LlmError> {
+    let usage = body.usage;
     let mut content_parts = Vec::new();
     let mut tool_calls = Vec::new();
 
@@ -89,6 +95,10 @@ pub(crate) fn parse_responses_response(
     Ok(MessagesResponse {
         content,
         tool_calls,
+        usage: usage.map(|u| LlmUsage {
+            input_tokens: u.input_tokens,
+            output_tokens: u.output_tokens,
+        }),
     })
 }
 
@@ -365,11 +375,27 @@ pub(crate) fn find_raw_tool_use_end(text: &str) -> Option<usize> {
 #[derive(Debug, Deserialize)]
 pub(crate) struct OpenAiResponse {
     pub(crate) choices: Vec<Choice>,
+    #[serde(default)]
+    pub(crate) usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiUsage {
+    pub(crate) prompt_tokens: i64,
+    pub(crate) completion_tokens: i64,
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct ResponsesApiResponse {
     pub(crate) output: Vec<ResponsesOutputItem>,
+    #[serde(default)]
+    pub(crate) usage: Option<ResponsesApiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ResponsesApiUsage {
+    pub(crate) input_tokens: i64,
+    pub(crate) output_tokens: i64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/egopulse/src/llm/responses.rs
+++ b/egopulse/src/llm/responses.rs
@@ -38,9 +38,13 @@ pub(crate) fn parse_openai_response(body: OpenAiResponse) -> Result<MessagesResp
     Ok(MessagesResponse {
         content,
         tool_calls,
-        usage: usage.map(|u| LlmUsage {
-            input_tokens: u.prompt_tokens,
-            output_tokens: u.completion_tokens,
+        usage: usage.and_then(|u| {
+            u.prompt_tokens
+                .zip(u.completion_tokens)
+                .map(|(pt, ct)| LlmUsage {
+                    input_tokens: pt,
+                    output_tokens: ct,
+                })
         }),
     })
 }
@@ -95,9 +99,13 @@ pub(crate) fn parse_responses_response(
     Ok(MessagesResponse {
         content,
         tool_calls,
-        usage: usage.map(|u| LlmUsage {
-            input_tokens: u.input_tokens,
-            output_tokens: u.output_tokens,
+        usage: usage.and_then(|u| {
+            u.input_tokens
+                .zip(u.output_tokens)
+                .map(|(it, ot)| LlmUsage {
+                    input_tokens: it,
+                    output_tokens: ot,
+                })
         }),
     })
 }
@@ -381,8 +389,10 @@ pub(crate) struct OpenAiResponse {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct OpenAiUsage {
-    pub(crate) prompt_tokens: i64,
-    pub(crate) completion_tokens: i64,
+    #[serde(default)]
+    pub(crate) prompt_tokens: Option<i64>,
+    #[serde(default)]
+    pub(crate) completion_tokens: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -394,8 +404,10 @@ pub(crate) struct ResponsesApiResponse {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct ResponsesApiUsage {
-    pub(crate) input_tokens: i64,
-    pub(crate) output_tokens: i64,
+    #[serde(default)]
+    pub(crate) input_tokens: Option<i64>,
+    #[serde(default)]
+    pub(crate) output_tokens: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/egopulse/src/slash_commands.rs
+++ b/egopulse/src/slash_commands.rs
@@ -391,6 +391,14 @@ mod tests {
 
     #[async_trait]
     impl LlmProvider for NoOpProvider {
+        fn provider_name(&self) -> &str {
+            "test"
+        }
+
+        fn model_name(&self) -> &str {
+            "test-model"
+        }
+
         async fn send_message(
             &self,
             _system: &str,
@@ -400,6 +408,7 @@ mod tests {
             Ok(MessagesResponse {
                 content: "summary".to_string(),
                 tool_calls: Vec::new(),
+                usage: None,
             })
         }
     }

--- a/egopulse/src/storage.rs
+++ b/egopulse/src/storage.rs
@@ -765,11 +765,12 @@ impl Database {
 
     /// LLM使用量の集計サマリを取得する。
     ///
-    /// `chat_id` と `since` でフィルタリング可能。
+    /// `chat_id`, `since`, `request_kind` でフィルタリング可能。
     pub fn get_llm_usage_summary(
         &self,
         chat_id: Option<i64>,
         since: Option<&str>,
+        request_kind: Option<&str>,
     ) -> Result<LlmUsageSummary, StorageError> {
         let conn = self.lock_conn()?;
 
@@ -788,8 +789,15 @@ impl Database {
             param_values.push(Box::new(cid));
         }
         if let Some(s) = since {
+            let normalized = chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc).to_rfc3339())
+                .unwrap_or_else(|_| s.to_string());
             sql.push_str(" AND created_at >= ?");
-            param_values.push(Box::new(s.to_string()));
+            param_values.push(Box::new(normalized));
+        }
+        if let Some(kind) = request_kind {
+            sql.push_str(" AND request_kind = ?");
+            param_values.push(Box::new(kind.to_string()));
         }
 
         let params_refs: Vec<&dyn rusqlite::types::ToSql> =
@@ -820,11 +828,12 @@ impl Database {
 
     /// モデル別のLLM使用量サマリを取得する。
     ///
-    /// `total_tokens` の降順で返す。`chat_id` と `since` でフィルタリング可能。
+    /// `total_tokens` の降順で返す。`chat_id`, `since`, `request_kind` でフィルタリング可能。
     pub fn get_llm_usage_by_model(
         &self,
         chat_id: Option<i64>,
         since: Option<&str>,
+        request_kind: Option<&str>,
     ) -> Result<Vec<LlmModelUsageSummary>, StorageError> {
         let conn = self.lock_conn()?;
 
@@ -843,8 +852,15 @@ impl Database {
             param_values.push(Box::new(cid));
         }
         if let Some(s) = since {
+            let normalized = chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc).to_rfc3339())
+                .unwrap_or_else(|_| s.to_string());
             sql.push_str(" AND created_at >= ?");
-            param_values.push(Box::new(s.to_string()));
+            param_values.push(Box::new(normalized));
+        }
+        if let Some(kind) = request_kind {
+            sql.push_str(" AND request_kind = ?");
+            param_values.push(Box::new(kind.to_string()));
         }
 
         sql.push_str(" GROUP BY model ORDER BY total_tokens DESC");
@@ -1241,7 +1257,7 @@ mod tests {
     fn get_llm_usage_summary_returns_zeros_when_empty() {
         let (db, _dir) = test_db();
 
-        let summary = db.get_llm_usage_summary(None, None).expect("summary");
+        let summary = db.get_llm_usage_summary(None, None, None).expect("summary");
 
         assert_eq!(summary.requests, 0);
         assert_eq!(summary.input_tokens, 0);
@@ -1285,7 +1301,7 @@ mod tests {
         })
         .expect("log 3");
 
-        let summary = db.get_llm_usage_summary(None, None).expect("summary");
+        let summary = db.get_llm_usage_summary(None, None, None).expect("summary");
 
         assert_eq!(summary.requests, 3);
         assert_eq!(summary.input_tokens, 600);
@@ -1319,7 +1335,9 @@ mod tests {
         })
         .expect("log 2");
 
-        let summary = db.get_llm_usage_summary(Some(100), None).expect("summary");
+        let summary = db
+            .get_llm_usage_summary(Some(100), None, None)
+            .expect("summary");
 
         assert_eq!(summary.requests, 1);
         assert_eq!(summary.input_tokens, 100);
@@ -1355,7 +1373,7 @@ mod tests {
         .expect("log 2");
 
         let summary = db
-            .get_llm_usage_summary(None, Some(&cutoff))
+            .get_llm_usage_summary(None, Some(&cutoff), None)
             .expect("summary");
 
         assert_eq!(summary.requests, 1);
@@ -1401,7 +1419,7 @@ mod tests {
         .expect("log 3");
 
         let summary = db
-            .get_llm_usage_summary(Some(100), Some(&cutoff))
+            .get_llm_usage_summary(Some(100), Some(&cutoff), None)
             .expect("summary");
 
         assert_eq!(summary.requests, 1);
@@ -1443,7 +1461,7 @@ mod tests {
         })
         .expect("log 3");
 
-        let models = db.get_llm_usage_by_model(None, None).expect("models");
+        let models = db.get_llm_usage_by_model(None, None, None).expect("models");
 
         assert_eq!(models.len(), 2);
         let gpt4 = models.iter().find(|m| m.model == "gpt-4").expect("gpt-4");
@@ -1484,7 +1502,7 @@ mod tests {
         })
         .expect("log 2");
 
-        let models = db.get_llm_usage_by_model(None, None).expect("models");
+        let models = db.get_llm_usage_by_model(None, None, None).expect("models");
 
         assert_eq!(models.len(), 2);
         assert!(

--- a/egopulse/src/storage.rs
+++ b/egopulse/src/storage.rs
@@ -67,6 +67,37 @@ pub struct ToolCall {
     pub timestamp: String,
 }
 
+/// LLM使用量ログの記録用データ。
+pub struct LlmUsageLogEntry<'a> {
+    pub chat_id: i64,
+    pub caller_channel: &'a str,
+    pub provider: &'a str,
+    pub model: &'a str,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub request_kind: &'a str,
+}
+
+/// LLM使用量の集計サマリ。
+#[derive(Debug, PartialEq)]
+pub struct LlmUsageSummary {
+    pub requests: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub total_tokens: i64,
+    pub last_request_at: Option<String>,
+}
+
+/// モデル別のLLM使用量サマリ。
+#[derive(Debug, PartialEq)]
+pub struct LlmModelUsageSummary {
+    pub model: String,
+    pub requests: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub total_tokens: i64,
+}
+
 /// Run a blocking database operation on a tokio blocking thread.
 pub async fn call_blocking<T, F>(db: Arc<Database>, f: F) -> Result<T, StorageError>
 where
@@ -82,7 +113,7 @@ where
 ///
 /// 新しいマイグレーションを追加する際はこの値をインクリメントし、
 /// `run_migrations` に対応する `if version < N` ブロックを追加する。
-const SCHEMA_VERSION: i64 = 1;
+const SCHEMA_VERSION: i64 = 2;
 
 impl Database {
     /// Open (or create) the database at `db_path` and initialize schema.
@@ -239,12 +270,30 @@ fn run_migrations(conn: &Connection) -> Result<(), StorageError> {
         version = 1;
     }
 
-    // --- v2 以降のマイグレーションはここに追加 ---
-    // if version < 2 {
-    //     conn.execute_batch("...")?;
-    //     set_schema_version(conn, 2, "...")?;
-    //     version = 2;
-    // }
+    if version < 2 {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS llm_usage_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id INTEGER NOT NULL,
+                caller_channel TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                model TEXT NOT NULL,
+                input_tokens INTEGER NOT NULL,
+                output_tokens INTEGER NOT NULL,
+                total_tokens INTEGER NOT NULL,
+                request_kind TEXT NOT NULL DEFAULT 'agent_loop',
+                created_at TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_llm_usage_chat_created
+                ON llm_usage_logs(chat_id, created_at);
+
+            CREATE INDEX IF NOT EXISTS idx_llm_usage_created
+                ON llm_usage_logs(created_at);",
+        )?;
+        set_schema_version(conn, 2, "add llm_usage_logs table for LLM usage tracking")?;
+        version = 2;
+    }
 
     debug_assert_eq!(version, SCHEMA_VERSION, "all migrations applied");
     Ok(())
@@ -689,6 +738,135 @@ impl Database {
 
         Ok(calls)
     }
+
+    /// LLM使用量ログを記録し、挿入された行IDを返す。
+    pub fn log_llm_usage(&self, entry: &LlmUsageLogEntry<'_>) -> Result<i64, StorageError> {
+        let conn = self.lock_conn()?;
+        let total_tokens = entry.input_tokens.saturating_add(entry.output_tokens);
+        let created_at = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO llm_usage_logs
+                (chat_id, caller_channel, provider, model, input_tokens, output_tokens, total_tokens, request_kind, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                entry.chat_id,
+                entry.caller_channel,
+                entry.provider,
+                entry.model,
+                entry.input_tokens,
+                entry.output_tokens,
+                total_tokens,
+                entry.request_kind,
+                created_at,
+            ],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    /// LLM使用量の集計サマリを取得する。
+    ///
+    /// `chat_id` と `since` でフィルタリング可能。
+    pub fn get_llm_usage_summary(
+        &self,
+        chat_id: Option<i64>,
+        since: Option<&str>,
+    ) -> Result<LlmUsageSummary, StorageError> {
+        let conn = self.lock_conn()?;
+
+        let mut sql = String::from(
+            "SELECT COUNT(*) as requests,
+                    COALESCE(SUM(input_tokens), 0) as input_tokens,
+                    COALESCE(SUM(output_tokens), 0) as output_tokens,
+                    COALESCE(SUM(total_tokens), 0) as total_tokens,
+                    MAX(created_at) as last_request_at
+             FROM llm_usage_logs WHERE 1=1",
+        );
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        if let Some(cid) = chat_id {
+            sql.push_str(" AND chat_id = ?");
+            param_values.push(Box::new(cid));
+        }
+        if let Some(s) = since {
+            sql.push_str(" AND created_at >= ?");
+            param_values.push(Box::new(s.to_string()));
+        }
+
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|p| p.as_ref()).collect();
+
+        let result = conn.query_row(&sql, params_refs.as_slice(), |row| {
+            Ok(LlmUsageSummary {
+                requests: row.get(0)?,
+                input_tokens: row.get(1)?,
+                output_tokens: row.get(2)?,
+                total_tokens: row.get(3)?,
+                last_request_at: row.get(4)?,
+            })
+        });
+
+        match result {
+            Ok(summary) => Ok(summary),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(LlmUsageSummary {
+                requests: 0,
+                input_tokens: 0,
+                output_tokens: 0,
+                total_tokens: 0,
+                last_request_at: None,
+            }),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// モデル別のLLM使用量サマリを取得する。
+    ///
+    /// `total_tokens` の降順で返す。`chat_id` と `since` でフィルタリング可能。
+    pub fn get_llm_usage_by_model(
+        &self,
+        chat_id: Option<i64>,
+        since: Option<&str>,
+    ) -> Result<Vec<LlmModelUsageSummary>, StorageError> {
+        let conn = self.lock_conn()?;
+
+        let mut sql = String::from(
+            "SELECT model,
+                    COUNT(*) as requests,
+                    COALESCE(SUM(input_tokens), 0) as input_tokens,
+                    COALESCE(SUM(output_tokens), 0) as output_tokens,
+                    COALESCE(SUM(total_tokens), 0) as total_tokens
+             FROM llm_usage_logs WHERE 1=1",
+        );
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        if let Some(cid) = chat_id {
+            sql.push_str(" AND chat_id = ?");
+            param_values.push(Box::new(cid));
+        }
+        if let Some(s) = since {
+            sql.push_str(" AND created_at >= ?");
+            param_values.push(Box::new(s.to_string()));
+        }
+
+        sql.push_str(" GROUP BY model ORDER BY total_tokens DESC");
+
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|p| p.as_ref()).collect();
+
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params_refs.as_slice(), |row| {
+                Ok(LlmModelUsageSummary {
+                    model: row.get(0)?,
+                    requests: row.get(1)?,
+                    input_tokens: row.get(2)?,
+                    output_tokens: row.get(3)?,
+                    total_tokens: row.get(4)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(rows)
+    }
 }
 
 // セッション一覧の表示名: chat_title → external_chat_id のチャネルプレフィクス除去 → そのまま
@@ -716,7 +894,8 @@ fn logical_session_thread(
 mod tests {
     use crate::error::StorageError;
 
-    use super::{Database, StoredMessage, ToolCall};
+    use super::{Database, LlmUsageLogEntry, StoredMessage, ToolCall};
+    use rusqlite::Connection;
 
     fn test_db() -> (Database, tempfile::TempDir) {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -966,7 +1145,7 @@ mod tests {
     fn schema_version_is_tracked_on_init() {
         let (db, _dir) = test_db();
         let version = db.schema_version().expect("schema version");
-        assert_eq!(version, 1, "新規DBはスキーマバージョン1で初期化される");
+        assert_eq!(version, 2, "新規DBはスキーマバージョン2で初期化される");
     }
 
     #[test]
@@ -984,9 +1163,11 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .expect("collect");
 
-        assert_eq!(rows.len(), 1, "v1 マイグレーションが1件記録される");
+        assert_eq!(rows.len(), 2, "v1・v2 マイグレーションが2件記録される");
         assert_eq!(rows[0].0, 1);
         assert!(rows[0].1.contains("initial schema"));
+        assert_eq!(rows[1].0, 2);
+        assert!(rows[1].1.contains("llm_usage_logs"));
     }
 
     #[test]
@@ -1006,6 +1187,386 @@ mod tests {
             first_version, second_version,
             "再起動してもバージョンは変わらない"
         );
-        assert_eq!(second_version, 1);
+        assert_eq!(second_version, 2);
+    }
+
+    #[test]
+    fn log_llm_usage_inserts_record() {
+        let (db, _dir) = test_db();
+
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 100,
+            output_tokens: 50,
+            request_kind: "agent_loop",
+        })
+        .expect("log usage");
+
+        let conn = db.conn.lock().expect("lock");
+        let (total_tokens, created_at): (i64, String) = conn
+            .query_row(
+                "SELECT total_tokens, created_at FROM llm_usage_logs WHERE chat_id = 100",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("row");
+
+        assert_eq!(total_tokens, 150);
+        assert!(created_at.contains('T'), "RFC3339形式であること");
+    }
+
+    #[test]
+    fn log_llm_usage_returns_row_id() {
+        let (db, _dir) = test_db();
+
+        let row_id = db
+            .log_llm_usage(&LlmUsageLogEntry {
+                chat_id: 100,
+                caller_channel: "tui",
+                provider: "openai",
+                model: "gpt-4",
+                input_tokens: 100,
+                output_tokens: 50,
+                request_kind: "agent_loop",
+            })
+            .expect("log usage");
+
+        assert!(row_id > 0);
+    }
+
+    #[test]
+    fn get_llm_usage_summary_returns_zeros_when_empty() {
+        let (db, _dir) = test_db();
+
+        let summary = db.get_llm_usage_summary(None, None).expect("summary");
+
+        assert_eq!(summary.requests, 0);
+        assert_eq!(summary.input_tokens, 0);
+        assert_eq!(summary.output_tokens, 0);
+        assert_eq!(summary.total_tokens, 0);
+        assert!(summary.last_request_at.is_none());
+    }
+
+    #[test]
+    fn get_llm_usage_summary_aggregates_all() {
+        let (db, _dir) = test_db();
+
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 100,
+            output_tokens: 50,
+            request_kind: "agent_loop",
+        })
+        .expect("log 1");
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 200,
+            output_tokens: 100,
+            request_kind: "agent_loop",
+        })
+        .expect("log 2");
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 200,
+            caller_channel: "web",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 300,
+            output_tokens: 150,
+            request_kind: "agent_loop",
+        })
+        .expect("log 3");
+
+        let summary = db.get_llm_usage_summary(None, None).expect("summary");
+
+        assert_eq!(summary.requests, 3);
+        assert_eq!(summary.input_tokens, 600);
+        assert_eq!(summary.output_tokens, 300);
+        assert_eq!(summary.total_tokens, 900);
+        assert!(summary.last_request_at.is_some());
+    }
+
+    #[test]
+    fn get_llm_usage_summary_filters_by_chat_id() {
+        let (db, _dir) = test_db();
+
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 100,
+            output_tokens: 50,
+            request_kind: "agent_loop",
+        })
+        .expect("log 1");
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 200,
+            caller_channel: "web",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 200,
+            output_tokens: 100,
+            request_kind: "agent_loop",
+        })
+        .expect("log 2");
+
+        let summary = db.get_llm_usage_summary(Some(100), None).expect("summary");
+
+        assert_eq!(summary.requests, 1);
+        assert_eq!(summary.input_tokens, 100);
+        assert_eq!(summary.output_tokens, 50);
+    }
+
+    #[test]
+    fn get_llm_usage_summary_filters_by_since() {
+        let (db, _dir) = test_db();
+
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 100,
+            output_tokens: 50,
+            request_kind: "agent_loop",
+        })
+        .expect("log 1");
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let cutoff = chrono::Utc::now().to_rfc3339();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 200,
+            output_tokens: 100,
+            request_kind: "agent_loop",
+        })
+        .expect("log 2");
+
+        let summary = db
+            .get_llm_usage_summary(None, Some(&cutoff))
+            .expect("summary");
+
+        assert_eq!(summary.requests, 1);
+        assert_eq!(summary.input_tokens, 200);
+    }
+
+    #[test]
+    fn get_llm_usage_summary_filters_by_chat_id_and_since() {
+        let (db, _dir) = test_db();
+
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 100,
+            output_tokens: 50,
+            request_kind: "agent_loop",
+        })
+        .expect("log 1");
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let cutoff = chrono::Utc::now().to_rfc3339();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 200,
+            caller_channel: "web",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 200,
+            output_tokens: 100,
+            request_kind: "agent_loop",
+        })
+        .expect("log 2");
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 300,
+            output_tokens: 150,
+            request_kind: "agent_loop",
+        })
+        .expect("log 3");
+
+        let summary = db
+            .get_llm_usage_summary(Some(100), Some(&cutoff))
+            .expect("summary");
+
+        assert_eq!(summary.requests, 1);
+        assert_eq!(summary.input_tokens, 300);
+    }
+
+    #[test]
+    fn get_llm_usage_by_model_groups_correctly() {
+        let (db, _dir) = test_db();
+
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 100,
+            output_tokens: 50,
+            request_kind: "agent_loop",
+        })
+        .expect("log 1");
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 200,
+            output_tokens: 100,
+            request_kind: "agent_loop",
+        })
+        .expect("log 2");
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "claude-3",
+            input_tokens: 300,
+            output_tokens: 150,
+            request_kind: "agent_loop",
+        })
+        .expect("log 3");
+
+        let models = db.get_llm_usage_by_model(None, None).expect("models");
+
+        assert_eq!(models.len(), 2);
+        let gpt4 = models.iter().find(|m| m.model == "gpt-4").expect("gpt-4");
+        assert_eq!(gpt4.requests, 2);
+        assert_eq!(gpt4.input_tokens, 300);
+        assert_eq!(gpt4.output_tokens, 150);
+
+        let claude = models
+            .iter()
+            .find(|m| m.model == "claude-3")
+            .expect("claude-3");
+        assert_eq!(claude.requests, 1);
+        assert_eq!(claude.input_tokens, 300);
+    }
+
+    #[test]
+    fn get_llm_usage_by_model_orders_by_total_tokens_desc() {
+        let (db, _dir) = test_db();
+
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "gpt-4",
+            input_tokens: 100,
+            output_tokens: 50,
+            request_kind: "agent_loop",
+        })
+        .expect("log 1");
+        db.log_llm_usage(&LlmUsageLogEntry {
+            chat_id: 100,
+            caller_channel: "tui",
+            provider: "openai",
+            model: "claude-3",
+            input_tokens: 300,
+            output_tokens: 150,
+            request_kind: "agent_loop",
+        })
+        .expect("log 2");
+
+        let models = db.get_llm_usage_by_model(None, None).expect("models");
+
+        assert_eq!(models.len(), 2);
+        assert!(
+            models[0].total_tokens >= models[1].total_tokens,
+            "total_tokens降順であること"
+        );
+        assert_eq!(models[0].model, "claude-3");
+    }
+
+    #[test]
+    fn migration_v2_creates_llm_usage_logs_table() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        let db = Database::new(&db_path).expect("db");
+
+        let conn = db.conn.lock().expect("lock");
+        let table_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='llm_usage_logs'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check table");
+
+        assert!(table_exists, "llm_usage_logsテーブルが存在すること");
+
+        let index_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name LIKE 'idx_llm_usage_%'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check indexes");
+
+        assert_eq!(index_count, 2, "2つのインデックスが作成されること");
+    }
+
+    #[test]
+    fn migration_v2_applied_on_existing_db() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime").join("egopulse.db");
+        std::fs::create_dir_all(db_path.parent().expect("parent")).expect("create dir");
+
+        // 生のConnectionでv1スキーマを手動構築（db_meta + schema_migrations + v1テーブル）
+        {
+            let conn = Connection::open(&db_path).expect("open");
+            conn.execute_batch("PRAGMA journal_mode=WAL;").expect("wal");
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS db_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL, note TEXT);
+                 INSERT OR REPLACE INTO db_meta (key, value) VALUES ('schema_version', '1');
+                 INSERT OR REPLACE INTO schema_migrations (version, applied_at, note) VALUES (1, '2025-01-01T00:00:00Z', 'test v1');
+                 CREATE TABLE IF NOT EXISTS chats (chat_id INTEGER PRIMARY KEY);
+                 CREATE TABLE IF NOT EXISTS messages (id TEXT NOT NULL, chat_id INTEGER NOT NULL, PRIMARY KEY (id, chat_id));
+                 CREATE TABLE IF NOT EXISTS sessions (chat_id INTEGER PRIMARY KEY, messages_json TEXT NOT NULL, updated_at TEXT NOT NULL);
+                 CREATE TABLE IF NOT EXISTS tool_calls (id TEXT PRIMARY KEY);",
+            )
+            .expect("create v1 schema");
+        }
+
+        let db = Database::new(&db_path).expect("reopen");
+        let version = db.schema_version().expect("version");
+        assert_eq!(version, 2);
+
+        let conn = db.conn.lock().expect("lock");
+        let table_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='llm_usage_logs'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check table");
+        assert!(table_exists);
+    }
+
+    #[test]
+    fn schema_version_increments_to_2() {
+        let (db, _dir) = test_db();
+        let version = db.schema_version().expect("version");
+        assert_eq!(
+            version, 2,
+            "スキーマバージョンが2にインクリメントされていること"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- EgoPulse の全 LLM 呼び出し（エージェントループ・セッション要約）において、リクエスト単位のトークン使用量を SQLite の `llm_usage_logs` テーブルに記録する仕組みを追加
- Chat Completions API（`prompt_tokens`/`completion_tokens`）と Responses API（`input_tokens`/`output_tokens`）の両方から usage をパースし、統一的な `LlmUsage` struct に正規化
- usage ロギングの失敗はエージェントループ全体に影響しない（fire-and-forget + warn ログ）

## 変更内容

| コミット | 内容 |
|---|---|
| `feat(storage)` | v2 マイグレーション（`llm_usage_logs` テーブル + 2インデックス）、`LlmUsageLogEntry`/`LlmUsageSummary`/`LlmModelUsageSummary` struct、`log_llm_usage`/`get_llm_usage_summary`/`get_llm_usage_by_model` メソッド |
| `feat(llm)` | `MessagesResponse` に `Option<LlmUsage>` 追加、`OpenAiResponse`/`ResponsesApiResponse` に usage パース追加、`LlmProvider` trait に `provider_name()`/`model_name()` 追加 |
| `feat(agent-loop)` | `turn.rs`（agent_loop）と `compaction.rs`（summarize）の LLM 呼び出し直後に usage ロギング挿入 |
| `docs` | `db.md` スキーマドキュメント更新 |

## テスト

- 341 テスト全通過（既存 337 + 新規 4）
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo check` ✅

Close #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * LLMトークン使用量の自動ログ記録を追加（エージェントループ、要約、ターン処理で記録）。
  * モデル別集計やフィルタ可能な利用状況クエリを提供。

* **Documentation**
  * データベーススキーマ文書を更新し、使用量ログ用テーブルとスキーマバージョンの更新を反映。

* **Tests**
  * 使用量ログ、集計クエリ、マイグレーションをカバーするテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->