### PR TITLE
fix(pipelines): browser history を compacted に直接保存 + デッドコード削除

### DIFF
--- a/egograph/pipelines/api/browser_history.py
+++ b/egograph/pipelines/api/browser_history.py
@@ -26,25 +26,31 @@ def ingest_browser_history_endpoint(
     _: None = Depends(verify_api_key),
     service: PipelineService = Depends(get_service),
 ) -> dict:
-    """Browser History payload を保存し、即時 compact run を enqueue する。"""
+    """Browser History payload を保存し、YouTube ingest run を enqueue する。"""
     try:
         validated_payload = BrowserHistoryPayload.model_validate(payload)
         result = run_browser_history_ingest(validated_payload)
-        run = None
+        youtube_run = None
         if result.compaction_targets:
-            run = service.enqueue_browser_history_compact(
-                list(result.compaction_targets),
-                sync_id=result.sync_id,
-                target_months=list(result.compaction_targets),
-                requested_by="api",
-            )
+            try:
+                youtube_run = service.enqueue_youtube_ingest(
+                    sync_id=result.sync_id,
+                    target_months=list(result.compaction_targets),
+                    requested_by="api",
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to enqueue youtube ingest for sync_id=%s",
+                    result.sync_id,
+                )
+                youtube_run = None
         return {
             "sync_id": result.sync_id,
             "accepted": result.accepted,
             "raw_saved": result.raw_saved,
             "events_saved": result.events_saved,
             "received_at": result.received_at,
-            "run_id": run.run_id if run else None,
+            "youtube_run_id": youtube_run.run_id if youtube_run else None,
         }
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/egograph/pipelines/service.py
+++ b/egograph/pipelines/service.py
@@ -172,33 +172,25 @@ class PipelineService:
             raise WorkflowNotFoundError(f"step log not found: {run_id}/{step_id}")
         return self.log_store.read_log(steps[-1].log_path or "")
 
-    def enqueue_browser_history_compact(
+    def enqueue_youtube_ingest(
         self,
-        targets: list[tuple[int, int]],
         *,
-        sync_id: str | None = None,
-        target_months: list[tuple[int, int]] | None = None,
+        sync_id: str,
+        target_months: list[tuple[int, int]],
         requested_by: str = "api",
     ) -> WorkflowRun:
-        """Browser History ingest 後の即時 compact run を積む。
+        """Browser History ingest 後の YouTube 派生 ingest run を積む。
 
-        sync_id / target_months を渡すと
-        compact 完了後に YouTube ingest を enqueue する。
+        ingest 時に compacted へ直接保存するため、即座に YouTube
+        ingest を実行できる。
         """
-        result_summary: dict = {
-            "compaction_targets": [
-                {"year": year, "month": month} for year, month in targets
-            ]
-        }
-        if sync_id and target_months:
-            result_summary["youtube_ingest"] = {
+        return self.scheduler.enqueue_event_run(
+            workflow_id="youtube_ingest_workflow",
+            requested_by=requested_by,
+            result_summary={
                 "sync_id": sync_id,
                 "target_months": [
                     {"year": year, "month": month} for year, month in target_months
                 ],
-            }
-        return self.scheduler.enqueue_event_run(
-            workflow_id="browser_history_compact_workflow",
-            requested_by=requested_by,
-            result_summary=result_summary,
+            },
         )

--- a/egograph/pipelines/sources/browser_history/__init__.py
+++ b/egograph/pipelines/sources/browser_history/__init__.py
@@ -2,8 +2,6 @@
 
 from pipelines.sources.browser_history.pipeline import (
     BrowserHistoryIngestResult,
-    enqueue_browser_history_compaction_event,
-    enqueue_youtube_ingest_event,
     run_browser_history_compact,
     run_browser_history_compact_maintenance,
     run_browser_history_ingest,
@@ -21,8 +19,6 @@ __all__ = [
     "BrowserHistoryItem",
     "BrowserHistoryPayload",
     "BrowserName",
-    "enqueue_browser_history_compaction_event",
-    "enqueue_youtube_ingest_event",
     "run_browser_history_compact",
     "run_browser_history_compact_maintenance",
     "run_browser_history_ingest",

--- a/egograph/pipelines/sources/browser_history/ingest_pipeline.py
+++ b/egograph/pipelines/sources/browser_history/ingest_pipeline.py
@@ -33,7 +33,7 @@ def run_browser_history_pipeline(
     *,
     received_at: datetime | None = None,
 ) -> BrowserHistoryPipelineResult:
-    """payload を raw/events/state へ保存する。"""
+    """payload を raw/compacted/state へ保存する。"""
     normalized_received_at = received_at or datetime.now(timezone.utc)
     accepted = len(payload.items)
 
@@ -61,11 +61,10 @@ def run_browser_history_pipeline(
             monthly_rows[(started_at.year, started_at.month)].append(row)
 
         for (year, month), partition_rows in monthly_rows.items():
-            saved_key = storage.save_parquet(
+            saved_key = storage.save_compacted_page_views(
                 partition_rows,
                 year=year,
                 month=month,
-                prefix="browser_history/page_views",
             )
             if not saved_key:
                 raise RuntimeError(

--- a/egograph/pipelines/sources/browser_history/pipeline.py
+++ b/egograph/pipelines/sources/browser_history/pipeline.py
@@ -1,7 +1,7 @@
 """Browser history ingest/compact pipeline entrypoints."""
 
 import logging
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from typing import Any
@@ -21,15 +21,11 @@ from pipelines.sources.common.settings import PipelinesSettings
 logger = logging.getLogger(__name__)
 
 CompactionTarget = tuple[int, int]
-CompactionEventEnqueuer = Callable[[Mapping[str, object]], str]
-
-_BROWSER_HISTORY_COMPACT_WORKFLOW_ID = "browser_history_compact_workflow"
-_YOUTUBE_INGEST_WORKFLOW_ID = "youtube_ingest_workflow"
 
 
 @dataclass(frozen=True)
 class BrowserHistoryIngestResult:
-    """Browser history ingest と compaction event enqueue の結果。"""
+    """Browser history ingest の結果。"""
 
     sync_id: str
     accepted: int
@@ -37,16 +33,13 @@ class BrowserHistoryIngestResult:
     events_saved: bool
     received_at: datetime
     compaction_targets: tuple[CompactionTarget, ...]
-    compact_run_id: str | None = None
 
     @classmethod
     def from_pipeline_result(
         cls,
         result: BrowserHistoryPipelineResult,
-        *,
-        compact_run_id: str | None = None,
     ) -> "BrowserHistoryIngestResult":
-        """ingest 結果へ enqueue run id を付与して返す。"""
+        """ingest pipeline の結果を ingest result へ変換する。"""
         return cls(
             sync_id=result.sync_id,
             accepted=result.accepted,
@@ -54,7 +47,6 @@ class BrowserHistoryIngestResult:
             events_saved=result.events_saved,
             received_at=result.received_at,
             compaction_targets=result.compaction_targets,
-            compact_run_id=compact_run_id,
         )
 
     def to_summary_dict(self) -> dict[str, object]:
@@ -90,79 +82,21 @@ def _resolve_browser_history_storage(
     )
 
 
-def enqueue_browser_history_compaction_event(
-    compaction_targets: Iterable[CompactionTarget],
-    enqueue_run: CompactionEventEnqueuer,
-    *,
-    workflow_id: str = _BROWSER_HISTORY_COMPACT_WORKFLOW_ID,
-) -> str | None:
-    """compaction targets を event run として enqueue する。"""
-    target_list = [{"year": year, "month": month} for year, month in compaction_targets]
-    if not target_list:
-        return None
-
-    return enqueue_run(
-        {
-            "workflow_id": workflow_id,
-            "trigger_type": "event",
-            "queued_reason": "event_enqueue",
-            "payload": {
-                "compaction_targets": target_list,
-            },
-        }
-    )
-
-
-def enqueue_youtube_ingest_event(
-    *,
-    sync_id: str,
-    target_months: Iterable[CompactionTarget],
-    enqueue_run: CompactionEventEnqueuer,
-    workflow_id: str = _YOUTUBE_INGEST_WORKFLOW_ID,
-) -> str | None:
-    """YouTube 派生 ingest 用 event run を enqueue する。"""
-    month_list = [{"year": year, "month": month} for year, month in target_months]
-    if not month_list:
-        return None
-
-    return enqueue_run(
-        {
-            "workflow_id": workflow_id,
-            "trigger_type": "event",
-            "queued_reason": "event_enqueue",
-            "payload": {
-                "sync_id": sync_id,
-                "target_months": month_list,
-            },
-        }
-    )
-
-
 def run_browser_history_ingest(
     payload: BrowserHistoryPayload,
     *,
     config: Config | None = None,
     storage: BrowserHistoryStorage | None = None,
     received_at: datetime | None = None,
-    enqueue_run: CompactionEventEnqueuer | None = None,
 ) -> BrowserHistoryIngestResult:
-    """Browser History payload を保存し、必要なら compact event を enqueue する。"""
+    """Browser History payload を compacted へ保存する。"""
     resolved_storage = _resolve_browser_history_storage(config, storage)
     result = run_browser_history_pipeline(
         payload,
         resolved_storage,
         received_at=received_at or datetime.now(timezone.utc),
     )
-    compact_run_id = None
-    if enqueue_run is not None:
-        compact_run_id = enqueue_browser_history_compaction_event(
-            result.compaction_targets,
-            enqueue_run,
-        )
-    return BrowserHistoryIngestResult.from_pipeline_result(
-        result,
-        compact_run_id=compact_run_id,
-    )
+    return BrowserHistoryIngestResult.from_pipeline_result(result)
 
 
 def run_browser_history_compact(
@@ -198,11 +132,11 @@ def run_browser_history_compact_maintenance(
 
 
 def compact_from_event_context(run: WorkflowRun) -> dict[str, object]:
-    """event run の result_summary から対象月を取り出して compact し、
-    続けて YouTube ingest を enqueue する。
+    """event run の result_summary から対象月を取り出して compact する。
 
-    result_summary に youtube_ingest (sync_id, target_months) が含まれていれば
-    compact 成功後に YouTube ingest ワークフローを event として積む。
+    maintenance workflow から定期実行される。
+    ingest 時は直接 compacted に保存するため、この関数は
+    events/ に残った古いファイルの再 compact 用。
     """
     raw_summary = run.result_summary or {}
     raw_targets = raw_summary.get("compaction_targets")
@@ -213,96 +147,7 @@ def compact_from_event_context(run: WorkflowRun) -> dict[str, object]:
             "operation": "compact",
             "target_months": [],
         }
-    result = run_browser_history_compact(targets)
-
-    # compact 成功後に YouTube ingest を enqueue
-    youtube_context = raw_summary.get("youtube_ingest")
-    if youtube_context and isinstance(youtube_context, dict):
-        _enqueue_youtube_ingest_via_db(youtube_context)
-
-    return result
-
-
-def _enqueue_youtube_ingest_via_db(
-    youtube_context: dict[str, Any],
-) -> None:
-    """DB に直接接続して YouTube ingest event run を enqueue する。
-
-    step 関数は service にアクセスできないため、最小限の DB 接続を
-    構築して enqueue する。
-    """
-    import threading  # noqa: PLC0415
-    from datetime import UTC, datetime  # noqa: PLC0415
-
-    from pipelines.config import PipelinesConfig  # noqa: PLC0415
-    from pipelines.domain.workflow import (  # noqa: PLC0415
-        QueuedReason,
-        TriggerType,
-    )
-    from pipelines.infrastructure.db.connection import (  # noqa: PLC0415
-        connect as db_connect,
-    )
-    from pipelines.infrastructure.db.schema import initialize_schema  # noqa: PLC0415
-    from pipelines.infrastructure.db.workflow_repository import (  # noqa: PLC0415
-        WorkflowRepository,
-    )
-    from pipelines.workflows.registry import get_workflows  # noqa: PLC0415
-
-    sync_id = youtube_context.get("sync_id")
-    raw_months = youtube_context.get("target_months")
-    if not isinstance(sync_id, str) or not sync_id.strip():
-        logger.warning("youtube_ingest context missing sync_id, skipping enqueue")
-        return
-    if not isinstance(raw_months, list) or not raw_months:
-        logger.warning("youtube_ingest context missing target_months, skipping enqueue")
-        return
-
-    target_months = [
-        {"year": m["year"], "month": m["month"]}
-        for m in raw_months
-        if isinstance(m, dict)
-        and isinstance(m.get("year"), int)
-        and isinstance(m.get("month"), int)
-    ]
-    if not target_months:
-        logger.warning(
-            "youtube_ingest context has no valid target_months, skipping enqueue"
-        )
-        return
-
-    try:
-        config = PipelinesConfig()
-        conn = db_connect(config.database_path)
-        initialize_schema(conn)
-        db_mutex = threading.RLock()
-        workflow_repo = WorkflowRepository(conn, mutex=db_mutex)
-        workflow_repo.register_workflows(get_workflows())
-
-        from pipelines.infrastructure.db.run_repository import (  # noqa: PLC0415
-            RunRepository,
-        )
-
-        run_repo = RunRepository(workflow_repo, conn, mutex=db_mutex)
-        run_repo.enqueue_run(
-            workflow_id=_YOUTUBE_INGEST_WORKFLOW_ID,
-            trigger_type=TriggerType.EVENT,
-            queued_reason=QueuedReason.EVENT_ENQUEUE,
-            requested_by="compact_step",
-            scheduled_at=datetime.now(tz=UTC),
-            result_summary={
-                "sync_id": sync_id,
-                "target_months": target_months,
-            },
-        )
-        logger.info(
-            "Enqueued youtube_ingest_workflow for sync_id=%s after compact",
-            sync_id,
-        )
-    except Exception:
-        logger.exception(
-            "Failed to enqueue youtube_ingest_workflow for sync_id=%s",
-            sync_id,
-        )
+    return run_browser_history_compact(targets)
 
 
 def _parse_event_targets(raw_targets: Any) -> tuple[CompactionTarget, ...]:

--- a/egograph/pipelines/sources/browser_history/storage.py
+++ b/egograph/pipelines/sources/browser_history/storage.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import random
+import time
 import uuid
 from datetime import datetime, timezone
 from io import BytesIO
@@ -22,6 +24,9 @@ from pipelines.sources.common.compaction import (
 
 logger = logging.getLogger(__name__)
 
+_MAX_COMPACTED_SAVE_RETRIES = 3
+_COMPACTED_SAVE_BACKOFF_SECONDS = 0.2
+
 
 def _normalize_path(path: str) -> str:
     return path.rstrip("/") + "/"
@@ -32,7 +37,7 @@ def _key_part(value: str) -> str:
 
 
 class BrowserHistoryStorage:
-    """Browser history の raw/events/state 保存を扱う。"""
+    """Browser history の raw/compacted/state 保存を扱う。"""
 
     def __init__(
         self,
@@ -93,35 +98,114 @@ class BrowserHistoryStorage:
             return None
         return key
 
-    def save_parquet(
+    def save_compacted_page_views(
         self,
         rows: list[dict[str, Any]],
         *,
         year: int,
         month: int,
-        prefix: str = "browser_history/page_views",
+        dataset_path: str = "browser_history/page_views",
+        dedupe_key: str = "page_view_id",
+        sort_by: str | None = "ingested_at_utc",
     ) -> str | None:
-        """events parquet を保存する。"""
+        """既存 compacted に新規行をマージして保存する。
+
+        楽観ロック (ETag) で同時書き込みを防ぐ。
+        競合時はリトライで再マージする。
+        """
         if not rows:
             return None
-        key = (
-            f"{self.events_path}{prefix}/year={year}/month={month:02d}/"
-            f"{uuid.uuid4()}.parquet"
+
+        key = build_compacted_key(
+            self.compacted_path,
+            data_domain="events",
+            dataset_path=dataset_path,
+            year=year,
+            month=month,
         )
-        try:
-            buffer = BytesIO()
-            pd.DataFrame(rows).to_parquet(buffer, index=False, engine="pyarrow")
-            buffer.seek(0)
-            self.s3.put_object(
-                Bucket=self.bucket_name,
-                Key=key,
-                Body=buffer.getvalue(),
-                ContentType="application/octet-stream",
+
+        for attempt in range(_MAX_COMPACTED_SAVE_RETRIES):
+            existing_rows: list[dict[str, Any]] = []
+            etag: str | None = None
+
+            try:
+                response = self.s3.get_object(Bucket=self.bucket_name, Key=key)
+                existing_df = pd.read_parquet(
+                    BytesIO(response["Body"].read()), engine="pyarrow"
+                )
+                existing_rows = existing_df.to_dict(orient="records")
+                raw_etag = response.get("ETag")
+                etag = raw_etag if isinstance(raw_etag, str) else None
+            except ClientError as exc:
+                if exc.response["Error"]["Code"] in ("NoSuchKey", "404"):
+                    existing_rows = []
+                    etag = None
+                else:
+                    logger.exception("Failed to read existing compacted: key=%s", key)
+                    raise
+
+            merged_df = compact_records(
+                existing_rows + rows,
+                dedupe_key=dedupe_key,
+                sort_by=sort_by,
             )
-        except Exception:
-            logger.exception("Failed to save browser history parquet")
-            return None
-        return key
+
+            try:
+                put_kwargs: dict[str, Any] = {}
+                if etag is not None:
+                    put_kwargs["IfMatch"] = etag
+                else:
+                    put_kwargs["IfNoneMatch"] = "*"
+
+                self.s3.put_object(
+                    Bucket=self.bucket_name,
+                    Key=key,
+                    Body=dataframe_to_parquet_bytes(merged_df),
+                    ContentType="application/octet-stream",
+                    **put_kwargs,
+                )
+                logger.info(
+                    "Saved compacted browser history page_views: "
+                    "key=%s rows=%d attempt=%d",
+                    key,
+                    len(merged_df),
+                    attempt + 1,
+                )
+                return key
+            except ClientError as exc:
+                error_code = exc.response.get("Error", {}).get("Code")
+                status_code = exc.response.get("ResponseMetadata", {}).get(
+                    "HTTPStatusCode"
+                )
+                is_conflict = (
+                    error_code in {"PreconditionFailed", "ConditionalRequestConflict"}
+                    or status_code == 412
+                )
+                if not is_conflict:
+                    logger.exception("Failed to save compacted page_views: key=%s", key)
+                    return None
+
+                if attempt >= _MAX_COMPACTED_SAVE_RETRIES - 1:
+                    logger.error(
+                        "Compacted page_views save conflict exceeded retries: key=%s",
+                        key,
+                    )
+                    return None
+
+                sleep_seconds = _COMPACTED_SAVE_BACKOFF_SECONDS * (
+                    2**attempt
+                ) + random.uniform(0.0, 0.05)
+                logger.warning(
+                    "Compacted page_views save conflict (attempt %d/%d). "
+                    "Retrying in %.2fs: key=%s",
+                    attempt + 1,
+                    _MAX_COMPACTED_SAVE_RETRIES,
+                    sleep_seconds,
+                    key,
+                )
+                time.sleep(sleep_seconds)
+
+        return None
 
     def get_state(
         self,

--- a/egograph/pipelines/tests/e2e/test_browser_history_ingest.py
+++ b/egograph/pipelines/tests/e2e/test_browser_history_ingest.py
@@ -6,6 +6,7 @@ service オーケストレーション境界の結合を検証する。
 """
 
 import time
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
 from urllib.parse import parse_qs, unquote, urlparse
@@ -121,8 +122,6 @@ def test_browser_history_ingest_api_executes_compaction_pipeline_end_to_end(
 ):
     """Browser History POST から compacted parquet 保存まで通しで実行できる。"""
     # Arrange
-    from datetime import datetime, timezone
-
     now = datetime.now(timezone.utc)
     date_str = now.strftime("%Y-%m-%d")
     time_str = now.strftime("%H:%M:%S")
@@ -170,32 +169,26 @@ def test_browser_history_ingest_api_executes_compaction_pipeline_end_to_end(
             assert body["accepted"] == 1
             assert body["raw_saved"] is True
             assert body["events_saved"] is True
-            assert body["run_id"]
+            assert body["youtube_run_id"]
 
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline:
                 run_response = client.get(
-                    f"/v1/runs/{body['run_id']}",
+                    f"/v1/runs/{body['youtube_run_id']}",
                     headers={"X-API-Key": "test-api-key"},
                 )
                 assert run_response.status_code == 200
                 run_detail = run_response.json()
                 if run_detail["run"]["status"] == "succeeded":
-                    assert run_detail["run"]["result_summary"] == {
-                        "provider": "browser_history",
-                        "operation": "compact",
-                        "target_months": ["2026-04"],
-                    }
                     assert run_detail["steps"][0]["status"] == "succeeded"
                     break
                 if run_detail["run"]["status"] == "failed":
                     raise AssertionError(run_detail["run"]["last_error_message"])
                 time.sleep(0.05)
             else:
-                raise AssertionError("browser history compaction run did not succeed")
+                raise AssertionError("youtube ingest run did not succeed")
 
         object_keys = [key for _, key in memory_s3.objects]
-        year_month = now.strftime("%Y/%m")
         year_month_day = now.strftime("%Y/%m/%d")
         assert any(
             key.startswith(f"raw/browser_history/chrome/{year_month_day}/")
@@ -203,7 +196,8 @@ def test_browser_history_ingest_api_executes_compaction_pipeline_end_to_end(
         )
         assert any(
             key.startswith(
-                f"events/browser_history/page_views/year={now.year}/month={now.month:02d}/"
+                f"compacted/events/browser_history/page_views/"
+                f"year={now.year}/month={now.month:02d}/data.parquet"
             )
             for key in object_keys
         )

--- a/egograph/pipelines/tests/integration/browser_history/test_pipeline.py
+++ b/egograph/pipelines/tests/integration/browser_history/test_pipeline.py
@@ -1,12 +1,14 @@
 """Browser History ingest のインテグレーションテスト。
 
-MemoryS3 モックを使用し、payload → raw/events/state 保存を検証する。
+MemoryS3 モックを使用し、payload → raw/compacted/state 保存を検証する。
 """
 
+import json
 from io import BytesIO
 from unittest.mock import patch
 
 import pandas as pd
+from botocore.exceptions import ClientError
 
 from pipelines.sources.browser_history.pipeline import run_browser_history_pipeline
 from pipelines.sources.browser_history.schema import BrowserHistoryPayload
@@ -36,7 +38,7 @@ class _MemoryS3:
     def __init__(self):
         self.objects: dict[str, bytes] = {}
 
-    def put_object(self, *, Bucket, Key, Body, ContentType):  # noqa: N803
+    def put_object(self, *, Bucket, Key, Body, ContentType, **kwargs):  # noqa: N803
         if isinstance(Body, str):
             body = Body.encode("utf-8")
         else:
@@ -45,7 +47,12 @@ class _MemoryS3:
         return {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
     def get_object(self, *, Bucket, Key):  # noqa: N803
-        return {"Body": BytesIO(self.objects[Key])}
+        if Key not in self.objects:
+            raise ClientError(
+                {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}},
+                "GetObject",
+            )
+        return {"Body": BytesIO(self.objects[Key]), "ETag": f'"{hash(Key):x}"'}
 
     def get_paginator(self, name: str):
         assert name == "list_objects_v2"
@@ -86,8 +93,8 @@ def _make_storage(memory_s3: _MemoryS3) -> BrowserHistoryStorage:
     )
 
 
-def test_ingest_saves_raw_events_and_state():
-    """Ingest が raw JSON, events Parquet, state を S3 に保存する。"""
+def test_ingest_saves_raw_compacted_and_state():
+    """Ingest が raw JSON, compacted Parquet, state を S3 に保存する。"""
     memory_s3 = _MemoryS3()
 
     with patch_storage_client(memory_s3):
@@ -102,9 +109,11 @@ def test_ingest_saves_raw_events_and_state():
             "raw data not found"
         )
         assert any(
-            key.startswith("events/browser_history/page_views/year=2026/month=03/")
+            key.startswith(
+                "compacted/events/browser_history/page_views/year=2026/month=03/"
+            )
             for key in keys
-        ), "events parquet not found"
+        ), "compacted parquet not found"
         assert "state/browser_history/device-1/edge/Default.json" in keys, (
             "state not found"
         )
@@ -135,13 +144,13 @@ def test_ingest_no_data_saves_state_only():
         assert not any(key.startswith("raw/") for key in keys), (
             "raw data should not be saved"
         )
-        assert not any(key.startswith("events/") for key in keys), (
-            "events should not be saved"
+        assert not any(key.startswith("compacted/") for key in keys), (
+            "compacted should not be saved"
         )
 
 
-def test_compact_deduplicates_duplicate_event_ids():
-    """Compaction が同一 visit_id のレコードを重複排除する。"""
+def test_duplicate_ingest_deduplicates_in_compacted():
+    """同一 visit_id の2回 ingest でも compacted は1行になる。"""
     memory_s3 = _MemoryS3()
 
     with patch_storage_client(memory_s3):
@@ -150,12 +159,12 @@ def test_compact_deduplicates_duplicate_event_ids():
         run_browser_history_pipeline(payload, storage)
         run_browser_history_pipeline(payload, storage)
 
-        key = storage.compact_month(year=2026, month=3)
-
-        assert key == (
-            "compacted/events/browser_history/page_views/year=2026/month=03/data.parquet"
+        compacted_key = (
+            "compacted/events/browser_history/page_views/"
+            "year=2026/month=03/data.parquet"
         )
-        df = pd.read_parquet(BytesIO(memory_s3.objects[key]))
+        assert compacted_key in memory_s3.objects
+        df = pd.read_parquet(BytesIO(memory_s3.objects[compacted_key]))
         assert len(df) == 1, f"Expected 1 deduplicated row, got {len(df)}"
 
 
@@ -190,8 +199,6 @@ def test_incremental_fetch_uses_state():
         run_browser_history_pipeline(payload2, storage)
 
         # state が更新されている
-        import json
-
         state = json.loads(memory_s3.objects[state_key])
         assert state["sync_id"] == "2f4377e4-8c80-4ef4-a6bb-7f9350dbd6cf"
         assert state["last_accepted_count"] == 1

--- a/egograph/pipelines/tests/unit/browser_history/test_pipeline.py
+++ b/egograph/pipelines/tests/unit/browser_history/test_pipeline.py
@@ -29,7 +29,9 @@ def _payload(items: list[dict] | None = None) -> BrowserHistoryPayload:
 def test_pipeline_success_path():
     storage = MagicMock()
     storage.save_raw_json.return_value = "raw/key.json"
-    storage.save_parquet.return_value = "events/key.parquet"
+    storage.save_compacted_page_views.return_value = (
+        "compacted/events/browser_history/page_views/year=2026/month=03/data.parquet"
+    )
 
     result = run_browser_history_pipeline(
         _payload(),
@@ -57,7 +59,7 @@ def test_pipeline_raises_when_raw_save_fails():
 def test_pipeline_raises_when_events_save_fails():
     storage = MagicMock()
     storage.save_raw_json.return_value = "raw/key.json"
-    storage.save_parquet.return_value = None
+    storage.save_compacted_page_views.return_value = None
 
     with pytest.raises(RuntimeError, match="Failed to save browser history events"):
         run_browser_history_pipeline(_payload(), storage)

--- a/egograph/pipelines/tests/unit/browser_history/test_pipeline_entrypoint.py
+++ b/egograph/pipelines/tests/unit/browser_history/test_pipeline_entrypoint.py
@@ -14,8 +14,6 @@ from pipelines.sources.browser_history.ingest_pipeline import (
 )
 from pipelines.sources.browser_history.pipeline import (
     compact_from_event_context,
-    enqueue_browser_history_compaction_event,
-    enqueue_youtube_ingest_event,
     run_browser_history_compact_maintenance,
     run_browser_history_ingest,
 )
@@ -33,71 +31,8 @@ def _payload() -> BrowserHistoryPayload:
     )
 
 
-def test_enqueue_browser_history_compaction_event_returns_none_without_targets():
-    """targets が空なら event enqueue を行わない。"""
-    result = enqueue_browser_history_compaction_event((), lambda payload: "run-1")
-
-    assert result is None
-
-
-def test_enqueue_browser_history_compaction_event_builds_event_payload():
-    """targets を event enqueue 用 payload に変換する。"""
-    captured: dict[str, object] = {}
-
-    def enqueue_run(payload):
-        captured.update(payload)
-        return "run-1"
-
-    run_id = enqueue_browser_history_compaction_event(
-        ((2026, 4), (2026, 3)),
-        enqueue_run,
-    )
-
-    assert run_id == "run-1"
-    assert captured == {
-        "workflow_id": "browser_history_compact_workflow",
-        "trigger_type": "event",
-        "queued_reason": "event_enqueue",
-        "payload": {
-            "compaction_targets": [
-                {"year": 2026, "month": 4},
-                {"year": 2026, "month": 3},
-            ],
-        },
-    }
-
-
-def test_enqueue_youtube_ingest_event_builds_event_payload():
-    """YouTube 派生 ingest 用 payload を組み立てる。"""
-    captured: dict[str, object] = {}
-
-    def enqueue_run(payload):
-        captured.update(payload)
-        return "run-youtube-1"
-
-    run_id = enqueue_youtube_ingest_event(
-        sync_id="sync-123",
-        target_months=((2026, 4), (2026, 3)),
-        enqueue_run=enqueue_run,
-    )
-
-    assert run_id == "run-youtube-1"
-    assert captured == {
-        "workflow_id": "youtube_ingest_workflow",
-        "trigger_type": "event",
-        "queued_reason": "event_enqueue",
-        "payload": {
-            "sync_id": "sync-123",
-            "target_months": [
-                {"year": 2026, "month": 4},
-                {"year": 2026, "month": 3},
-            ],
-        },
-    }
-
-
-def test_run_browser_history_ingest_returns_compact_run_id(monkeypatch):
-    """ingest 成功後、compaction target があれば event run id を結果へ含める。"""
+def test_run_browser_history_ingest_returns_pipeline_result(monkeypatch):
+    """ingest 成功後、結果を BrowserHistoryIngestResult として返す。"""
     expected_received_at = datetime(2026, 4, 4, 12, 0, tzinfo=timezone.utc)
     dummy_storage = object()
 
@@ -121,12 +56,10 @@ def test_run_browser_history_ingest_returns_compact_run_id(monkeypatch):
         _payload(),
         storage=dummy_storage,
         received_at=expected_received_at,
-        enqueue_run=lambda _: "run-compact-1",
     )
 
     assert result.sync_id == "12345678-1234-5678-1234-567812345678"
     assert result.compaction_targets == ((2026, 4),)
-    assert result.compact_run_id == "run-compact-1"
     assert result.to_summary_dict() == {
         "sync_id": "12345678-1234-5678-1234-567812345678",
         "accepted": 2,
@@ -134,7 +67,6 @@ def test_run_browser_history_ingest_returns_compact_run_id(monkeypatch):
         "events_saved": True,
         "received_at": "2026-04-04T12:00:00+00:00",
         "compaction_targets": [{"year": 2026, "month": 4}],
-        "compact_run_id": "run-compact-1",
     }
 
 

--- a/egograph/pipelines/tests/unit/browser_history/test_storage.py
+++ b/egograph/pipelines/tests/unit/browser_history/test_storage.py
@@ -1,6 +1,8 @@
 import json
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 from botocore.exceptions import ClientError
 from pipelines.sources.browser_history.storage import BrowserHistoryStorage
@@ -32,20 +34,6 @@ class TestBrowserHistoryStorage:
         assert key is not None
         assert key.startswith("raw/browser_history/edge/")
         assert key.endswith(".json")
-
-    def test_save_parquet_uses_expected_key_format(self):
-        with patch(
-            "pipelines.sources.browser_history.storage.pd.DataFrame.to_parquet"
-        ) as _mock_to_parquet:
-            key = self.storage.save_parquet(
-                [{"page_view_id": "pv1", "started_at_utc": "2026-03-22T08:31:12Z"}],
-                year=2026,
-                month=3,
-            )
-
-        assert key is not None
-        assert key.startswith("events/browser_history/page_views/year=2026/month=03/")
-        assert key.endswith(".parquet")
 
     def test_build_state_key_uses_source_browser_profile_granularity(self):
         key = self.storage.build_state_key("home pc", "edge", "Profile 1")
@@ -145,3 +133,153 @@ class TestBrowserHistoryStorage:
             pytest.raises(RuntimeError, match="r2 down"),
         ):
             self.storage.compact_month(year=2026, month=3)
+
+    def test_save_compacted_page_views_first_write_uses_if_none_match(self):
+        """既存ファイルがない場合、IfNoneMatch='*' で書き込む。"""
+        self.mock_s3.get_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}},
+            "GetObject",
+        )
+        with (
+            patch(
+                "pipelines.sources.browser_history.storage.compact_records",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "pipelines.sources.browser_history.storage.dataframe_to_parquet_bytes",
+                return_value=b"parquet-data",
+            ),
+        ):
+            key = self.storage.save_compacted_page_views(
+                [{"page_view_id": "pv1", "ingested_at_utc": "2026-03-22T12:00:00Z"}],
+                year=2026,
+                month=3,
+            )
+
+        assert key == (
+            "compacted/events/browser_history/page_views/"
+            "year=2026/month=03/data.parquet"
+        )
+        put_kwargs = self.mock_s3.put_object.call_args.kwargs
+        assert put_kwargs["IfNoneMatch"] == "*"
+        assert "IfMatch" not in put_kwargs
+
+    def test_save_compacted_page_views_existing_uses_if_match(self):
+        """既存ファイルがある場合、ETag を IfMatch に渡す。"""
+        existing_df = pd.DataFrame(
+            [{"page_view_id": "pv1", "ingested_at_utc": "2026-03-22T10:00:00Z"}]
+        )
+        buffer = BytesIO()
+        existing_df.to_parquet(buffer, index=False, engine="pyarrow")
+        buffer.seek(0)
+
+        self.mock_s3.get_object.return_value = {
+            "Body": buffer,
+            "ETag": '"abc123"',
+        }
+        with (
+            patch(
+                "pipelines.sources.browser_history.storage.compact_records",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "pipelines.sources.browser_history.storage.dataframe_to_parquet_bytes",
+                return_value=b"parquet-data",
+            ),
+        ):
+            key = self.storage.save_compacted_page_views(
+                [{"page_view_id": "pv2", "ingested_at_utc": "2026-03-22T12:00:00Z"}],
+                year=2026,
+                month=3,
+            )
+
+        assert key is not None
+        put_kwargs = self.mock_s3.put_object.call_args.kwargs
+        assert put_kwargs["IfMatch"] == '"abc123"'
+        assert "IfNoneMatch" not in put_kwargs
+
+    def test_save_compacted_page_views_retries_on_precondition_failed(self):
+        """412 Conflict のときはリトライして保存する。"""
+        self.mock_s3.get_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}},
+            "GetObject",
+        )
+        precondition_error = ClientError(
+            {
+                "Error": {
+                    "Code": "PreconditionFailed",
+                    "Message": "etag mismatch",
+                },
+                "ResponseMetadata": {"HTTPStatusCode": 412},
+            },
+            "PutObject",
+        )
+        self.mock_s3.put_object.side_effect = [
+            precondition_error,
+            {"ResponseMetadata": {"HTTPStatusCode": 200}},
+        ]
+        with (
+            patch(
+                "pipelines.sources.browser_history.storage.time.sleep",
+                lambda _: None,
+            ),
+            patch(
+                "pipelines.sources.browser_history.storage.compact_records",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "pipelines.sources.browser_history.storage.dataframe_to_parquet_bytes",
+                return_value=b"parquet-data",
+            ),
+        ):
+            key = self.storage.save_compacted_page_views(
+                [{"page_view_id": "pv1", "ingested_at_utc": "2026-03-22T12:00:00Z"}],
+                year=2026,
+                month=3,
+            )
+
+        assert key == (
+            "compacted/events/browser_history/page_views/"
+            "year=2026/month=03/data.parquet"
+        )
+        assert self.mock_s3.put_object.call_count == 2
+
+    def test_save_compacted_page_views_returns_none_after_max_retries(self):
+        """リトライ上限に達したら None を返す。"""
+        self.mock_s3.get_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}},
+            "GetObject",
+        )
+        precondition_error = ClientError(
+            {
+                "Error": {
+                    "Code": "PreconditionFailed",
+                    "Message": "etag mismatch",
+                },
+                "ResponseMetadata": {"HTTPStatusCode": 412},
+            },
+            "PutObject",
+        )
+        self.mock_s3.put_object.side_effect = precondition_error
+        with (
+            patch(
+                "pipelines.sources.browser_history.storage.time.sleep",
+                lambda _: None,
+            ),
+            patch(
+                "pipelines.sources.browser_history.storage.compact_records",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "pipelines.sources.browser_history.storage.dataframe_to_parquet_bytes",
+                return_value=b"parquet-data",
+            ),
+        ):
+            key = self.storage.save_compacted_page_views(
+                [{"page_view_id": "pv1", "ingested_at_utc": "2026-03-22T12:00:00Z"}],
+                year=2026,
+                month=3,
+            )
+
+        assert key is None
+        assert self.mock_s3.put_object.call_count == 3

--- a/egograph/pipelines/tests/unit/test_api_endpoints.py
+++ b/egograph/pipelines/tests/unit/test_api_endpoints.py
@@ -135,8 +135,8 @@ def test_cancel_run_idempotent_for_non_queued_run(tmp_path):
         assert cancel_again.json()["status"] == "canceled"
 
 
-def test_browser_history_ingest_returns_202_with_compact_run(tmp_path):
-    """Browser history ingest は compact run 情報を返す。"""
+def test_browser_history_ingest_returns_202_with_youtube_run(tmp_path):
+    """Browser history ingest は YouTube ingest run 情報を返す。"""
     config = PipelinesConfig(
         database_path=tmp_path / "state.sqlite3",
         logs_root=tmp_path / "logs",
@@ -145,8 +145,8 @@ def test_browser_history_ingest_returns_202_with_compact_run(tmp_path):
     app = create_app(config)
     app.dependency_overrides[verify_api_key] = lambda: None
     fake_service = SimpleNamespace(
-        enqueue_browser_history_compact=lambda *args, **kwargs: SimpleNamespace(
-            run_id="compact-run-1"
+        enqueue_youtube_ingest=lambda *args, **kwargs: SimpleNamespace(
+            run_id="youtube-run-1"
         ),
     )
     app.dependency_overrides[get_service] = lambda: fake_service
@@ -160,17 +160,64 @@ def test_browser_history_ingest_returns_202_with_compact_run(tmp_path):
         compaction_targets=((2026, 4),),
     )
 
-    with patch(
-        "pipelines.api.browser_history.BrowserHistoryPayload.model_validate",
-        return_value=object(),
-    ), patch(
-        "pipelines.api.browser_history.run_browser_history_ingest",
-        return_value=result,
-    ), TestClient(app) as client:
+    with (
+        patch(
+            "pipelines.api.browser_history.BrowserHistoryPayload.model_validate",
+            return_value=object(),
+        ),
+        patch(
+            "pipelines.api.browser_history.run_browser_history_ingest",
+            return_value=result,
+        ),
+        TestClient(app) as client,
+    ):
         response = client.post("/v1/ingest/browser-history", json={"dummy": "payload"})
 
     assert response.status_code == 202
     body = response.json()
-    assert body["run_id"] == "compact-run-1"
     assert body["sync_id"] == "sync-1"
-    assert "youtube_run_id" not in body
+    assert body["youtube_run_id"] == "youtube-run-1"
+
+
+def test_browser_history_ingest_returns_202_when_youtube_enqueue_fails(tmp_path):
+    """YouTube enqueue が失敗しても ingest は 202 を返す。"""
+    config = PipelinesConfig(
+        database_path=tmp_path / "state.sqlite3",
+        logs_root=tmp_path / "logs",
+        dispatcher_poll_seconds=60,
+    )
+    app = create_app(config)
+    app.dependency_overrides[verify_api_key] = lambda: None
+    fake_service = SimpleNamespace(
+        enqueue_youtube_ingest=lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError("scheduler down")
+        ),
+    )
+    app.dependency_overrides[get_service] = lambda: fake_service
+
+    result = SimpleNamespace(
+        sync_id="sync-1",
+        accepted=1,
+        raw_saved=True,
+        events_saved=True,
+        received_at="2026-04-22T00:00:00+00:00",
+        compaction_targets=((2026, 4),),
+    )
+
+    with (
+        patch(
+            "pipelines.api.browser_history.BrowserHistoryPayload.model_validate",
+            return_value=object(),
+        ),
+        patch(
+            "pipelines.api.browser_history.run_browser_history_ingest",
+            return_value=result,
+        ),
+        TestClient(app) as client,
+    ):
+        response = client.post("/v1/ingest/browser-history", json={"dummy": "payload"})
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["sync_id"] == "sync-1"
+    assert body["youtube_run_id"] is None

--- a/egograph/pipelines/workflows/registry.py
+++ b/egograph/pipelines/workflows/registry.py
@@ -155,7 +155,10 @@ def get_workflows() -> dict[str, WorkflowDefinition]:
         WorkflowDefinition(
             workflow_id="browser_history_compact_workflow",
             name="Browser history compact workflow",
-            description="Compact browser history immediately after ingest",
+            description=(
+                "Compact browser history from events/ "
+                "for maintenance/reprocessing"
+            ),
             steps=(
                 _inprocess_step(
                     "run_browser_history_compact",


### PR DESCRIPTION
## 概要

Browser history ingest を `events/` ステージングを経由せず `compacted/` に直接保存するよう変更し、併せてデッドコードを整理した。

## 背景

YouTube ingest が `events/` 配下の古い parquet（`sync_id` 列追加前のコミット `6b34b9c` 以前に作成されたファイル）を読もうとして `ArrowInvalid: No match for FieldRef.Name(sync_id)` で失敗していた。

Browser history はもともとイベント単位で保存した後に compact で統合していたが、イベント分割のメリットが薄く（製本の単位は Browser History 側）、直接 compacted に保存する方がシンプル。

## 変更内容

### データフロー変更
- **`save_compacted_page_views`** 追加: ETag 楽観ロック + merge/dedup + 指数バックオフリトライ
- **`ingest_pipeline.py`**: `save_parquet` → `save_compacted_page_views` に切替
- **`api/browser_history.py`**: compact workflow 経由ではなく、直接 YouTube ingest を enqueue
- **`service.py`**: `enqueue_youtube_ingest` を追加（旧 `enqueue_browser_history_compact` は削除）

### デッドコード削除
- `save_parquet` メソッド + テスト
- `enqueue_browser_history_compaction_event` 関数
- `enqueue_youtube_ingest_event` 関数
- `CompactionEventEnqueuer` 型エイリアス
- `_BROWSER_HISTORY_COMPACT_WORKFLOW_ID` 定数
- `BrowserHistoryIngestResult.compact_run_id` フィールド
- `run_browser_history_ingest` の `enqueue_run` パラメータ
- 未使用 import（`Callable`, `Mapping`）

### テスト更新
- 統合テスト: `compacted/` パスのアサーション、重複排除テストの再設計
- E2E テスト: YouTube ingest run の検証
- 単体テスト: ETag リトライ（4件）、YouTube enqueue 失敗時 graceful degradation（1件）を追加
- デッドテスト 3件を削除、1件を生きたパスに更新

### 修正後も維持
- `compact_from_event_context`: maintenance workflow 用（`events/` の古いファイル再 compact 用）
- `compact_month`: 定期 maintenance で使用
- `browser_history_compact_workflow`: レジストリに維持（手動実行・maintenance 用）

## テスト結果

```
363 passed, 2 skipped, 0 failures
ruff check: clean
ruff format: clean
```