### PR TITLE
refactor(backend): データアクセス層の統合リファクタリング

### DIFF
--- a/egograph/backend/api/browser_history_data.py
+++ b/egograph/backend/api/browser_history_data.py
@@ -7,53 +7,21 @@ import duckdb
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from backend.api.schemas import PageViewResponse, TopDomainResponse
-from backend.config import BackendConfig
 from backend.constants import (
     DEFAULT_PAGE_VIEWS_LIMIT,
     DEFAULT_TOP_DOMAINS_LIMIT,
     MAX_LIMIT,
     MIN_LIMIT,
 )
-from backend.dependencies import get_config, get_db_connection, verify_api_key_docs
-from backend.infrastructure.database import (
-    BrowserHistoryQueryParams,
-    get_page_views,
-    get_top_domains,
+from backend.dependencies import get_db_connection, get_browser_history_repository, verify_api_key_docs
+from backend.infrastructure.repositories.browser_history_repository import (
+    BrowserHistoryRepository,
 )
-from backend.validators import to_utc_range, validate_date_range, validate_limit
+from backend.validators import validate_date_range, validate_limit
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/data/browser-history", tags=["data", "browser_history"])
-
-
-def _build_query_params(
-    db_connection: duckdb.DuckDBPyConnection,
-    config: BackendConfig,
-    start_date: date,
-    end_date: date,
-    limit: int,
-) -> tuple[BrowserHistoryQueryParams, int]:
-    """共通のクエリパラメータと limit を検証して構築する。"""
-    try:
-        start, end = validate_date_range(start_date, end_date)
-        validated_limit = validate_limit(limit, max_value=MAX_LIMIT)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    utc_start, utc_end = to_utc_range(start, end, config.timezone)
-    params = BrowserHistoryQueryParams(
-        conn=db_connection,
-        bucket=config.r2.bucket_name,
-        events_path=config.r2.events_path,
-        start_date=start,
-        end_date=end,
-        utc_start=utc_start,
-        utc_end=utc_end,
-        tz_name=str(config.timezone),
-        r2_config=config.r2,
-    )
-    return params, validated_limit
 
 
 @router.get("/page-views", response_model=list[PageViewResponse])
@@ -69,22 +37,18 @@ def get_page_views_endpoint(
     browser: str | None = Query(None, description="フィルタ対象のブラウザ"),
     profile: str | None = Query(None, description="フィルタ対象のプロファイル"),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
-    config: BackendConfig = Depends(get_config),
+    repository: BrowserHistoryRepository = Depends(get_browser_history_repository),
     _api_key: None = Depends(verify_api_key_docs),
 ):
     """指定期間の page view 一覧を取得する。"""
-    params, validated_limit = _build_query_params(
-        db_connection,
-        config,
-        start_date,
-        end_date,
-        limit,
-    )
-    return get_page_views(
-        params,
-        browser=browser,
-        profile=profile,
-        limit=validated_limit,
+    try:
+        start, end = validate_date_range(start_date, end_date)
+        validated_limit = validate_limit(limit, max_value=MAX_LIMIT)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return repository.get_page_views(
+        db_connection, start, end, browser=browser, profile=profile, limit=validated_limit
     )
 
 
@@ -101,20 +65,16 @@ def get_top_domains_endpoint(
     browser: str | None = Query(None, description="フィルタ対象のブラウザ"),
     profile: str | None = Query(None, description="フィルタ対象のプロファイル"),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
-    config: BackendConfig = Depends(get_config),
+    repository: BrowserHistoryRepository = Depends(get_browser_history_repository),
     _api_key: None = Depends(verify_api_key_docs),
 ):
     """指定期間の domain ランキングを取得する。"""
-    params, validated_limit = _build_query_params(
-        db_connection,
-        config,
-        start_date,
-        end_date,
-        limit,
-    )
-    return get_top_domains(
-        params,
-        browser=browser,
-        profile=profile,
-        limit=validated_limit,
+    try:
+        start, end = validate_date_range(start_date, end_date)
+        validated_limit = validate_limit(limit, max_value=MAX_LIMIT)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return repository.get_top_domains(
+        db_connection, start, end, browser=browser, profile=profile, limit=validated_limit
     )

--- a/egograph/backend/api/browser_history_data.py
+++ b/egograph/backend/api/browser_history_data.py
@@ -13,7 +13,11 @@ from backend.constants import (
     MAX_LIMIT,
     MIN_LIMIT,
 )
-from backend.dependencies import get_db_connection, get_browser_history_repository, verify_api_key_docs
+from backend.dependencies import (
+    get_browser_history_repository,
+    get_db_connection,
+    verify_api_key_docs,
+)
 from backend.infrastructure.repositories.browser_history_repository import (
     BrowserHistoryRepository,
 )
@@ -48,7 +52,12 @@ def get_page_views_endpoint(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return repository.get_page_views(
-        db_connection, start, end, browser=browser, profile=profile, limit=validated_limit
+        db_connection,
+        start,
+        end,
+        browser=browser,
+        profile=profile,
+        limit=validated_limit,
     )
 
 
@@ -76,5 +85,10 @@ def get_top_domains_endpoint(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return repository.get_top_domains(
-        db_connection, start, end, browser=browser, profile=profile, limit=validated_limit
+        db_connection,
+        start,
+        end,
+        browser=browser,
+        profile=profile,
+        limit=validated_limit,
     )

--- a/egograph/backend/api/data.py
+++ b/egograph/backend/api/data.py
@@ -11,20 +11,14 @@ import duckdb
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from backend.api.schemas import ListeningStatsResponse, TopTrackResponse
-from backend.config import BackendConfig
 from backend.constants import (
     DEFAULT_TOP_TRACKS_LIMIT,
     MAX_LIMIT,
     MIN_LIMIT,
 )
-from backend.dependencies import get_config, get_db_connection, verify_api_key_docs
-from backend.infrastructure.database import (
-    QueryParams,
-    get_listening_stats,
-    get_top_tracks,
-)
+from backend.dependencies import get_db_connection, get_spotify_repository, verify_api_key_docs
+from backend.infrastructure.repositories.spotify_repository import SpotifyRepository
 from backend.validators import (
-    to_utc_range,
     validate_date_range,
     validate_granularity,
     validate_limit,
@@ -43,7 +37,7 @@ async def get_top_tracks_endpoint(
         DEFAULT_TOP_TRACKS_LIMIT, ge=MIN_LIMIT, le=MAX_LIMIT, description="取得する曲数"
     ),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
-    config: BackendConfig = Depends(get_config),
+    repository: SpotifyRepository = Depends(get_spotify_repository),
     _api_key: None = Depends(verify_api_key_docs),
 ):
     """指定期間で最も再生された曲を取得します。
@@ -67,18 +61,7 @@ async def get_top_tracks_endpoint(
         raise HTTPException(status_code=400, detail=str(e)) from e
 
     logger.info("Getting top tracks: %s to %s, limit=%s", start_date, end_date, limit)
-    utc_start, utc_end = to_utc_range(start, end, config.timezone)
-    params = QueryParams(
-        conn=db_connection,
-        bucket=config.r2.bucket_name,
-        events_path=config.r2.events_path,
-        start_date=start,
-        end_date=end,
-        utc_start=utc_start,
-        utc_end=utc_end,
-        tz_name=str(config.timezone),
-    )
-    return get_top_tracks(params, validated_limit)
+    return repository.get_top_tracks(db_connection, start, end, validated_limit)
 
 
 @router.get("/stats/listening", response_model=list[ListeningStatsResponse])
@@ -89,7 +72,7 @@ async def get_listening_stats_endpoint(
         "day", pattern="^(day|week|month)$", description="集計単位"
     ),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
-    config: BackendConfig = Depends(get_config),
+    repository: SpotifyRepository = Depends(get_spotify_repository),
     _api_key: None = Depends(verify_api_key_docs),
 ):
     """期間別の視聴統計を取得します。
@@ -118,15 +101,4 @@ async def get_listening_stats_endpoint(
         end_date,
         granularity,
     )
-    utc_start, utc_end = to_utc_range(start, end, config.timezone)
-    params = QueryParams(
-        conn=db_connection,
-        bucket=config.r2.bucket_name,
-        events_path=config.r2.events_path,
-        start_date=start,
-        end_date=end,
-        utc_start=utc_start,
-        utc_end=utc_end,
-        tz_name=str(config.timezone),
-    )
-    return get_listening_stats(params, validated_granularity)
+    return repository.get_listening_stats(db_connection, start, end, validated_granularity)

--- a/egograph/backend/api/data.py
+++ b/egograph/backend/api/data.py
@@ -16,7 +16,11 @@ from backend.constants import (
     MAX_LIMIT,
     MIN_LIMIT,
 )
-from backend.dependencies import get_db_connection, get_spotify_repository, verify_api_key_docs
+from backend.dependencies import (
+    get_db_connection,
+    get_spotify_repository,
+    verify_api_key_docs,
+)
 from backend.infrastructure.repositories.spotify_repository import SpotifyRepository
 from backend.validators import (
     validate_date_range,
@@ -101,4 +105,6 @@ async def get_listening_stats_endpoint(
         end_date,
         granularity,
     )
-    return repository.get_listening_stats(db_connection, start, end, validated_granularity)
+    return repository.get_listening_stats(
+        db_connection, start, end, validated_granularity
+    )

--- a/egograph/backend/api/github.py
+++ b/egograph/backend/api/github.py
@@ -22,7 +22,11 @@ from backend.constants import (
     MAX_LIMIT,
     MIN_LIMIT,
 )
-from backend.dependencies import get_db_connection, get_github_repository, verify_api_key_docs
+from backend.dependencies import (
+    get_db_connection,
+    get_github_repository,
+    verify_api_key_docs,
+)
 from backend.infrastructure.repositories.github_repository import GitHubRepository
 from backend.validators import (
     validate_date_range,
@@ -81,7 +85,13 @@ def get_pull_requests_endpoint(
         limit,
     )
     return repository.get_pull_requests(
-        db_connection, start, end, owner=owner, repo=repo, state=state, limit=validated_limit
+        db_connection,
+        start,
+        end,
+        owner=owner,
+        repo=repo,
+        state=state,
+        limit=validated_limit,
     )
 
 
@@ -156,7 +166,9 @@ def get_repositories_endpoint(
     """
     validated_limit = validate_limit(limit, max_value=1000)
     logger.info("Getting repositories: owner=%s, limit=%s", owner, validated_limit)
-    return repository.get_repositories(db_connection, owner=owner, limit=validated_limit)
+    return repository.get_repositories(
+        db_connection, owner=owner, limit=validated_limit
+    )
 
 
 @router.get("/activity-stats", response_model=list[ActivityStatsResponse])
@@ -195,7 +207,9 @@ def get_activity_stats_endpoint(
         end_date,
         granularity,
     )
-    return repository.get_activity_stats(db_connection, start, end, granularity=validated_granularity)
+    return repository.get_activity_stats(
+        db_connection, start, end, granularity=validated_granularity
+    )
 
 
 @router.get("/repo-summary-stats", response_model=list[RepoSummaryStatsResponse])
@@ -234,4 +248,6 @@ def get_repo_summary_stats_endpoint(
         owner,
         repo,
     )
-    return repository.get_repo_summary_stats(db_connection, start, end, owner=owner, repo_name=repo)
+    return repository.get_repo_summary_stats(
+        db_connection, start, end, owner=owner, repo_name=repo
+    )

--- a/egograph/backend/api/github.py
+++ b/egograph/backend/api/github.py
@@ -5,7 +5,7 @@ LLMを介さず、直接GitHub Worklogデータを取得するためのREST API�
 """
 
 import logging
-from datetime import date, datetime
+from datetime import date
 
 import duckdb
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -17,23 +17,14 @@ from backend.api.schemas import (
     RepositoryResponse,
     RepoSummaryStatsResponse,
 )
-from backend.config import BackendConfig
 from backend.constants import (
     DEFAULT_LIMIT,
     MAX_LIMIT,
     MIN_LIMIT,
 )
-from backend.dependencies import get_config, get_db_connection, verify_api_key_docs
-from backend.infrastructure.database import (
-    GitHubQueryParams,
-    get_activity_stats,
-    get_commits,
-    get_pull_requests,
-    get_repo_summary_stats,
-    get_repositories,
-)
+from backend.dependencies import get_db_connection, get_github_repository, verify_api_key_docs
+from backend.infrastructure.repositories.github_repository import GitHubRepository
 from backend.validators import (
-    to_utc_range,
     validate_date_range,
     validate_granularity,
     validate_limit,
@@ -55,7 +46,7 @@ def get_pull_requests_endpoint(
         DEFAULT_LIMIT, ge=MIN_LIMIT, le=MAX_LIMIT, description="取得するPR数"
     ),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
-    config: BackendConfig = Depends(get_config),
+    repository: GitHubRepository = Depends(get_github_repository),
     _api_key: None = Depends(verify_api_key_docs),
 ):
     """指定期間のPull Requestイベントを取得します。
@@ -89,20 +80,8 @@ def get_pull_requests_endpoint(
         state,
         limit,
     )
-    utc_start, utc_end = to_utc_range(start, end, config.timezone)
-    params = GitHubQueryParams(
-        conn=db_connection,
-        bucket=config.r2.bucket_name,
-        events_path=config.r2.events_path,
-        master_path=config.r2.master_path,
-        start_date=start,
-        end_date=end,
-        utc_start=utc_start,
-        utc_end=utc_end,
-        tz_name=str(config.timezone),
-    )
-    return get_pull_requests(
-        params, owner=owner, repo=repo, state=state, limit=validated_limit
+    return repository.get_pull_requests(
+        db_connection, start, end, owner=owner, repo=repo, state=state, limit=validated_limit
     )
 
 
@@ -116,7 +95,7 @@ def get_commits_endpoint(
         DEFAULT_LIMIT, ge=MIN_LIMIT, le=MAX_LIMIT, description="取得するCommit数"
     ),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
-    config: BackendConfig = Depends(get_config),
+    repository: GitHubRepository = Depends(get_github_repository),
     _api_key: None = Depends(verify_api_key_docs),
 ):
     """指定期間のCommitイベントを取得します。
@@ -148,19 +127,9 @@ def get_commits_endpoint(
         repo,
         limit,
     )
-    utc_start, utc_end = to_utc_range(start, end, config.timezone)
-    params = GitHubQueryParams(
-        conn=db_connection,
-        bucket=config.r2.bucket_name,
-        events_path=config.r2.events_path,
-        master_path=config.r2.master_path,
-        start_date=start,
-        end_date=end,
-        utc_start=utc_start,
-        utc_end=utc_end,
-        tz_name=str(config.timezone),
+    return repository.get_commits(
+        db_connection, start, end, owner=owner, repo=repo, limit=validated_limit
     )
-    return get_commits(params, owner=owner, repo=repo, limit=validated_limit)
 
 
 @router.get("/repositories", response_model=list[RepositoryResponse])
@@ -170,7 +139,7 @@ def get_repositories_endpoint(
         DEFAULT_LIMIT, ge=MIN_LIMIT, le=MAX_LIMIT, description="取得するRepository数"
     ),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
-    config: BackendConfig = Depends(get_config),
+    repository: GitHubRepository = Depends(get_github_repository),
     _api_key: None = Depends(verify_api_key_docs),
 ):
     """Repositoryマスターを取得します。
@@ -187,18 +156,7 @@ def get_repositories_endpoint(
     """
     validated_limit = validate_limit(limit, max_value=1000)
     logger.info("Getting repositories: owner=%s, limit=%s", owner, validated_limit)
-    params = GitHubQueryParams(
-        conn=db_connection,
-        bucket=config.r2.bucket_name,
-        events_path=config.r2.events_path,
-        master_path=config.r2.master_path,
-        start_date=date(1, 1, 1),
-        end_date=date(9999, 12, 31),
-        utc_start=datetime.min,
-        utc_end=datetime.max,
-        tz_name=str(config.timezone),
-    )
-    return get_repositories(params, owner=owner, limit=validated_limit)
+    return repository.get_repositories(db_connection, owner=owner, limit=validated_limit)
 
 
 @router.get("/activity-stats", response_model=list[ActivityStatsResponse])
@@ -209,7 +167,7 @@ def get_activity_stats_endpoint(
         "day", pattern="^(day|week|month)$", description="集計単位"
     ),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
-    config: BackendConfig = Depends(get_config),
+    repository: GitHubRepository = Depends(get_github_repository),
     _api_key: None = Depends(verify_api_key_docs),
 ):
     """期間別のアクティビティ統計を取得します。
@@ -237,19 +195,7 @@ def get_activity_stats_endpoint(
         end_date,
         granularity,
     )
-    utc_start, utc_end = to_utc_range(start, end, config.timezone)
-    params = GitHubQueryParams(
-        conn=db_connection,
-        bucket=config.r2.bucket_name,
-        events_path=config.r2.events_path,
-        master_path=config.r2.master_path,
-        start_date=start,
-        end_date=end,
-        utc_start=utc_start,
-        utc_end=utc_end,
-        tz_name=str(config.timezone),
-    )
-    return get_activity_stats(params, granularity=validated_granularity)
+    return repository.get_activity_stats(db_connection, start, end, granularity=validated_granularity)
 
 
 @router.get("/repo-summary-stats", response_model=list[RepoSummaryStatsResponse])
@@ -259,7 +205,7 @@ def get_repo_summary_stats_endpoint(
     owner: str | None = Query(None, description="フィルタ対象のオーナー"),
     repo: str | None = Query(None, description="フィルタ対象のリポジトリ"),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
-    config: BackendConfig = Depends(get_config),
+    repository: GitHubRepository = Depends(get_github_repository),
     _api_key: None = Depends(verify_api_key_docs),
 ):
     """リポジトリ別のサマリー統計を取得します。
@@ -288,16 +234,4 @@ def get_repo_summary_stats_endpoint(
         owner,
         repo,
     )
-    utc_start, utc_end = to_utc_range(start, end, config.timezone)
-    params = GitHubQueryParams(
-        conn=db_connection,
-        bucket=config.r2.bucket_name,
-        events_path=config.r2.events_path,
-        master_path=config.r2.master_path,
-        start_date=start,
-        end_date=end,
-        utc_start=utc_start,
-        utc_end=utc_end,
-        tz_name=str(config.timezone),
-    )
-    return get_repo_summary_stats(params, owner=owner, repo_name=repo)
+    return repository.get_repo_summary_stats(db_connection, start, end, owner=owner, repo_name=repo)

--- a/egograph/backend/api/youtube.py
+++ b/egograph/backend/api/youtube.py
@@ -115,7 +115,9 @@ async def get_watching_stats_endpoint(
         granularity,
     )
 
-    return repository.get_watching_stats(db_connection, start, end, validated_granularity)
+    return repository.get_watching_stats(
+        db_connection, start, end, validated_granularity
+    )
 
 
 @router.get("/stats/top-videos", response_model=list[TopVideoResponse])

--- a/egograph/backend/api/youtube.py
+++ b/egograph/backend/api/youtube.py
@@ -6,6 +6,7 @@ YouTube視聴イベントデータを直接取得するためのREST APIエン�
 import logging
 from datetime import date
 
+import duckdb
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from backend.api.schemas import (
@@ -14,13 +15,12 @@ from backend.api.schemas import (
     WatchEventResponse,
     WatchingStatsResponse,
 )
-from backend.config import BackendConfig
 from backend.constants import (
     DEFAULT_TOP_TRACKS_LIMIT,
     MAX_LIMIT,
     MIN_LIMIT,
 )
-from backend.dependencies import get_config
+from backend.dependencies import get_db_connection, get_youtube_repository
 from backend.infrastructure.repositories.youtube_repository import YouTubeRepository
 from backend.validators import (
     validate_date_range,
@@ -43,7 +43,8 @@ async def get_watch_events_endpoint(
         le=MAX_LIMIT,
         description="取得するイベント数",
     ),
-    config: BackendConfig = Depends(get_config),
+    db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
+    repository: YouTubeRepository = Depends(get_youtube_repository),
 ):
     """指定期間の視聴イベントを取得します。
 
@@ -74,8 +75,7 @@ async def get_watch_events_endpoint(
         limit,
     )
 
-    repository = YouTubeRepository(config.r2, tz=config.timezone)
-    return repository.get_watch_events(start, end, validated_limit)
+    return repository.get_watch_events(db_connection, start, end, validated_limit)
 
 
 @router.get("/stats/watching", response_model=list[WatchingStatsResponse])
@@ -85,7 +85,8 @@ async def get_watching_stats_endpoint(
     granularity: str = Query(
         "day", pattern="^(day|week|month)$", description="集計単位"
     ),
-    config: BackendConfig = Depends(get_config),
+    db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
+    repository: YouTubeRepository = Depends(get_youtube_repository),
 ):
     """期間別の視聴統計を取得します。
 
@@ -114,8 +115,7 @@ async def get_watching_stats_endpoint(
         granularity,
     )
 
-    repository = YouTubeRepository(config.r2, tz=config.timezone)
-    return repository.get_watching_stats(start, end, validated_granularity)
+    return repository.get_watching_stats(db_connection, start, end, validated_granularity)
 
 
 @router.get("/stats/top-videos", response_model=list[TopVideoResponse])
@@ -128,7 +128,8 @@ async def get_top_videos_endpoint(
         le=MAX_LIMIT,
         description="取得する動画数",
     ),
-    config: BackendConfig = Depends(get_config),
+    db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
+    repository: YouTubeRepository = Depends(get_youtube_repository),
 ):
     """指定期間で最も視聴された動画を取得します。
 
@@ -157,8 +158,7 @@ async def get_top_videos_endpoint(
         limit,
     )
 
-    repository = YouTubeRepository(config.r2, tz=config.timezone)
-    return repository.get_top_videos(start, end, validated_limit)
+    return repository.get_top_videos(db_connection, start, end, validated_limit)
 
 
 @router.get("/stats/top-channels", response_model=list[TopChannelResponse])
@@ -171,7 +171,8 @@ async def get_top_channels_endpoint(
         le=MAX_LIMIT,
         description="取得するチャンネル数",
     ),
-    config: BackendConfig = Depends(get_config),
+    db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
+    repository: YouTubeRepository = Depends(get_youtube_repository),
 ):
     """指定期間で最も視聴されたチャンネルを取得します。
 
@@ -200,5 +201,4 @@ async def get_top_channels_endpoint(
         limit,
     )
 
-    repository = YouTubeRepository(config.r2, tz=config.timezone)
-    return repository.get_top_channels(start, end, validated_limit)
+    return repository.get_top_channels(db_connection, start, end, validated_limit)

--- a/egograph/backend/dependencies.py
+++ b/egograph/backend/dependencies.py
@@ -10,7 +10,7 @@ import duckdb
 from fastapi import Depends, Security
 from fastapi.security import APIKeyHeader
 
-from backend.config import BackendConfig
+from backend.config import BackendConfig, R2Config
 from backend.infrastructure.database import DuckDBConnection
 from backend.infrastructure.repositories.browser_history_repository import (
     BrowserHistoryRepository,
@@ -80,25 +80,42 @@ def get_db_connection(
         yield conn
 
 
+def _require_r2(config: BackendConfig) -> R2Config:
+    """R2設定が存在することを検証して返す。
+
+    Args:
+        config: Backend設定
+
+    Returns:
+        R2Config
+
+    Raises:
+        ValueError: R2設定が不足している場合
+    """
+    if not config.r2:
+        raise ValueError("R2 configuration is required")
+    return config.r2
+
+
 def get_spotify_repository(
     config: BackendConfig = Depends(get_config),
 ) -> SpotifyRepository:
-    return SpotifyRepository(config.r2, tz=config.timezone)
+    return SpotifyRepository(_require_r2(config), tz=config.timezone)
 
 
 def get_github_repository(
     config: BackendConfig = Depends(get_config),
 ) -> GitHubRepository:
-    return GitHubRepository(config.r2, tz=config.timezone)
+    return GitHubRepository(_require_r2(config), tz=config.timezone)
 
 
 def get_browser_history_repository(
     config: BackendConfig = Depends(get_config),
 ) -> BrowserHistoryRepository:
-    return BrowserHistoryRepository(config.r2, tz=config.timezone)
+    return BrowserHistoryRepository(_require_r2(config), tz=config.timezone)
 
 
 def get_youtube_repository(
     config: BackendConfig = Depends(get_config),
 ) -> YouTubeRepository:
-    return YouTubeRepository(config.r2, tz=config.timezone)
+    return YouTubeRepository(_require_r2(config), tz=config.timezone)

--- a/egograph/backend/dependencies.py
+++ b/egograph/backend/dependencies.py
@@ -12,6 +12,12 @@ from fastapi.security import APIKeyHeader
 
 from backend.config import BackendConfig
 from backend.infrastructure.database import DuckDBConnection
+from backend.infrastructure.repositories.browser_history_repository import (
+    BrowserHistoryRepository,
+)
+from backend.infrastructure.repositories.github_repository import GitHubRepository
+from backend.infrastructure.repositories.spotify_repository import SpotifyRepository
+from backend.infrastructure.repositories.youtube_repository import YouTubeRepository
 
 logger = logging.getLogger(__name__)
 
@@ -72,3 +78,27 @@ def get_db_connection(
 
     with DuckDBConnection(config.r2) as conn:
         yield conn
+
+
+def get_spotify_repository(
+    config: BackendConfig = Depends(get_config),
+) -> SpotifyRepository:
+    return SpotifyRepository(config.r2, tz=config.timezone)
+
+
+def get_github_repository(
+    config: BackendConfig = Depends(get_config),
+) -> GitHubRepository:
+    return GitHubRepository(config.r2, tz=config.timezone)
+
+
+def get_browser_history_repository(
+    config: BackendConfig = Depends(get_config),
+) -> BrowserHistoryRepository:
+    return BrowserHistoryRepository(config.r2, tz=config.timezone)
+
+
+def get_youtube_repository(
+    config: BackendConfig = Depends(get_config),
+) -> YouTubeRepository:
+    return YouTubeRepository(config.r2, tz=config.timezone)

--- a/egograph/backend/infrastructure/database/__init__.py
+++ b/egograph/backend/infrastructure/database/__init__.py
@@ -29,10 +29,6 @@ from backend.infrastructure.database.queries import (
 )
 from backend.infrastructure.database.query_params import QueryParams, execute_query
 
-# TODO(Step4): Remove backward-compatible aliases after API files are updated
-BrowserHistoryQueryParams = QueryParams  # noqa: A004  # backward compat
-GitHubQueryParams = QueryParams  # noqa: A004  # backward compat
-
 __all__ = [
     # R2 Data Lake (DuckDB)
     "DuckDBConnection",

--- a/egograph/backend/infrastructure/database/__init__.py
+++ b/egograph/backend/infrastructure/database/__init__.py
@@ -4,13 +4,11 @@ DuckDB 接続管理とクエリユーティリティを提供します。
 """
 
 from backend.infrastructure.database.browser_history_queries import (
-    BrowserHistoryQueryParams,
     get_page_views,
     get_top_domains,
 )
 from backend.infrastructure.database.connection import DuckDBConnection
 from backend.infrastructure.database.github_queries import (
-    GitHubQueryParams,
     get_activity_stats,
     get_commits,
     get_prs_parquet_path,
@@ -24,19 +22,21 @@ from backend.infrastructure.database.parquet_paths import (
     build_partition_paths,
 )
 from backend.infrastructure.database.queries import (
-    QueryParams,
-    execute_query,
     get_listening_stats,
     get_parquet_path,
     get_top_tracks,
     search_tracks_by_name,
 )
+from backend.infrastructure.database.query_params import QueryParams, execute_query
+
+# TODO(Step4): Remove backward-compatible aliases after API files are updated
+BrowserHistoryQueryParams = QueryParams  # noqa: A004  # backward compat
+GitHubQueryParams = QueryParams  # noqa: A004  # backward compat
 
 __all__ = [
     # R2 Data Lake (DuckDB)
     "DuckDBConnection",
     # Browser History
-    "BrowserHistoryQueryParams",
     "get_page_views",
     "get_top_domains",
     # Spotify
@@ -49,7 +49,6 @@ __all__ = [
     "build_partition_paths",
     "build_dataset_glob",
     # GitHub
-    "GitHubQueryParams",
     "get_prs_parquet_path",
     "get_pull_requests",
     "get_commits",

--- a/egograph/backend/infrastructure/database/__init__.py
+++ b/egograph/backend/infrastructure/database/__init__.py
@@ -11,7 +11,6 @@ from backend.infrastructure.database.connection import DuckDBConnection
 from backend.infrastructure.database.github_queries import (
     get_activity_stats,
     get_commits,
-    get_prs_parquet_path,
     get_pull_requests,
     get_repo_summary_stats,
     get_repos_parquet_path,
@@ -25,7 +24,6 @@ from backend.infrastructure.database.queries import (
     get_listening_stats,
     get_parquet_path,
     get_top_tracks,
-    search_tracks_by_name,
 )
 from backend.infrastructure.database.query_params import QueryParams, execute_query
 
@@ -41,11 +39,9 @@ __all__ = [
     "get_parquet_path",
     "get_top_tracks",
     "get_listening_stats",
-    "search_tracks_by_name",
     "build_partition_paths",
     "build_dataset_glob",
     # GitHub
-    "get_prs_parquet_path",
     "get_pull_requests",
     "get_commits",
     "get_repositories",

--- a/egograph/backend/infrastructure/database/browser_history_queries.py
+++ b/egograph/backend/infrastructure/database/browser_history_queries.py
@@ -1,84 +1,24 @@
 """Browser History データ用のSQLクエリテンプレートとヘルパー関数。"""
 
-from dataclasses import dataclass
-from datetime import date, datetime
 from typing import Any
 
-import duckdb
-
-from backend.config import R2Config
 from backend.constants import DEFAULT_PAGE_VIEWS_LIMIT, DEFAULT_TOP_DOMAINS_LIMIT
 from backend.infrastructure.database.parquet_paths import build_partition_paths
-from backend.infrastructure.database.queries import execute_query
-
-BROWSER_HISTORY_PAGE_VIEWS_PARTITION_PATH = (
-    "s3://{bucket}/{events_path}browser_history/page_views/"
-    "year={year}/month={month}/**/*.parquet"
-)
+from backend.infrastructure.database.query_params import QueryParams, execute_query
 
 
-@dataclass
-class BrowserHistoryQueryParams:
-    """Browser Historyクエリ用の共通パラメータ。"""
-
-    conn: duckdb.DuckDBPyConnection
-    bucket: str
-    events_path: str
-    start_date: date
-    end_date: date
-    utc_start: datetime
-    utc_end: datetime
-    tz_name: str = "UTC"
-    r2_config: R2Config | None = None
-
-
-def _generate_browser_history_partition_paths(
-    bucket: str,
-    events_path: str,
-    utc_start: datetime,
-    utc_end: datetime,
-) -> list[str]:
-    """指定期間のBrowser Historyパーティションパスを生成する。"""
-    paths: list[str] = []
-    current = date(utc_start.year, utc_start.month, 1)
-    end_month = date(utc_end.year, utc_end.month, 1)
-
-    while current <= end_month:
-        paths.append(
-            BROWSER_HISTORY_PAGE_VIEWS_PARTITION_PATH.format(
-                bucket=bucket,
-                events_path=events_path,
-                year=current.year,
-                month=f"{current.month:02d}",
-            )
-        )
-        if current.month == 12:
-            current = current.replace(year=current.year + 1, month=1)
-        else:
-            current = current.replace(month=current.month + 1)
-
-    return paths
-
-
-def _resolve_partition_paths(params: BrowserHistoryQueryParams) -> list[str]:
-    if params.r2_config is not None:
-        return build_partition_paths(
-            params.r2_config,
-            data_domain="events",
-            dataset_path="browser_history/page_views",
-            utc_start=params.utc_start,
-            utc_end=params.utc_end,
-        )
-    return _generate_browser_history_partition_paths(
-        params.bucket,
-        params.events_path,
-        params.utc_start,
-        params.utc_end,
+def _resolve_partition_paths(params: QueryParams) -> list[str]:
+    return build_partition_paths(
+        params.r2_config,
+        data_domain="events",
+        dataset_path="browser_history/page_views",
+        utc_start=params.utc_start,
+        utc_end=params.utc_end,
     )
 
 
 def get_page_views(
-    params: BrowserHistoryQueryParams,
+    params: QueryParams,
     *,
     browser: str | None = None,
     profile: str | None = None,
@@ -121,7 +61,7 @@ def get_page_views(
 
 
 def get_top_domains(
-    params: BrowserHistoryQueryParams,
+    params: QueryParams,
     *,
     browser: str | None = None,
     profile: str | None = None,

--- a/egograph/backend/infrastructure/database/github_queries.py
+++ b/egograph/backend/infrastructure/database/github_queries.py
@@ -1,42 +1,17 @@
 """GitHub データ用のSQLクエリテンプレートとヘルパー関数。"""
 
 import logging
-from dataclasses import dataclass
-from datetime import date, datetime
 from typing import Any
 
-import duckdb
-import numpy as np
-
-from backend.config import R2Config
 from backend.infrastructure.database.parquet_paths import build_partition_paths
+from backend.infrastructure.database.query_params import QueryParams, execute_query
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class GitHubQueryParams:
-    """GitHubデータクエリ用の共通パラメータ。"""
-
-    conn: duckdb.DuckDBPyConnection
-    bucket: str
-    events_path: str
-    master_path: str
-    start_date: date
-    end_date: date
-    utc_start: datetime
-    utc_end: datetime
-    tz_name: str = "UTC"
-    r2_config: R2Config | None = None
-
-
 # Parquetパスパターン
 GITHUB_PRS_PATH = "s3://{bucket}/{events_path}github/pull_requests/**/*.parquet"
-GITHUB_PRS_PARTITION_PATH = "s3://{bucket}/{events_path}github/pull_requests/year={year}/month={month}/**/*.parquet"
 GITHUB_COMMITS_PATH = "s3://{bucket}/{events_path}github/commits/**/*.parquet"
-GITHUB_COMMITS_PARTITION_PATH = (
-    "s3://{bucket}/{events_path}github/commits/year={year}/month={month}/**/*.parquet"
-)
 GITHUB_REPOS_PATH = "s3://{bucket}/{master_path}github/repositories/**/*.parquet"
 
 
@@ -79,141 +54,28 @@ def get_repos_parquet_path(bucket: str, master_path: str) -> str:
     return GITHUB_REPOS_PATH.format(bucket=bucket, master_path=master_path)
 
 
-def _generate_partition_paths(
-    path_template: str,
-    bucket: str,
-    events_path: str,
-    utc_start: datetime,
-    utc_end: datetime,
-    log_label: str,
-) -> list[str]:
-    """指定期間の月パーティションパスリストを生成します。"""
-    paths: list[str] = []
-    current = date(utc_start.year, utc_start.month, 1)
-    end_month = date(utc_end.year, utc_end.month, 1)
-
-    while current <= end_month:
-        path = path_template.format(
-            bucket=bucket,
-            events_path=events_path,
-            year=current.year,
-            month=f"{current.month:02d}",
-        )
-        paths.append(path)
-
-        if current.month == 12:
-            current = current.replace(year=current.year + 1, month=1)
-        else:
-            current = current.replace(month=current.month + 1)
-
-    logger.debug(
-        "Generated %d %s partition paths for period %s to %s",
-        len(paths),
-        log_label,
-        utc_start,
-        utc_end,
-    )
-    return paths
-
-
-def _generate_pr_partition_paths(
-    bucket: str, events_path: str, utc_start: datetime, utc_end: datetime
-) -> list[str]:
-    """指定期間の月パーティションに対応するPRイベントParquetパスリストを生成します。"""
-    return _generate_partition_paths(
-        GITHUB_PRS_PARTITION_PATH, bucket, events_path, utc_start, utc_end, "PR"
+def _resolve_pr_partition_paths(params: QueryParams) -> list[str]:
+    return build_partition_paths(
+        params.r2_config,
+        data_domain="events",
+        dataset_path="github/pull_requests",
+        utc_start=params.utc_start,
+        utc_end=params.utc_end,
     )
 
 
-def _generate_commit_partition_paths(
-    bucket: str, events_path: str, utc_start: datetime, utc_end: datetime
-) -> list[str]:
-    """指定期間の月パーティションに対応するCommitイベントParquetパスリストを生成します。"""
-    return _generate_partition_paths(
-        GITHUB_COMMITS_PARTITION_PATH,
-        bucket,
-        events_path,
-        utc_start,
-        utc_end,
-        "commit",
+def _resolve_commit_partition_paths(params: QueryParams) -> list[str]:
+    return build_partition_paths(
+        params.r2_config,
+        data_domain="events",
+        dataset_path="github/commits",
+        utc_start=params.utc_start,
+        utc_end=params.utc_end,
     )
-
-
-def _resolve_pr_partition_paths(params: GitHubQueryParams) -> list[str]:
-    if params.r2_config is not None:
-        return build_partition_paths(
-            params.r2_config,
-            data_domain="events",
-            dataset_path="github/pull_requests",
-            utc_start=params.utc_start,
-            utc_end=params.utc_end,
-        )
-    return _generate_pr_partition_paths(
-        params.bucket, params.events_path, params.utc_start, params.utc_end
-    )
-
-
-def _resolve_commit_partition_paths(params: GitHubQueryParams) -> list[str]:
-    if params.r2_config is not None:
-        return build_partition_paths(
-            params.r2_config,
-            data_domain="events",
-            dataset_path="github/commits",
-            utc_start=params.utc_start,
-            utc_end=params.utc_end,
-        )
-    return _generate_commit_partition_paths(
-        params.bucket, params.events_path, params.utc_start, params.utc_end
-    )
-
-
-def execute_query(
-    conn: duckdb.DuckDBPyConnection, sql: str, params: list[Any] | None = None
-) -> list[dict[str, Any]]:
-    """SQLクエリを実行し、結果を辞書のリストとして返します。
-
-    Args:
-        conn: DuckDBコネクション
-        sql: 実行するSQLクエリ
-        params: SQLパラメータ（オプション）
-
-    Returns:
-        クエリ結果（辞書のリスト）
-
-    Raises:
-        duckdb.Error: SQLクエリ実行に失敗した場合
-    """
-    result = conn.execute(sql, params or [])
-    df = result.df()
-    records = df.to_dict(orient="records")
-    # numpy/pandas型をPython標準型に変換（JSONシリアライズ対応）
-    return [
-        {k: _convert_numpy_types(v) for k, v in record.items()} for record in records
-    ]
-
-
-def _convert_numpy_types(value: Any) -> Any:
-    """numpy/pandas型をPython標準型に変換します。
-
-    Args:
-        value: 変換対象の値
-
-    Returns:
-        Python標準型に変換された値
-    """
-    if isinstance(value, np.ndarray):
-        return value.tolist()
-    if isinstance(value, (np.integer, np.int64, np.int32)):
-        return int(value)
-    if isinstance(value, (np.floating, np.float64, np.float32)):
-        return float(value)
-    if isinstance(value, (np.bool_, bool)):
-        return bool(value)
-    return value
 
 
 def get_pull_requests(
-    params: GitHubQueryParams,
+    params: QueryParams,
     owner: str | None = None,
     repo: str | None = None,
     state: str | None = None,
@@ -318,7 +180,7 @@ def get_pull_requests(
 
 
 def get_commits(
-    params: GitHubQueryParams,
+    params: QueryParams,
     owner: str | None = None,
     repo: str | None = None,
     limit: int | None = None,
@@ -396,7 +258,7 @@ def get_commits(
 
 
 def get_repositories(
-    params: GitHubQueryParams,
+    params: QueryParams,
     owner: str | None = None,
     repo: str | None = None,
     limit: int | None = None,
@@ -436,7 +298,9 @@ def get_repositories(
             ...
         ]
     """
-    repos_path = get_repos_parquet_path(params.bucket, params.master_path)
+    repos_path = get_repos_parquet_path(
+        params.r2_config.bucket_name, params.r2_config.master_path
+    )
 
     query = """
         SELECT
@@ -492,7 +356,7 @@ def get_repositories(
 
 
 def get_activity_stats(
-    params: GitHubQueryParams,
+    params: QueryParams,
     granularity: str = "day",
 ) -> list[dict[str, Any]]:
     """期間別のアクティビティ統計を取得します。
@@ -617,7 +481,7 @@ def get_activity_stats(
 
 
 def get_repo_summary_stats(
-    params: GitHubQueryParams,
+    params: QueryParams,
     owner: str | None = None,
     repo_name: str | None = None,
 ) -> list[dict[str, Any]]:

--- a/egograph/backend/infrastructure/database/github_queries.py
+++ b/egograph/backend/infrastructure/database/github_queries.py
@@ -10,35 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 # Parquetパスパターン
-GITHUB_PRS_PATH = "s3://{bucket}/{events_path}github/pull_requests/**/*.parquet"
-GITHUB_COMMITS_PATH = "s3://{bucket}/{events_path}github/commits/**/*.parquet"
 GITHUB_REPOS_PATH = "s3://{bucket}/{master_path}github/repositories/**/*.parquet"
-
-
-def get_prs_parquet_path(bucket: str, events_path: str) -> str:
-    """GitHub PRイベントのS3パスパターンを生成します。
-
-    Args:
-        bucket: R2バケット名
-        events_path: イベントデータのパスプレフィックス
-
-    Returns:
-        S3パスパターン（例: s3://egograph/events/github/pull_requests/**/*.parquet）
-    """
-    return GITHUB_PRS_PATH.format(bucket=bucket, events_path=events_path)
-
-
-def get_commits_parquet_path(bucket: str, events_path: str) -> str:
-    """GitHub CommitイベントのS3パスパターンを生成します。
-
-    Args:
-        bucket: R2バケット名
-        events_path: イベントデータのパスプレフィックス
-
-    Returns:
-        S3パスパターン（例: s3://egograph/events/github/commits/**/*.parquet）
-    """
-    return GITHUB_COMMITS_PATH.format(bucket=bucket, events_path=events_path)
 
 
 def get_repos_parquet_path(bucket: str, master_path: str) -> str:

--- a/egograph/backend/infrastructure/database/queries.py
+++ b/egograph/backend/infrastructure/database/queries.py
@@ -1,13 +1,8 @@
 """Spotify データ用のSQLクエリテンプレートとヘルパー関数。"""
 
 import logging
-from dataclasses import dataclass
-from datetime import date, datetime
 from typing import Any
 
-import duckdb
-
-from backend.config import R2Config
 from backend.constants import (
     DEFAULT_SEARCH_TRACKS_LIMIT,
     DEFAULT_TOP_TRACKS_LIMIT,
@@ -17,30 +12,13 @@ from backend.infrastructure.database.parquet_paths import (
     build_dataset_glob,
     build_partition_paths,
 )
+from backend.infrastructure.database.query_params import QueryParams, execute_query
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class QueryParams:
-    """Spotifyデータクエリ用の共通パラメータ。"""
-
-    conn: duckdb.DuckDBPyConnection
-    bucket: str
-    events_path: str
-    start_date: date
-    end_date: date
-    utc_start: datetime
-    utc_end: datetime
-    tz_name: str = "UTC"
-    r2_config: R2Config | None = None
-
-
 # Parquetパスパターン
 SPOTIFY_PLAYS_PATH = "s3://{bucket}/{events_path}spotify/plays/**/*.parquet"
-SPOTIFY_PLAYS_PARTITION_PATH = (
-    "s3://{bucket}/{events_path}spotify/plays/year={year}/month={month}/**/*.parquet"
-)
 
 
 def get_parquet_path(bucket: str, events_path: str) -> str:
@@ -56,81 +34,14 @@ def get_parquet_path(bucket: str, events_path: str) -> str:
     return SPOTIFY_PLAYS_PATH.format(bucket=bucket, events_path=events_path)
 
 
-def _generate_partition_paths(
-    bucket: str, events_path: str, utc_start: datetime, utc_end: datetime
-) -> list[str]:
-    """指定期間の月パーティションに対応するParquetパスリストを生成します。
-
-    Args:
-        bucket: R2バケット名
-        events_path: イベントデータのパスプレフィックス
-        utc_start: 開始時刻 (naive UTC)
-        utc_end: 終了時刻 (naive UTC, 排他)
-
-    Returns:
-        月パーティションごとのS3パスリスト
-    """
-    paths: list[str] = []
-    current = date(utc_start.year, utc_start.month, 1)
-    # utc_end は排他だが、その月のデータを含む可能性があるため end の月も含める
-    end_month = date(utc_end.year, utc_end.month, 1)
-
-    while current <= end_month:
-        path = SPOTIFY_PLAYS_PARTITION_PATH.format(
-            bucket=bucket,
-            events_path=events_path,
-            year=current.year,
-            month=f"{current.month:02d}",
-        )
-        paths.append(path)
-
-        if current.month == 12:
-            current = current.replace(year=current.year + 1, month=1)
-        else:
-            current = current.replace(month=current.month + 1)
-
-    logger.debug(
-        "Generated %d partition paths for period %s to %s",
-        len(paths),
-        utc_start,
-        utc_end,
-    )
-    return paths
-
-
 def _resolve_partition_paths(params: QueryParams) -> list[str]:
-    if params.r2_config is not None:
-        return build_partition_paths(
-            params.r2_config,
-            data_domain="events",
-            dataset_path="spotify/plays",
-            utc_start=params.utc_start,
-            utc_end=params.utc_end,
-        )
-    return _generate_partition_paths(
-        params.bucket, params.events_path, params.utc_start, params.utc_end
+    return build_partition_paths(
+        params.r2_config,
+        data_domain="events",
+        dataset_path="spotify/plays",
+        utc_start=params.utc_start,
+        utc_end=params.utc_end,
     )
-
-
-def execute_query(
-    conn: duckdb.DuckDBPyConnection, sql: str, params: list[Any] | None = None
-) -> list[dict[str, Any]]:
-    """SQLクエリを実行し、結果を辞書のリストとして返します。
-
-    Args:
-        conn: DuckDBコネクション
-        sql: 実行するSQLクエリ
-        params: SQLパラメータ（オプション）
-
-    Returns:
-        クエリ結果（辞書のリスト）
-
-    Raises:
-        duckdb.Error: SQLクエリ実行に失敗した場合
-    """
-    result = conn.execute(sql, params or [])
-    df = result.df()
-    return df.to_dict(orient="records")
 
 
 def get_top_tracks(
@@ -282,14 +193,10 @@ def search_tracks_by_name(
         ]
     """
     # 全期間を対象とするため、ワイルドカードパスを使用
-    parquet_path = (
-        build_dataset_glob(
-            params.r2_config,
-            data_domain="events",
-            dataset_path="spotify/plays",
-        )
-        if params.r2_config is not None
-        else get_parquet_path(params.bucket, params.events_path)
+    parquet_path = build_dataset_glob(
+        params.r2_config,
+        data_domain="events",
+        dataset_path="spotify/plays",
     )
 
     search_pattern = f"%{query}%"

--- a/egograph/backend/infrastructure/database/queries.py
+++ b/egograph/backend/infrastructure/database/queries.py
@@ -4,12 +4,10 @@ import logging
 from typing import Any
 
 from backend.constants import (
-    DEFAULT_SEARCH_TRACKS_LIMIT,
     DEFAULT_TOP_TRACKS_LIMIT,
     MS_TO_MINUTES_FACTOR,
 )
 from backend.infrastructure.database.parquet_paths import (
-    build_dataset_glob,
     build_partition_paths,
 )
 from backend.infrastructure.database.query_params import QueryParams, execute_query
@@ -167,56 +165,4 @@ def get_listening_stats(
     )
     return execute_query(
         params.conn, query, [partition_paths, params.utc_start, params.utc_end]
-    )
-
-
-def search_tracks_by_name(
-    params: QueryParams, query: str, limit: int = DEFAULT_SEARCH_TRACKS_LIMIT
-) -> list[dict[str, Any]]:
-    """トラック名またはアーティスト名で検索します。
-
-    Args:
-        params: クエリパラメータ（コネクション、バケット、パス）
-        query: 検索クエリ（部分一致）
-        limit: 取得する結果数（デフォルト: 20）
-
-    Returns:
-        検索結果のリスト
-        [
-            {
-                "track_name": str,
-                "artist": str,
-                "play_count": int,
-                "last_played": str
-            },
-            ...
-        ]
-    """
-    # 全期間を対象とするため、ワイルドカードパスを使用
-    parquet_path = build_dataset_glob(
-        params.r2_config,
-        data_domain="events",
-        dataset_path="spotify/plays",
-    )
-
-    search_pattern = f"%{query}%"
-    sql = """
-        SELECT
-            track_name,
-            CASE
-                WHEN len(artist_names) >= 1 THEN artist_names[1] ELSE NULL
-            END as artist,
-            COUNT(*) as play_count,
-            MAX(played_at_utc)::VARCHAR as last_played
-        FROM read_parquet(?)
-        WHERE LOWER(track_name) LIKE LOWER(?)
-           OR (len(artist_names) >= 1 AND LOWER(artist_names[1]) LIKE LOWER(?))
-        GROUP BY track_name, artist
-        ORDER BY play_count DESC
-        LIMIT ?
-    """
-
-    logger.debug("Searching tracks with query: %s, limit=%s", query, limit)
-    return execute_query(
-        params.conn, sql, [parquet_path, search_pattern, search_pattern, limit]
     )

--- a/egograph/backend/infrastructure/database/query_params.py
+++ b/egograph/backend/infrastructure/database/query_params.py
@@ -6,7 +6,7 @@ numpy/pandas型の自動変換によるJSONシリアライズ対応を含みま�
 import logging
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Any
+from typing import Any, Sequence
 
 import duckdb
 import numpy as np
@@ -60,7 +60,9 @@ def _normalize_value(value: Any) -> Any:
 
 
 def execute_query(
-    conn: duckdb.DuckDBPyConnection, sql: str, params: list[Any] | None = None
+    conn: duckdb.DuckDBPyConnection,
+    sql: str,
+    params: Sequence[Any] | None = None,
 ) -> list[dict[str, Any]]:
     """SQLクエリを実行し、結果を辞書のリストとして返します。
 
@@ -77,7 +79,7 @@ def execute_query(
     Raises:
         duckdb.Error: SQLクエリ実行に失敗した場合
     """
-    result = conn.execute(sql, params or [])
+    result = conn.execute(sql, tuple(params) if params else ())
     df = result.df()
     records = df.to_dict(orient="records")
     return [

--- a/egograph/backend/infrastructure/database/query_params.py
+++ b/egograph/backend/infrastructure/database/query_params.py
@@ -1,0 +1,85 @@
+"""統合クエリパラメータとクエリ実行ユーティリティ。
+
+numpy/pandas型の自動変換によるJSONシリアライズ対応を含みます。
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+import duckdb
+import numpy as np
+
+from backend.config import R2Config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class QueryParams:
+    """クエリ用の共通パラメータ（不変）。
+
+    Attributes:
+        conn: DuckDBコネクション
+        r2_config: R2設定（必須）
+        start_date: 検索開始日
+        end_date: 検索終了日
+        utc_start: UTC開始時刻
+        utc_end: UTC終了時刻
+        tz_name: タイムゾーン名（デフォルト: UTC）
+    """
+
+    conn: duckdb.DuckDBPyConnection
+    r2_config: R2Config
+    start_date: date
+    end_date: date
+    utc_start: datetime
+    utc_end: datetime
+    tz_name: str = "UTC"
+
+
+def _normalize_value(value: Any) -> Any:
+    """numpy/pandas型をPython標準型に変換します。
+
+    Args:
+        value: 変換対象の値
+
+    Returns:
+        Python標準型に変換された値
+    """
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (np.integer, np.int64, np.int32)):
+        return int(value)
+    if isinstance(value, (np.floating, np.float64, np.float32)):
+        return float(value)
+    if isinstance(value, (np.bool_, bool)):
+        return bool(value)
+    return value
+
+
+def execute_query(
+    conn: duckdb.DuckDBPyConnection, sql: str, params: list[Any] | None = None
+) -> list[dict[str, Any]]:
+    """SQLクエリを実行し、結果を辞書のリストとして返します。
+
+    numpy/pandas型をPython標準型に変換することで、JSONシリアライズに対応します。
+
+    Args:
+        conn: DuckDBコネクション
+        sql: 実行するSQLクエリ
+        params: SQLパラメータ（オプション）
+
+    Returns:
+        クエリ結果（辞書のリスト）
+
+    Raises:
+        duckdb.Error: SQLクエリ実行に失敗した場合
+    """
+    result = conn.execute(sql, params or [])
+    df = result.df()
+    records = df.to_dict(orient="records")
+    return [
+        {k: _normalize_value(v) for k, v in record.items()} for record in records
+    ]

--- a/egograph/backend/infrastructure/database/youtube_queries.py
+++ b/egograph/backend/infrastructure/database/youtube_queries.py
@@ -13,9 +13,6 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_WATCH_EVENTS_LIMIT = 100_000
 
-# TODO(Step4): Remove backward-compat alias after Repository/API files updated
-YouTubeQueryParams = QueryParams  # noqa: A004  # backward compat
-
 YOUTUBE_WATCH_EVENTS_PATH = (
     "s3://{bucket}/{events_path}youtube/watch_events/**/*.parquet"
 )

--- a/egograph/backend/infrastructure/database/youtube_queries.py
+++ b/egograph/backend/infrastructure/database/youtube_queries.py
@@ -1,38 +1,24 @@
 """YouTube データ用のSQLクエリテンプレートとヘルパー関数。"""
 
 import logging
-from dataclasses import dataclass
-from datetime import date, datetime
 from typing import Any
 
 import duckdb
 
 from backend.constants import DEFAULT_TOP_TRACKS_LIMIT
+from backend.infrastructure.database.parquet_paths import build_partition_paths
+from backend.infrastructure.database.query_params import QueryParams, execute_query
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_WATCH_EVENTS_LIMIT = 100_000
 
-
-@dataclass
-class YouTubeQueryParams:
-    """YouTubeデータクエリ用の共通パラメータ。"""
-
-    conn: duckdb.DuckDBPyConnection
-    bucket: str
-    events_path: str
-    master_path: str
-    start_date: date
-    end_date: date
-    utc_start: datetime
-    utc_end: datetime
-    tz_name: str = "UTC"
-
+# TODO(Step4): Remove backward-compat alias after Repository/API files updated
+YouTubeQueryParams = QueryParams  # noqa: A004  # backward compat
 
 YOUTUBE_WATCH_EVENTS_PATH = (
     "s3://{bucket}/{events_path}youtube/watch_events/**/*.parquet"
 )
-YOUTUBE_WATCH_EVENTS_PARTITION_PATH = "s3://{bucket}/{events_path}youtube/watch_events/year={year}/month={month}/**/*.parquet"
 YOUTUBE_VIDEOS_PATH = "s3://{bucket}/{master_path}youtube/videos/data.parquet"
 YOUTUBE_CHANNELS_PATH = "s3://{bucket}/{master_path}youtube/channels/data.parquet"
 
@@ -52,80 +38,14 @@ def get_channels_parquet_path(bucket: str, master_path: str) -> str:
     return YOUTUBE_CHANNELS_PATH.format(bucket=bucket, master_path=master_path)
 
 
-def _generate_partition_paths(
-    bucket: str, events_path: str, utc_start: datetime, utc_end: datetime
-) -> list[str]:
-    """指定期間の月パーティションに対応するParquetパスリストを生成します。"""
-    paths: list[str] = []
-    current = date(utc_start.year, utc_start.month, 1)
-    end_month = date(utc_end.year, utc_end.month, 1)
-
-    while current <= end_month:
-        paths.append(
-            YOUTUBE_WATCH_EVENTS_PARTITION_PATH.format(
-                bucket=bucket,
-                events_path=events_path,
-                year=current.year,
-                month=f"{current.month:02d}",
-            )
-        )
-        if current.month == 12:
-            current = current.replace(year=current.year + 1, month=1)
-        else:
-            current = current.replace(month=current.month + 1)
-
-    logger.debug(
-        "Generated %d partition paths for period %s to %s",
-        len(paths),
-        utc_start,
-        utc_end,
+def _resolve_watch_event_paths(params: QueryParams) -> list[str]:
+    return build_partition_paths(
+        params.r2_config,
+        data_domain="events",
+        dataset_path="youtube/watch_events",
+        utc_start=params.utc_start,
+        utc_end=params.utc_end,
     )
-    return paths
-
-
-def _resolve_watch_event_paths(params: YouTubeQueryParams) -> list[str]:
-    """実在する月パーティションのみを返し、未作成時は全体globへフォールバックする。"""
-    partition_paths = _generate_partition_paths(
-        params.bucket, params.events_path, params.utc_start, params.utc_end
-    )
-    existing_paths: list[str] = []
-
-    for path in partition_paths:
-        try:
-            matched_count = params.conn.execute(
-                "SELECT COUNT(*) FROM glob(?)",
-                [path],
-            ).fetchone()[0]
-        except duckdb.Error:
-            logger.warning(
-                "Failed to validate partition path with glob(); "
-                "fallback to dataset glob: %s",
-                path,
-                exc_info=True,
-            )
-            return [get_watch_events_parquet_path(params.bucket, params.events_path)]
-        if matched_count > 0:
-            existing_paths.append(path)
-
-    if existing_paths:
-        return existing_paths
-
-    fallback = get_watch_events_parquet_path(params.bucket, params.events_path)
-    logger.debug(
-        "No month partitions found for %s to %s; fallback to dataset glob: %s",
-        params.start_date,
-        params.end_date,
-        fallback,
-    )
-    return [fallback]
-
-
-def execute_query(
-    conn: duckdb.DuckDBPyConnection, sql: str, params: list[Any] | None = None
-) -> list[dict[str, Any]]:
-    """SQLクエリを実行し、結果を辞書のリストとして返します。"""
-    result = conn.execute(sql, params or [])
-    return result.df().to_dict(orient="records")
 
 
 def _parquet_file_exists(conn: duckdb.DuckDBPyConnection, path: str) -> bool:
@@ -144,15 +64,19 @@ def _parquet_file_exists(conn: duckdb.DuckDBPyConnection, path: str) -> bool:
 
 
 def _build_enriched_cte(
-    params: YouTubeQueryParams,
+    params: QueryParams,
 ) -> tuple[str, list[Any]]:
     """マスターデータの有無に応じた CTE とパラメータを構築する。
 
     マスター Parquet が存在しない場合は、空結果の CTE を生成し
     LEFT JOIN + COALESCE で watch events 側の値がそのまま使われるようにする。
     """
-    videos_path = get_videos_parquet_path(params.bucket, params.master_path)
-    channels_path = get_channels_parquet_path(params.bucket, params.master_path)
+    videos_path = get_videos_parquet_path(
+        params.r2_config.bucket_name, params.r2_config.master_path
+    )
+    channels_path = get_channels_parquet_path(
+        params.r2_config.bucket_name, params.r2_config.master_path
+    )
 
     has_videos = _parquet_file_exists(params.conn, videos_path)
     has_channels = _parquet_file_exists(params.conn, channels_path)
@@ -220,7 +144,7 @@ def _build_enriched_cte(
 
 
 def get_watch_events(
-    params: YouTubeQueryParams, limit: int | None = None
+    params: QueryParams, limit: int | None = None
 ) -> list[dict[str, Any]]:
     """指定期間の視聴イベントを取得します。"""
     ctes, cte_params = _build_enriched_cte(params)
@@ -246,7 +170,7 @@ def get_watch_events(
 
 
 def get_watching_stats(
-    params: YouTubeQueryParams, granularity: str = "day"
+    params: QueryParams, granularity: str = "day"
 ) -> list[dict[str, Any]]:
     """期間別の視聴統計を取得します。"""
     date_format_map = {
@@ -283,7 +207,7 @@ def get_watching_stats(
 
 
 def get_top_videos(
-    params: YouTubeQueryParams, limit: int = DEFAULT_TOP_TRACKS_LIMIT
+    params: QueryParams, limit: int = DEFAULT_TOP_TRACKS_LIMIT
 ) -> list[dict[str, Any]]:
     """指定期間で最も視聴された動画を取得します。"""
     ctes, cte_params = _build_enriched_cte(params)
@@ -305,7 +229,7 @@ def get_top_videos(
 
 
 def get_top_channels(
-    params: YouTubeQueryParams, limit: int = DEFAULT_TOP_TRACKS_LIMIT
+    params: QueryParams, limit: int = DEFAULT_TOP_TRACKS_LIMIT
 ) -> list[dict[str, Any]]:
     """指定期間で最も視聴されたチャンネルを取得します。"""
     ctes, cte_params = _build_enriched_cte(params)

--- a/egograph/backend/infrastructure/database/youtube_queries.py
+++ b/egograph/backend/infrastructure/database/youtube_queries.py
@@ -13,16 +13,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_WATCH_EVENTS_LIMIT = 100_000
 
-YOUTUBE_WATCH_EVENTS_PATH = (
-    "s3://{bucket}/{events_path}youtube/watch_events/**/*.parquet"
-)
 YOUTUBE_VIDEOS_PATH = "s3://{bucket}/{master_path}youtube/videos/data.parquet"
 YOUTUBE_CHANNELS_PATH = "s3://{bucket}/{master_path}youtube/channels/data.parquet"
-
-
-def get_watch_events_parquet_path(bucket: str, events_path: str) -> str:
-    """YouTube視聴イベントのS3パスパターンを生成します。"""
-    return YOUTUBE_WATCH_EVENTS_PATH.format(bucket=bucket, events_path=events_path)
 
 
 def get_videos_parquet_path(bucket: str, master_path: str) -> str:

--- a/egograph/backend/infrastructure/repositories/browser_history_repository.py
+++ b/egograph/backend/infrastructure/repositories/browser_history_repository.py
@@ -5,13 +5,14 @@ from datetime import date
 from typing import Any
 from zoneinfo import ZoneInfo
 
+import duckdb
+
 from backend.config import R2Config
-from backend.infrastructure.database import (
-    BrowserHistoryQueryParams,
-    DuckDBConnection,
+from backend.infrastructure.database.browser_history_queries import (
     get_page_views,
     get_top_domains,
 )
+from backend.infrastructure.database.query_params import QueryParams
 from backend.validators import to_utc_range
 
 logger = logging.getLogger(__name__)
@@ -26,25 +27,24 @@ class BrowserHistoryRepository:
 
     def _build_params(
         self,
-        conn: DuckDBConnection,
+        conn: duckdb.DuckDBPyConnection,
         start_date: date,
         end_date: date,
-    ) -> BrowserHistoryQueryParams:
+    ) -> QueryParams:
         utc_start, utc_end = to_utc_range(start_date, end_date, self._tz)
-        return BrowserHistoryQueryParams(
+        return QueryParams(
             conn=conn,
-            bucket=self.r2_config.bucket_name,
-            events_path=self.r2_config.events_path,
+            r2_config=self.r2_config,
             start_date=start_date,
             end_date=end_date,
             utc_start=utc_start,
             utc_end=utc_end,
             tz_name=str(self._tz),
-            r2_config=self.r2_config,
         )
 
     def _run_query(
         self,
+        conn: duckdb.DuckDBPyConnection,
         *,
         start_date: date,
         end_date: date,
@@ -54,29 +54,29 @@ class BrowserHistoryRepository:
         query_func,
         log_label: str,
     ) -> list[dict[str, Any]]:
-        with DuckDBConnection(self.r2_config) as conn:
-            params = self._build_params(conn, start_date, end_date)
-            result = query_func(
-                params,
-                browser=browser,
-                profile=profile,
-                limit=limit,
-            )
-            logger.info(
-                "Retrieved %s: start_date=%s, end_date=%s, browser=%s, "
-                "profile=%s, limit=%s, count=%s",
-                log_label,
-                start_date,
-                end_date,
-                browser,
-                profile,
-                limit,
-                len(result),
-            )
-            return result
+        params = self._build_params(conn, start_date, end_date)
+        result = query_func(
+            params,
+            browser=browser,
+            profile=profile,
+            limit=limit,
+        )
+        logger.info(
+            "Retrieved %s: start_date=%s, end_date=%s, browser=%s, "
+            "profile=%s, limit=%s, count=%s",
+            log_label,
+            start_date,
+            end_date,
+            browser,
+            profile,
+            limit,
+            len(result),
+        )
+        return result
 
     def get_page_views(
         self,
+        conn: duckdb.DuckDBPyConnection,
         start_date: date,
         end_date: date,
         *,
@@ -86,6 +86,7 @@ class BrowserHistoryRepository:
     ) -> list[dict[str, Any]]:
         """指定期間のpage view一覧を取得する。"""
         return self._run_query(
+            conn=conn,
             start_date=start_date,
             end_date=end_date,
             browser=browser,
@@ -97,6 +98,7 @@ class BrowserHistoryRepository:
 
     def get_top_domains(
         self,
+        conn: duckdb.DuckDBPyConnection,
         start_date: date,
         end_date: date,
         *,
@@ -106,6 +108,7 @@ class BrowserHistoryRepository:
     ) -> list[dict[str, Any]]:
         """指定期間のdomainランキングを取得する。"""
         return self._run_query(
+            conn=conn,
             start_date=start_date,
             end_date=end_date,
             browser=browser,

--- a/egograph/backend/infrastructure/repositories/github_repository.py
+++ b/egograph/backend/infrastructure/repositories/github_repository.py
@@ -9,16 +9,17 @@ from datetime import date, datetime
 from typing import Any
 from zoneinfo import ZoneInfo
 
+import duckdb
+
 from backend.config import R2Config
-from backend.infrastructure.database import (
-    DuckDBConnection,
-    GitHubQueryParams,
+from backend.infrastructure.database.github_queries import (
     get_activity_stats,
     get_commits,
     get_pull_requests,
     get_repo_summary_stats,
     get_repositories,
 )
+from backend.infrastructure.database.query_params import QueryParams
 from backend.validators import to_utc_range
 
 logger = logging.getLogger(__name__)
@@ -43,27 +44,25 @@ class GitHubRepository:
 
     def _build_params(
         self,
-        conn: DuckDBConnection,
+        conn: duckdb.DuckDBPyConnection,
         start_date: date,
         end_date: date,
-    ) -> GitHubQueryParams:
+    ) -> QueryParams:
         """共通のクエリパラメータを構築する。"""
         utc_start, utc_end = to_utc_range(start_date, end_date, self._tz)
-        return GitHubQueryParams(
+        return QueryParams(
             conn=conn,
-            bucket=self.r2_config.bucket_name,
-            events_path=self.r2_config.events_path,
-            master_path=self.r2_config.master_path,
+            r2_config=self.r2_config,
             start_date=start_date,
             end_date=end_date,
             utc_start=utc_start,
             utc_end=utc_end,
             tz_name=str(self._tz),
-            r2_config=self.r2_config,
         )
 
     def get_pull_requests(
         self,
+        conn: duckdb.DuckDBPyConnection,
         start_date: date,
         end_date: date,
         owner: str | None = None,
@@ -74,6 +73,7 @@ class GitHubRepository:
         """指定期間のPull Requestイベントを取得します。
 
         Args:
+            conn: DuckDB コネクション
             start_date: 開始日
             end_date: 終了日
             owner: フィルタ対象のオーナー（オプション）
@@ -87,30 +87,30 @@ class GitHubRepository:
         Raises:
             duckdb.Error: データベース操作に失敗した場合
         """
-        with DuckDBConnection(self.r2_config) as conn:
-            params = self._build_params(conn, start_date, end_date)
-            result = get_pull_requests(
-                params,
-                owner=owner,
-                repo=repo,
-                state=state,
-                limit=limit,
-            )
-            logger.info(
-                "Retrieved pull requests: start_date=%s, end_date=%s, "
-                "owner=%s, repo=%s, state=%s, limit=%s, count=%s",
-                start_date,
-                end_date,
-                owner,
-                repo,
-                state,
-                limit,
-                len(result),
-            )
-            return result
+        params = self._build_params(conn, start_date, end_date)
+        result = get_pull_requests(
+            params,
+            owner=owner,
+            repo=repo,
+            state=state,
+            limit=limit,
+        )
+        logger.info(
+            "Retrieved pull requests: start_date=%s, end_date=%s, "
+            "owner=%s, repo=%s, state=%s, limit=%s, count=%s",
+            start_date,
+            end_date,
+            owner,
+            repo,
+            state,
+            limit,
+            len(result),
+        )
+        return result
 
     def get_commits(
         self,
+        conn: duckdb.DuckDBPyConnection,
         start_date: date,
         end_date: date,
         owner: str | None = None,
@@ -120,6 +120,7 @@ class GitHubRepository:
         """指定期間のCommitイベントを取得します。
 
         Args:
+            conn: DuckDB コネクション
             start_date: 開始日
             end_date: 終了日
             owner: フィルタ対象のオーナー（オプション）
@@ -132,23 +133,23 @@ class GitHubRepository:
         Raises:
             duckdb.Error: データベース操作に失敗した場合
         """
-        with DuckDBConnection(self.r2_config) as conn:
-            params = self._build_params(conn, start_date, end_date)
-            result = get_commits(params, owner=owner, repo=repo, limit=limit)
-            logger.info(
-                "Retrieved commits: start_date=%s, end_date=%s, owner=%s, "
-                "repo=%s, limit=%s, count=%s",
-                start_date,
-                end_date,
-                owner,
-                repo,
-                limit,
-                len(result),
-            )
-            return result
+        params = self._build_params(conn, start_date, end_date)
+        result = get_commits(params, owner=owner, repo=repo, limit=limit)
+        logger.info(
+            "Retrieved commits: start_date=%s, end_date=%s, owner=%s, "
+            "repo=%s, limit=%s, count=%s",
+            start_date,
+            end_date,
+            owner,
+            repo,
+            limit,
+            len(result),
+        )
+        return result
 
     def get_repositories(
         self,
+        conn: duckdb.DuckDBPyConnection,
         owner: str | None = None,
         repo: str | None = None,
         limit: int | None = None,
@@ -156,6 +157,7 @@ class GitHubRepository:
         """Repositoryマスターを取得します。
 
         Args:
+            conn: DuckDB コネクション
             owner: フィルタ対象のオーナー（オプション）
             repo: フィルタ対象のリポジトリ（オプション）
             limit: 取得件数上限（オプション）
@@ -166,31 +168,28 @@ class GitHubRepository:
         Raises:
             duckdb.Error: データベース操作に失敗した場合
         """
-        with DuckDBConnection(self.r2_config) as conn:
-            params = GitHubQueryParams(
-                conn=conn,
-                bucket=self.r2_config.bucket_name,
-                events_path=self.r2_config.events_path,
-                master_path=self.r2_config.master_path,
-                start_date=date(1, 1, 1),
-                end_date=date(9999, 12, 31),
-                utc_start=datetime.min,
-                utc_end=datetime.max,
-                tz_name=str(self._tz),
-                r2_config=self.r2_config,
-            )
-            result = get_repositories(params, owner=owner, repo=repo, limit=limit)
-            logger.info(
-                "Retrieved repositories: owner=%s, repo=%s, limit=%s, count=%s",
-                owner,
-                repo,
-                limit,
-                len(result),
-            )
-            return result
+        params = QueryParams(
+            conn=conn,
+            r2_config=self.r2_config,
+            start_date=date(1, 1, 1),
+            end_date=date(9999, 12, 31),
+            utc_start=datetime.min,
+            utc_end=datetime.max,
+            tz_name=str(self._tz),
+        )
+        result = get_repositories(params, owner=owner, repo=repo, limit=limit)
+        logger.info(
+            "Retrieved repositories: owner=%s, repo=%s, limit=%s, count=%s",
+            owner,
+            repo,
+            limit,
+            len(result),
+        )
+        return result
 
     def get_activity_stats(
         self,
+        conn: duckdb.DuckDBPyConnection,
         start_date: date,
         end_date: date,
         granularity: str = "day",
@@ -198,6 +197,7 @@ class GitHubRepository:
         """期間別のアクティビティ統計を取得します。
 
         Args:
+            conn: DuckDB コネクション
             start_date: 開始日
             end_date: 終了日
             granularity: 集計単位（"day", "week", "month"）
@@ -209,21 +209,21 @@ class GitHubRepository:
             duckdb.Error: データベース操作に失敗した場合
             ValueError: granularityが無効な場合
         """
-        with DuckDBConnection(self.r2_config) as conn:
-            params = self._build_params(conn, start_date, end_date)
-            result = get_activity_stats(params, granularity=granularity)
-            logger.info(
-                "Retrieved activity stats: start_date=%s, end_date=%s, "
-                "granularity=%s, count=%s",
-                start_date,
-                end_date,
-                granularity,
-                len(result),
-            )
-            return result
+        params = self._build_params(conn, start_date, end_date)
+        result = get_activity_stats(params, granularity=granularity)
+        logger.info(
+            "Retrieved activity stats: start_date=%s, end_date=%s, "
+            "granularity=%s, count=%s",
+            start_date,
+            end_date,
+            granularity,
+            len(result),
+        )
+        return result
 
     def get_repo_summary_stats(
         self,
+        conn: duckdb.DuckDBPyConnection,
         start_date: date,
         end_date: date,
         owner: str | None = None,
@@ -232,6 +232,7 @@ class GitHubRepository:
         """リポジトリ別のサマリー統計を取得します。
 
         Args:
+            conn: DuckDB コネクション
             start_date: 開始日
             end_date: 終了日
             owner: フィルタ対象のオーナー（オプション）
@@ -243,20 +244,19 @@ class GitHubRepository:
         Raises:
             duckdb.Error: データベース操作に失敗した場合
         """
-        with DuckDBConnection(self.r2_config) as conn:
-            params = self._build_params(conn, start_date, end_date)
-            result = get_repo_summary_stats(
-                params,
-                owner=owner,
-                repo_name=repo_name,
-            )
-            logger.info(
-                "Retrieved repo summary stats: start_date=%s, end_date=%s, "
-                "owner=%s, repo=%s, count=%s",
-                start_date,
-                end_date,
-                owner,
-                repo_name,
-                len(result),
-            )
-            return result
+        params = self._build_params(conn, start_date, end_date)
+        result = get_repo_summary_stats(
+            params,
+            owner=owner,
+            repo_name=repo_name,
+        )
+        logger.info(
+            "Retrieved repo summary stats: start_date=%s, end_date=%s, "
+            "owner=%s, repo=%s, count=%s",
+            start_date,
+            end_date,
+            owner,
+            repo_name,
+            len(result),
+        )
+        return result

--- a/egograph/backend/infrastructure/repositories/spotify_repository.py
+++ b/egograph/backend/infrastructure/repositories/spotify_repository.py
@@ -9,13 +9,11 @@ from datetime import date
 from typing import Any
 from zoneinfo import ZoneInfo
 
+import duckdb
+
 from backend.config import R2Config
-from backend.infrastructure.database import (
-    DuckDBConnection,
-    QueryParams,
-    get_listening_stats,
-    get_top_tracks,
-)
+from backend.infrastructure.database.query_params import QueryParams
+from backend.infrastructure.database.queries import get_listening_stats, get_top_tracks
 from backend.validators import to_utc_range
 
 logger = logging.getLogger(__name__)
@@ -39,11 +37,16 @@ class SpotifyRepository:
         self._tz = tz or ZoneInfo("UTC")
 
     def get_top_tracks(
-        self, start_date: date, end_date: date, limit: int
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        start_date: date,
+        end_date: date,
+        limit: int,
     ) -> list[dict[str, Any]]:
         """指定期間で最も再生された曲を取得します。
 
         Args:
+            conn: DuckDB コネクション
             start_date: 開始日
             end_date: 終了日
             limit: 取得する曲数
@@ -55,34 +58,36 @@ class SpotifyRepository:
             duckdb.Error: データベース操作に失敗した場合
         """
         utc_start, utc_end = to_utc_range(start_date, end_date, self._tz)
-        with DuckDBConnection(self.r2_config) as conn:
-            params = QueryParams(
-                conn=conn,
-                bucket=self.r2_config.bucket_name,
-                events_path=self.r2_config.events_path,
-                start_date=start_date,
-                end_date=end_date,
-                utc_start=utc_start,
-                utc_end=utc_end,
-                tz_name=str(self._tz),
-                r2_config=self.r2_config,
-            )
-            result = get_top_tracks(params, limit)
-            logger.info(
-                "Retrieved top tracks: start_date=%s, end_date=%s, limit=%s, count=%s",
-                start_date,
-                end_date,
-                limit,
-                len(result),
-            )
-            return result
+        params = QueryParams(
+            conn=conn,
+            r2_config=self.r2_config,
+            start_date=start_date,
+            end_date=end_date,
+            utc_start=utc_start,
+            utc_end=utc_end,
+            tz_name=str(self._tz),
+        )
+        result = get_top_tracks(params, limit)
+        logger.info(
+            "Retrieved top tracks: start_date=%s, end_date=%s, limit=%s, count=%s",
+            start_date,
+            end_date,
+            limit,
+            len(result),
+        )
+        return result
 
     def get_listening_stats(
-        self, start_date: date, end_date: date, granularity: str
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        start_date: date,
+        end_date: date,
+        granularity: str,
     ) -> list[dict[str, Any]]:
         """指定期間の視聴統計を取得します。
 
         Args:
+            conn: DuckDB コネクション
             start_date: 開始日
             end_date: 終了日
             granularity: 集計単位（"day", "week", "month"）
@@ -94,25 +99,22 @@ class SpotifyRepository:
             duckdb.Error: データベース操作に失敗した場合
         """
         utc_start, utc_end = to_utc_range(start_date, end_date, self._tz)
-        with DuckDBConnection(self.r2_config) as conn:
-            params = QueryParams(
-                conn=conn,
-                bucket=self.r2_config.bucket_name,
-                events_path=self.r2_config.events_path,
-                start_date=start_date,
-                end_date=end_date,
-                utc_start=utc_start,
-                utc_end=utc_end,
-                tz_name=str(self._tz),
-                r2_config=self.r2_config,
-            )
-            result = get_listening_stats(params, granularity)
-            logger.info(
-                "Retrieved listening stats: "
-                "start_date=%s, end_date=%s, granularity=%s, count=%s",
-                start_date,
-                end_date,
-                granularity,
-                len(result),
-            )
-            return result
+        params = QueryParams(
+            conn=conn,
+            r2_config=self.r2_config,
+            start_date=start_date,
+            end_date=end_date,
+            utc_start=utc_start,
+            utc_end=utc_end,
+            tz_name=str(self._tz),
+        )
+        result = get_listening_stats(params, granularity)
+        logger.info(
+            "Retrieved listening stats: "
+            "start_date=%s, end_date=%s, granularity=%s, count=%s",
+            start_date,
+            end_date,
+            granularity,
+            len(result),
+        )
+        return result

--- a/egograph/backend/infrastructure/repositories/spotify_repository.py
+++ b/egograph/backend/infrastructure/repositories/spotify_repository.py
@@ -12,8 +12,8 @@ from zoneinfo import ZoneInfo
 import duckdb
 
 from backend.config import R2Config
-from backend.infrastructure.database.query_params import QueryParams
 from backend.infrastructure.database.queries import get_listening_stats, get_top_tracks
+from backend.infrastructure.database.query_params import QueryParams
 from backend.validators import to_utc_range
 
 logger = logging.getLogger(__name__)

--- a/egograph/backend/infrastructure/repositories/youtube_repository.py
+++ b/egograph/backend/infrastructure/repositories/youtube_repository.py
@@ -10,10 +10,11 @@ from datetime import date
 from typing import Any
 from zoneinfo import ZoneInfo
 
+import duckdb
+
 from backend.config import R2Config
-from backend.infrastructure.database import DuckDBConnection
+from backend.infrastructure.database.query_params import QueryParams
 from backend.infrastructure.database.youtube_queries import (
-    YouTubeQueryParams,
     get_top_channels,
     get_top_videos,
     get_watch_events,
@@ -43,16 +44,14 @@ class YouTubeRepository:
 
     def _build_params(
         self,
-        conn: DuckDBConnection,
+        conn: duckdb.DuckDBPyConnection,
         start_date: date,
         end_date: date,
-    ) -> YouTubeQueryParams:
+    ) -> QueryParams:
         utc_start, utc_end = to_utc_range(start_date, end_date, self._tz)
-        return YouTubeQueryParams(
+        return QueryParams(
             conn=conn,
-            bucket=self.r2_config.bucket_name,
-            events_path=self.r2_config.events_path,
-            master_path=self.r2_config.master_path,
+            r2_config=self.r2_config,
             start_date=start_date,
             end_date=end_date,
             utc_start=utc_start,
@@ -60,50 +59,41 @@ class YouTubeRepository:
             tz_name=str(self._tz),
         )
 
-    def _execute_query(
+    def _execute_fn(
         self,
+        conn: duckdb.DuckDBPyConnection,
         start_date: date,
         end_date: date,
         query_func: Callable[..., list[dict[str, Any]]],
         query_name: str,
-        **query_kwargs,
+        **kwargs,
     ) -> list[dict[str, Any]]:
-        """共通クエリ実行ヘルパー。
-
-        Args:
-            start_date: 開始日
-            end_date: 終了日
-            query_func: クエリ実行関数
-            query_name: ログ用クエリ名
-            **query_kwargs: クエリ関数に渡す追加パラメータ
-
-        Returns:
-            クエリ結果
-        """
-        with DuckDBConnection(self.r2_config) as conn:
-            params = self._build_params(conn, start_date, end_date)
-            result = query_func(params, **query_kwargs)
-
-            # クエリパラメータをログに含める
-            log_params = ", ".join(
-                f"{k}={v}" for k, v in query_kwargs.items() if v is not None
-            )
-            logger.info(
-                "Retrieved %s: start_date=%s, end_date=%s, %s, count=%s",
-                query_name,
-                start_date,
-                end_date,
-                log_params,
-                len(result),
-            )
-            return result
+        params = self._build_params(conn, start_date, end_date)
+        result = query_func(params, **kwargs)
+        log_params = ", ".join(
+            f"{k}={v}" for k, v in kwargs.items() if v is not None
+        )
+        logger.info(
+            "Retrieved %s: start_date=%s, end_date=%s, %s, count=%s",
+            query_name,
+            start_date,
+            end_date,
+            log_params,
+            len(result),
+        )
+        return result
 
     def get_watch_events(
-        self, start_date: date, end_date: date, limit: int | None = None
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        start_date: date,
+        end_date: date,
+        limit: int | None = None,
     ) -> list[dict[str, Any]]:
         """指定期間の視聴イベントを取得します。
 
         Args:
+            conn: DuckDB コネクション
             start_date: 開始日
             end_date: 終了日
             limit: 取得するイベント数（デフォルト: None = 全件）
@@ -114,16 +104,21 @@ class YouTubeRepository:
         Raises:
             duckdb.Error: データベース操作に失敗した場合
         """
-        return self._execute_query(
-            start_date, end_date, get_watch_events, "watch events", limit=limit
+        return self._execute_fn(
+            conn, start_date, end_date, get_watch_events, "watch events", limit=limit
         )
 
     def get_watching_stats(
-        self, start_date: date, end_date: date, granularity: str = "day"
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        start_date: date,
+        end_date: date,
+        granularity: str = "day",
     ) -> list[dict[str, Any]]:
         """指定期間の視聴統計を取得します。
 
         Args:
+            conn: DuckDB コネクション
             start_date: 開始日
             end_date: 終了日
             granularity: 集計単位（"day", "week", "month"）
@@ -135,7 +130,8 @@ class YouTubeRepository:
             duckdb.Error: データベース操作に失敗した場合
             ValueError: granularityが無効な場合
         """
-        return self._execute_query(
+        return self._execute_fn(
+            conn,
             start_date,
             end_date,
             get_watching_stats,
@@ -144,11 +140,16 @@ class YouTubeRepository:
         )
 
     def get_top_videos(
-        self, start_date: date, end_date: date, limit: int = 10
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        start_date: date,
+        end_date: date,
+        limit: int = 10,
     ) -> list[dict[str, Any]]:
         """指定期間で最も視聴された動画を取得します。
 
         Args:
+            conn: DuckDB コネクション
             start_date: 開始日
             end_date: 終了日
             limit: 取得する動画数（デフォルト: 10）
@@ -159,16 +160,21 @@ class YouTubeRepository:
         Raises:
             duckdb.Error: データベース操作に失敗した場合
         """
-        return self._execute_query(
-            start_date, end_date, get_top_videos, "top videos", limit=limit
+        return self._execute_fn(
+            conn, start_date, end_date, get_top_videos, "top videos", limit=limit
         )
 
     def get_top_channels(
-        self, start_date: date, end_date: date, limit: int = 10
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        start_date: date,
+        end_date: date,
+        limit: int = 10,
     ) -> list[dict[str, Any]]:
         """指定期間で最も視聴されたチャンネルを取得します。
 
         Args:
+            conn: DuckDB コネクション
             start_date: 開始日
             end_date: 終了日
             limit: 取得するチャンネル数（デフォルト: 10）
@@ -179,6 +185,6 @@ class YouTubeRepository:
         Raises:
             duckdb.Error: データベース操作に失敗した場合
         """
-        return self._execute_query(
-            start_date, end_date, get_top_channels, "top channels", limit=limit
+        return self._execute_fn(
+            conn, start_date, end_date, get_top_channels, "top channels", limit=limit
         )

--- a/egograph/backend/tests/fixtures/youtube.py
+++ b/egograph/backend/tests/fixtures/youtube.py
@@ -9,7 +9,7 @@ def patch_youtube_paths(youtube_with_sample_data):
     stack = ExitStack()
     stack.enter_context(
         patch(
-            "backend.infrastructure.database.youtube_queries._generate_partition_paths",
+            "backend.infrastructure.database.youtube_queries.build_partition_paths",
             return_value=[youtube_with_sample_data.test_watch_events_parquet_path],
         )
     )

--- a/egograph/backend/tests/integration/test_api_data.py
+++ b/egograph/backend/tests/integration/test_api_data.py
@@ -1,6 +1,8 @@
 """API/Data統合テスト。"""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock
+
+from backend.dependencies import get_spotify_repository
 
 
 class TestTopTracksEndpoint:
@@ -17,21 +19,26 @@ class TestTopTracksEndpoint:
             }
         ]
 
-        with patch("backend.api.data.get_top_tracks", return_value=mock_result):
-            response = test_client.get(
-                "/v1/data/spotify/stats/top-tracks?start_date=2024-01-01&end_date=2024-01-03&limit=5",
-                headers={"X-API-Key": "test-backend-key"},
-            )
+        mock_repo = MagicMock()
+        mock_repo.get_top_tracks.return_value = mock_result
+        test_client.app.dependency_overrides[get_spotify_repository] = (
+            lambda: mock_repo
+        )
 
-            assert response.status_code == 200
-            data = response.json()
-            assert isinstance(data, list)
-            assert len(data) > 0
-            # 最初のトラックの構造を確認
-            assert "track_name" in data[0]
-            assert "artist" in data[0]
-            assert "play_count" in data[0]
-            assert "total_minutes" in data[0]
+        response = test_client.get(
+            "/v1/data/spotify/stats/top-tracks?start_date=2024-01-01&end_date=2024-01-03&limit=5",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        # 最初のトラックの構造を確認
+        assert "track_name" in data[0]
+        assert "artist" in data[0]
+        assert "play_count" in data[0]
+        assert "total_minutes" in data[0]
 
     def test_get_top_tracks_requires_api_key(self, test_client):
         """API Keyが必要。"""
@@ -81,21 +88,26 @@ class TestListeningStatsEndpoint:
             }
         ]
 
-        with patch("backend.api.data.get_listening_stats", return_value=mock_result):
-            response = test_client.get(
-                "/v1/data/spotify/stats/listening?start_date=2024-01-01&end_date=2024-01-03&granularity=day",
-                headers={"X-API-Key": "test-backend-key"},
-            )
+        mock_repo = MagicMock()
+        mock_repo.get_listening_stats.return_value = mock_result
+        test_client.app.dependency_overrides[get_spotify_repository] = (
+            lambda: mock_repo
+        )
 
-            assert response.status_code == 200
-            data = response.json()
-            assert isinstance(data, list)
-            assert len(data) > 0
-            # 最初の統計の構造を確認
-            assert "period" in data[0]
-            assert "total_ms" in data[0]
-            assert "track_count" in data[0]
-            assert "unique_tracks" in data[0]
+        response = test_client.get(
+            "/v1/data/spotify/stats/listening?start_date=2024-01-01&end_date=2024-01-03&granularity=day",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        # 最初の統計の構造を確認
+        assert "period" in data[0]
+        assert "total_ms" in data[0]
+        assert "track_count" in data[0]
+        assert "unique_tracks" in data[0]
 
     def test_get_listening_stats_requires_api_key(self, test_client):
         """API Keyが必要。"""
@@ -127,11 +139,16 @@ class TestListeningStatsEndpoint:
             }
         ]
 
-        with patch("backend.api.data.get_listening_stats", return_value=mock_result):
-            # granularity省略
-            response = test_client.get(
-                "/v1/data/spotify/stats/listening?start_date=2024-01-01&end_date=2024-01-03",
-                headers={"X-API-Key": "test-backend-key"},
-            )
+        mock_repo = MagicMock()
+        mock_repo.get_listening_stats.return_value = mock_result
+        test_client.app.dependency_overrides[get_spotify_repository] = (
+            lambda: mock_repo
+        )
 
-            assert response.status_code == 200
+        # granularity省略
+        response = test_client.get(
+            "/v1/data/spotify/stats/listening?start_date=2024-01-01&end_date=2024-01-03",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200

--- a/egograph/backend/tests/integration/test_browser_history_data_api.py
+++ b/egograph/backend/tests/integration/test_browser_history_data_api.py
@@ -1,6 +1,8 @@
 """Browser History Data API 統合テスト。"""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock
+
+from backend.dependencies import get_browser_history_repository
 
 
 class TestPageViewsEndpoint:
@@ -21,14 +23,15 @@ class TestPageViewsEndpoint:
             }
         ]
 
-        with patch(
-            "backend.api.browser_history_data.get_page_views",
-            return_value=mock_result,
-        ):
-            response = test_client.get(
-                "/v1/data/browser-history/page-views?start_date=2026-03-20&end_date=2026-03-22&limit=5&browser=edge&profile=Default",
-                headers={"X-API-Key": "test-backend-key"},
-            )
+        mock_repo = MagicMock()
+        mock_repo.get_page_views.return_value = mock_result
+        test_client.app.dependency_overrides[
+            get_browser_history_repository
+        ] = lambda: mock_repo
+        response = test_client.get(
+            "/v1/data/browser-history/page-views?start_date=2026-03-20&end_date=2026-03-22&limit=5&browser=edge&profile=Default",
+            headers={"X-API-Key": "test-backend-key"},
+        )
 
         assert response.status_code == 200
         data = response.json()
@@ -63,14 +66,15 @@ class TestTopDomainsEndpoint:
             }
         ]
 
-        with patch(
-            "backend.api.browser_history_data.get_top_domains",
-            return_value=mock_result,
-        ):
-            response = test_client.get(
-                "/v1/data/browser-history/top-domains?start_date=2026-03-20&end_date=2026-03-22&limit=5&browser=edge&profile=Default",
-                headers={"X-API-Key": "test-backend-key"},
-            )
+        mock_repo = MagicMock()
+        mock_repo.get_top_domains.return_value = mock_result
+        test_client.app.dependency_overrides[
+            get_browser_history_repository
+        ] = lambda: mock_repo
+        response = test_client.get(
+            "/v1/data/browser-history/top-domains?start_date=2026-03-20&end_date=2026-03-22&limit=5&browser=edge&profile=Default",
+            headers={"X-API-Key": "test-backend-key"},
+        )
 
         assert response.status_code == 200
         data = response.json()

--- a/egograph/backend/tests/integration/test_compacted_parquet_reads.py
+++ b/egograph/backend/tests/integration/test_compacted_parquet_reads.py
@@ -9,12 +9,10 @@ from pydantic import SecretStr
 
 from backend.config import R2Config
 from backend.infrastructure.database.browser_history_queries import (
-    BrowserHistoryQueryParams,
     get_page_views,
     get_top_domains,
 )
 from backend.infrastructure.database.github_queries import (
-    GitHubQueryParams,
     get_activity_stats,
     get_commits,
     get_pull_requests,
@@ -81,14 +79,12 @@ def test_spotify_queries_read_local_compacted_parquet(duckdb_conn, tmp_path):
     utc_start, utc_end = _utc_range(date(2024, 1, 1), date(2024, 1, 31))
     params = QueryParams(
         conn=duckdb_conn,
-        bucket="test-bucket",
-        events_path="events/",
+        r2_config=_build_config(local_root),
         start_date=date(2024, 1, 1),
         end_date=date(2024, 1, 31),
         utc_start=utc_start,
         utc_end=utc_end,
         tz_name="UTC",
-        r2_config=_build_config(local_root),
     )
 
     top_tracks = get_top_tracks(params, limit=5)
@@ -182,17 +178,14 @@ def test_github_queries_read_local_compacted_parquet(duckdb_conn, tmp_path):
     ).to_parquet(commit_dir / "data.parquet")
 
     utc_start, utc_end = _utc_range(date(2024, 1, 1), date(2024, 1, 31))
-    params = GitHubQueryParams(
+    params = QueryParams(
         conn=duckdb_conn,
-        bucket="test-bucket",
-        events_path="events/",
-        master_path="master/",
+        r2_config=_build_config(local_root),
         start_date=date(2024, 1, 1),
         end_date=date(2024, 1, 31),
         utc_start=utc_start,
         utc_end=utc_end,
         tz_name="UTC",
-        r2_config=_build_config(local_root),
     )
 
     prs = get_pull_requests(params)
@@ -258,16 +251,14 @@ def test_browser_history_queries_read_local_compacted_parquet(duckdb_conn, tmp_p
     ).to_parquet(browser_dir / "data.parquet")
 
     utc_start, utc_end = _utc_range(date(2026, 3, 20), date(2026, 3, 21))
-    params = BrowserHistoryQueryParams(
+    params = QueryParams(
         conn=duckdb_conn,
-        bucket="test-bucket",
-        events_path="events/",
+        r2_config=_build_config(local_root),
         start_date=date(2026, 3, 20),
         end_date=date(2026, 3, 21),
         utc_start=utc_start,
         utc_end=utc_end,
         tz_name="UTC",
-        r2_config=_build_config(local_root),
     )
 
     page_views = get_page_views(params, browser="edge", profile="Default", limit=10)
@@ -340,14 +331,12 @@ def test_spotify_queries_with_jst_timezone(duckdb_conn, tmp_path):
 
     params = QueryParams(
         conn=duckdb_conn,
-        bucket="test-bucket",
-        events_path="events/",
+        r2_config=_build_config(local_root),
         start_date=date(2024, 1, 1),
         end_date=date(2024, 1, 1),
         utc_start=utc_start,
         utc_end=utc_end,
         tz_name="Asia/Tokyo",
-        r2_config=_build_config(local_root),
     )
 
     top_tracks = get_top_tracks(params, limit=5)

--- a/egograph/backend/tests/integration/test_github.py
+++ b/egograph/backend/tests/integration/test_github.py
@@ -1,6 +1,8 @@
 """API/GitHub統合テスト（REDフェーズ）。"""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock
+
+from backend.dependencies import get_github_repository
 
 
 class TestPullRequestsEndpoint:
@@ -38,20 +40,25 @@ class TestPullRequestsEndpoint:
             }
         ]
 
-        with patch("backend.api.github.get_pull_requests", return_value=mock_result):
-            response = test_client.get(
-                "/v1/data/github/pull-requests?start_date=2024-01-01&end_date=2024-01-31&limit=10",
-                headers={"X-API-Key": "test-backend-key"},
-            )
+        mock_repo = MagicMock()
+        mock_repo.get_pull_requests.return_value = mock_result
+        test_client.app.dependency_overrides[get_github_repository] = (
+            lambda: mock_repo
+        )
 
-            assert response.status_code == 200
-            data = response.json()
-            assert isinstance(data, list)
-            assert len(data) > 0
-            assert "pr_event_id" in data[0]
-            assert "owner" in data[0]
-            assert "pr_number" in data[0]
-            assert "title" in data[0]
+        response = test_client.get(
+            "/v1/data/github/pull-requests?start_date=2024-01-01&end_date=2024-01-31&limit=10",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert "pr_event_id" in data[0]
+        assert "owner" in data[0]
+        assert "pr_number" in data[0]
+        assert "title" in data[0]
 
     def test_get_pull_requests_requires_api_key(self, test_client):
         """API Keyが必要。"""
@@ -100,20 +107,25 @@ class TestCommitsEndpoint:
             }
         ]
 
-        with patch("backend.api.github.get_commits", return_value=mock_result):
-            response = test_client.get(
-                "/v1/data/github/commits?start_date=2024-01-01&end_date=2024-01-31&limit=10",
-                headers={"X-API-Key": "test-backend-key"},
-            )
+        mock_repo = MagicMock()
+        mock_repo.get_commits.return_value = mock_result
+        test_client.app.dependency_overrides[get_github_repository] = (
+            lambda: mock_repo
+        )
 
-            assert response.status_code == 200
-            data = response.json()
-            assert isinstance(data, list)
-            assert len(data) > 0
-            assert "commit_event_id" in data[0]
-            assert "owner" in data[0]
-            assert "sha" in data[0]
-            assert "message" in data[0]
+        response = test_client.get(
+            "/v1/data/github/commits?start_date=2024-01-01&end_date=2024-01-31&limit=10",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert "commit_event_id" in data[0]
+        assert "owner" in data[0]
+        assert "sha" in data[0]
+        assert "message" in data[0]
 
     def test_get_commits_requires_api_key(self, test_client):
         """API Keyが必要。"""
@@ -153,20 +165,25 @@ class TestRepositoriesEndpoint:
             }
         ]
 
-        with patch("backend.api.github.get_repositories", return_value=mock_result):
-            response = test_client.get(
-                "/v1/data/github/repositories",
-                headers={"X-API-Key": "test-backend-key"},
-            )
+        mock_repo = MagicMock()
+        mock_repo.get_repositories.return_value = mock_result
+        test_client.app.dependency_overrides[get_github_repository] = (
+            lambda: mock_repo
+        )
 
-            assert response.status_code == 200
-            data = response.json()
-            assert isinstance(data, list)
-            assert len(data) > 0
-            assert "repo_id" in data[0]
-            assert "owner" in data[0]
-            assert "repo" in data[0]
-            assert "primary_language" in data[0]
+        response = test_client.get(
+            "/v1/data/github/repositories",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert "repo_id" in data[0]
+        assert "owner" in data[0]
+        assert "repo" in data[0]
+        assert "primary_language" in data[0]
 
     def test_get_repositories_requires_api_key(self, test_client):
         """API Keyが必要。"""
@@ -191,20 +208,25 @@ class TestActivityStatsEndpoint:
             }
         ]
 
-        with patch("backend.api.github.get_activity_stats", return_value=mock_result):
-            response = test_client.get(
-                "/v1/data/github/activity-stats?start_date=2024-01-01&end_date=2024-01-31&granularity=day",
-                headers={"X-API-Key": "test-backend-key"},
-            )
+        mock_repo = MagicMock()
+        mock_repo.get_activity_stats.return_value = mock_result
+        test_client.app.dependency_overrides[get_github_repository] = (
+            lambda: mock_repo
+        )
 
-            assert response.status_code == 200
-            data = response.json()
-            assert isinstance(data, list)
-            assert len(data) > 0
-            assert "period" in data[0]
-            assert "prs_created" in data[0]
-            assert "prs_merged" in data[0]
-            assert "commits_count" in data[0]
+        response = test_client.get(
+            "/v1/data/github/activity-stats?start_date=2024-01-01&end_date=2024-01-31&granularity=day",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert "period" in data[0]
+        assert "prs_created" in data[0]
+        assert "prs_merged" in data[0]
+        assert "commits_count" in data[0]
 
     def test_get_activity_stats_requires_api_key(self, test_client):
         """API Keyが必要。"""
@@ -244,22 +266,25 @@ class TestRepoSummaryStatsEndpoint:
             }
         ]
 
-        with patch(
-            "backend.api.github.get_repo_summary_stats", return_value=mock_result
-        ):
-            response = test_client.get(
-                "/v1/data/github/repo-summary-stats?start_date=2024-01-01&end_date=2024-01-31",
-                headers={"X-API-Key": "test-backend-key"},
-            )
+        mock_repo = MagicMock()
+        mock_repo.get_repo_summary_stats.return_value = mock_result
+        test_client.app.dependency_overrides[get_github_repository] = (
+            lambda: mock_repo
+        )
 
-            assert response.status_code == 200
-            data = response.json()
-            assert isinstance(data, list)
-            assert len(data) > 0
-            assert "owner" in data[0]
-            assert "repo" in data[0]
-            assert "prs_total" in data[0]
-            assert "commits_total" in data[0]
+        response = test_client.get(
+            "/v1/data/github/repo-summary-stats?start_date=2024-01-01&end_date=2024-01-31",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert "owner" in data[0]
+        assert "repo" in data[0]
+        assert "prs_total" in data[0]
+        assert "commits_total" in data[0]
 
     def test_get_repo_summary_stats_requires_api_key(self, test_client):
         """API Keyが必要。"""

--- a/egograph/backend/tests/unit/database/test_browser_history_queries.py
+++ b/egograph/backend/tests/unit/database/test_browser_history_queries.py
@@ -1,69 +1,52 @@
 """Browser History Queries層のテスト。"""
 
-from datetime import date, datetime, timezone
+from datetime import date, timezone
 from unittest.mock import patch
 
+from pydantic import SecretStr
+
+from backend.config import R2Config
 from backend.infrastructure.database import (
-    BrowserHistoryQueryParams,
+    QueryParams,
     get_page_views,
     get_top_domains,
-)
-from backend.infrastructure.database.browser_history_queries import (
-    _generate_browser_history_partition_paths,
 )
 from backend.validators import to_utc_range
 
 
-def _bqp(**overrides):
-    """テスト用 BrowserHistoryQueryParams ファクトリ。"""
-    defaults = dict(
-        bucket="test-bucket",
+def _make_r2_config(bucket_name: str = "test-bucket") -> R2Config:
+    return R2Config.model_construct(
+        endpoint_url="https://test.r2.cloudflarestorage.com",
+        access_key_id="test_key",
+        secret_access_key=SecretStr("test_secret"),
+        bucket_name=bucket_name,
+        raw_path="raw/",
         events_path="events/",
+        master_path="master/",
+        local_parquet_root=None,
+    )
+
+
+def _bqp(**overrides):
+    """テスト用 QueryParams ファクトリ。"""
+    defaults: dict = dict(
+        r2_config=_make_r2_config(),
         tz_name="UTC",
     )
     defaults.update(overrides)
+    defaults.pop("bucket", None)
+    defaults.pop("events_path", None)
+    defaults.pop("master_path", None)
     sd = defaults.pop("start_date")
     ed = defaults.pop("end_date")
     utc_start, utc_end = to_utc_range(sd, ed, timezone.utc)
-    return BrowserHistoryQueryParams(
+    return QueryParams(
         start_date=sd,
         end_date=ed,
         utc_start=utc_start,
         utc_end=utc_end,
         **defaults,
     )
-
-
-class TestGenerateBrowserHistoryPartitionPaths:
-    """Browser Historyパーティションパス生成のテスト。"""
-
-    def test_generates_single_month_path(self):
-        """同月期間のパスを生成する。"""
-        paths = _generate_browser_history_partition_paths(
-            bucket="test-bucket",
-            events_path="events/",
-            utc_start=datetime(2026, 3, 1),
-            utc_end=datetime(2026, 4, 1),
-        )
-
-        assert len(paths) == 2  # Mar + Apr (utc_end が次月のため)
-        assert paths[0] == (
-            "s3://test-bucket/events/browser_history/page_views/year=2026/month=03/**/*.parquet"
-        )
-
-    def test_generates_multiple_month_paths(self):
-        """複数月期間のパスを生成する。"""
-        paths = _generate_browser_history_partition_paths(
-            bucket="test-bucket",
-            events_path="events/",
-            utc_start=datetime(2026, 3, 20),
-            utc_end=datetime(2026, 5, 1),
-        )
-
-        assert len(paths) == 3
-        assert "year=2026/month=03" in paths[0]
-        assert "year=2026/month=04" in paths[1]
-        assert "year=2026/month=05" in paths[2]
 
 
 class TestGetPageViews:
@@ -77,13 +60,11 @@ class TestGetPageViews:
         parquet_path = browser_history_with_sample_data.test_page_views_parquet_path
 
         with patch(
-            "backend.infrastructure.database.browser_history_queries._generate_browser_history_partition_paths",
+            "backend.infrastructure.database.browser_history_queries._resolve_partition_paths",
             return_value=[parquet_path],
         ):
             params = _bqp(
                 conn=browser_history_with_sample_data,
-                bucket="test-bucket",
-                events_path="events/",
                 start_date=date(2026, 3, 20),
                 end_date=date(2026, 3, 22),
             )
@@ -97,13 +78,11 @@ class TestGetPageViews:
         parquet_path = browser_history_with_sample_data.test_page_views_parquet_path
 
         with patch(
-            "backend.infrastructure.database.browser_history_queries._generate_browser_history_partition_paths",
+            "backend.infrastructure.database.browser_history_queries._resolve_partition_paths",
             return_value=[parquet_path],
         ):
             params = _bqp(
                 conn=browser_history_with_sample_data,
-                bucket="test-bucket",
-                events_path="events/",
                 start_date=date(2026, 3, 20),
                 end_date=date(2026, 3, 22),
             )
@@ -128,13 +107,11 @@ class TestGetTopDomains:
         parquet_path = browser_history_with_sample_data.test_page_views_parquet_path
 
         with patch(
-            "backend.infrastructure.database.browser_history_queries._generate_browser_history_partition_paths",
+            "backend.infrastructure.database.browser_history_queries._resolve_partition_paths",
             return_value=[parquet_path],
         ):
             params = _bqp(
                 conn=browser_history_with_sample_data,
-                bucket="test-bucket",
-                events_path="events/",
                 start_date=date(2026, 3, 20),
                 end_date=date(2026, 3, 22),
             )
@@ -154,13 +131,11 @@ class TestGetTopDomains:
         parquet_path = browser_history_with_sample_data.test_page_views_parquet_path
 
         with patch(
-            "backend.infrastructure.database.browser_history_queries._generate_browser_history_partition_paths",
+            "backend.infrastructure.database.browser_history_queries._resolve_partition_paths",
             return_value=[parquet_path],
         ):
             params = _bqp(
                 conn=browser_history_with_sample_data,
-                bucket="test-bucket",
-                events_path="events/",
                 start_date=date(2026, 3, 20),
                 end_date=date(2026, 3, 22),
             )

--- a/egograph/backend/tests/unit/database/test_queries.py
+++ b/egograph/backend/tests/unit/database/test_queries.py
@@ -1,10 +1,12 @@
 """Database/Queries層のテスト。"""
 
-from datetime import date, datetime, timezone
+from datetime import date, timezone
 from unittest.mock import patch
 
 import pytest
+from pydantic import SecretStr
 
+from backend.config import R2Config
 from backend.infrastructure.database import (
     QueryParams,
     execute_query,
@@ -13,18 +15,33 @@ from backend.infrastructure.database import (
     get_top_tracks,
     search_tracks_by_name,
 )
-from backend.infrastructure.database.queries import _generate_partition_paths
 from backend.validators import to_utc_range
+
+
+def _make_r2_config(bucket_name: str = "test-bucket") -> R2Config:
+    return R2Config.model_construct(
+        endpoint_url="https://test.r2.cloudflarestorage.com",
+        access_key_id="test_key",
+        secret_access_key=SecretStr("test_secret"),
+        bucket_name=bucket_name,
+        raw_path="raw/",
+        events_path="events/",
+        master_path="master/",
+        local_parquet_root=None,
+    )
 
 
 def _qp(**overrides):
     """テスト用 QueryParams ファクトリ（UTC で日付を解釈）。"""
-    defaults = dict(
-        bucket="test-bucket",
-        events_path="events/",
+    defaults: dict = dict(
+        r2_config=_make_r2_config(),
         tz_name="UTC",
     )
     defaults.update(overrides)
+    # Drop legacy fields no longer present on unified QueryParams
+    defaults.pop("bucket", None)
+    defaults.pop("events_path", None)
+    defaults.pop("master_path", None)
     sd = defaults.pop("start_date")
     ed = defaults.pop("end_date")
     utc_start, utc_end = to_utc_range(sd, ed, timezone.utc)
@@ -35,62 +52,6 @@ def _qp(**overrides):
         utc_end=utc_end,
         **defaults,
     )
-
-
-class TestGeneratePartitionPaths:
-    """_generate_partition_paths のテスト。"""
-
-    def test_generates_single_month_path(self):
-        """1ヶ月分のパスを生成。"""
-        bucket = "my-bucket"
-        events_path = "events/"
-        start = datetime(2024, 1, 1)
-        end = datetime(2024, 2, 1)  # 排他、2/1 00:00 まで → Jan+Feb
-
-        paths = _generate_partition_paths(bucket, events_path, start, end)
-
-        # utc_end が 2/1 なので 2月も含まれる（安全側に倒す）
-        assert len(paths) == 2
-        assert (
-            paths[0]
-            == "s3://my-bucket/events/spotify/plays/year=2024/month=01/**/*.parquet"
-        )
-
-    def test_generates_multiple_month_paths(self):
-        """複数月のパスを生成。"""
-        bucket = "test-bucket"
-        events_path = "data/"
-        start = datetime(2024, 11, 15)
-        end = datetime(2025, 2, 1)
-
-        paths = _generate_partition_paths(bucket, events_path, start, end)
-
-        assert len(paths) == 4
-        assert (
-            paths[0]
-            == "s3://test-bucket/data/spotify/plays/year=2024/month=11/**/*.parquet"
-        )
-        assert (
-            paths[1]
-            == "s3://test-bucket/data/spotify/plays/year=2024/month=12/**/*.parquet"
-        )
-        assert (
-            paths[2]
-            == "s3://test-bucket/data/spotify/plays/year=2025/month=01/**/*.parquet"
-        )
-
-    def test_handles_year_boundary(self):
-        """年をまたぐ期間を正しく処理。"""
-        bucket = "bucket"
-        events_path = "events/"
-        start = datetime(2023, 12, 1)
-        end = datetime(2024, 2, 1)
-
-        paths = _generate_partition_paths(bucket, events_path, start, end)
-
-        assert len(paths) == 3
-        assert "year=2023/month=12" in paths[0]
-        assert "year=2024/month=01" in paths[1]
 
 
 class TestGetParquetPath:
@@ -177,20 +138,16 @@ class TestGetTopTracks:
     def test_returns_top_tracks(self, duckdb_with_sample_data):
         """トップトラックを取得。"""
         # Arrange: get_top_tracksを使用してトップトラックを取得
-        bucket = "test-bucket"
-        events_path = "events/"
         parquet_path = duckdb_with_sample_data.test_parquet_path
 
-        # _generate_partition_pathsをモックしてテスト用のparquetパスを返す
+        # _resolve_partition_pathsをモックしてテスト用のparquetパスを返す
         with patch(
-            "backend.infrastructure.database.queries._generate_partition_paths",
+            "backend.infrastructure.database.queries._resolve_partition_paths",
             return_value=[parquet_path],
         ):
             # Act: get_top_tracks関数を直接呼び出す
             params = _qp(
                 conn=duckdb_with_sample_data,
-                bucket=bucket,
-                events_path=events_path,
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 3),
             )
@@ -206,20 +163,16 @@ class TestGetTopTracks:
     def test_respects_limit_parameter(self, duckdb_with_sample_data):
         """limitパラメータを尊重。"""
         # Arrange: get_top_tracksを使用
-        bucket = "test-bucket"
-        events_path = "events/"
         parquet_path = duckdb_with_sample_data.test_parquet_path
 
-        # _generate_partition_pathsをモックしてテスト用のparquetパスを返す
+        # _resolve_partition_pathsをモックしてテスト用のparquetパスを返す
         with patch(
-            "backend.infrastructure.database.queries._generate_partition_paths",
+            "backend.infrastructure.database.queries._resolve_partition_paths",
             return_value=[parquet_path],
         ):
             # Act: limit=2でトップトラックを取得
             params = _qp(
                 conn=duckdb_with_sample_data,
-                bucket=bucket,
-                events_path=events_path,
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 3),
             )
@@ -231,20 +184,16 @@ class TestGetTopTracks:
     def test_filters_by_date_range(self, duckdb_with_sample_data):
         """日付範囲でフィルタリング。"""
         # Arrange: get_top_tracksを使用
-        bucket = "test-bucket"
-        events_path = "events/"
         parquet_path = duckdb_with_sample_data.test_parquet_path
 
-        # _generate_partition_pathsをモックしてテスト用のparquetパスを返す
+        # _resolve_partition_pathsをモックしてテスト用のparquetパスを返す
         with patch(
-            "backend.infrastructure.database.queries._generate_partition_paths",
+            "backend.infrastructure.database.queries._resolve_partition_paths",
             return_value=[parquet_path],
         ):
             # Act: 2024-01-01のデータのみ取得
             params = _qp(
                 conn=duckdb_with_sample_data,
-                bucket=bucket,
-                events_path=events_path,
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 1),
             )
@@ -260,20 +209,16 @@ class TestGetListeningStats:
     def test_aggregates_by_day(self, duckdb_with_sample_data):
         """日単位で集計。"""
         # Arrange: get_listening_statsを使用
-        bucket = "test-bucket"
-        events_path = "events/"
         parquet_path = duckdb_with_sample_data.test_parquet_path
 
-        # _generate_partition_pathsをモックしてテスト用のparquetパスを返す
+        # _resolve_partition_pathsをモックしてテスト用のparquetパスを返す
         with patch(
-            "backend.infrastructure.database.queries._generate_partition_paths",
+            "backend.infrastructure.database.queries._resolve_partition_paths",
             return_value=[parquet_path],
         ):
             # Act: 日単位で統計情報を取得
             params = _qp(
                 conn=duckdb_with_sample_data,
-                bucket=bucket,
-                events_path=events_path,
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 3),
             )
@@ -287,20 +232,16 @@ class TestGetListeningStats:
     def test_aggregates_by_month(self, duckdb_with_sample_data):
         """月単位で集計。"""
         # Arrange: get_listening_statsを使用
-        bucket = "test-bucket"
-        events_path = "events/"
         parquet_path = duckdb_with_sample_data.test_parquet_path
 
-        # _generate_partition_pathsをモックしてテスト用のparquetパスを返す
+        # _resolve_partition_pathsをモックしてテスト用のparquetパスを返す
         with patch(
-            "backend.infrastructure.database.queries._generate_partition_paths",
+            "backend.infrastructure.database.queries._resolve_partition_paths",
             return_value=[parquet_path],
         ):
             # Act: 月単位で統計情報を取得
             params = _qp(
                 conn=duckdb_with_sample_data,
-                bucket=bucket,
-                events_path=events_path,
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 3),
             )
@@ -314,20 +255,16 @@ class TestGetListeningStats:
     def test_invalid_granularity_raises_error(self, duckdb_with_sample_data):
         """無効な粒度でエラー発生。"""
         # Arrange: get_listening_statsを使用
-        bucket = "test-bucket"
-        events_path = "events/"
         parquet_path = duckdb_with_sample_data.test_parquet_path
 
-        # _generate_partition_pathsをモックしてテスト用のparquetパスを返す
+        # _resolve_partition_pathsをモックしてテスト用のparquetパスを返す
         with patch(
-            "backend.infrastructure.database.queries._generate_partition_paths",
+            "backend.infrastructure.database.queries._resolve_partition_paths",
             return_value=[parquet_path],
         ):
             # Act & Assert: 無効なgranularityでValueErrorが発生することを検証
             params = _qp(
                 conn=duckdb_with_sample_data,
-                bucket=bucket,
-                events_path=events_path,
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 3),
             )
@@ -339,7 +276,7 @@ class TestGetListeningStats:
         parquet_path = duckdb_with_sample_data.test_parquet_path
         with (
             patch(
-                "backend.infrastructure.database.queries._generate_partition_paths",
+                "backend.infrastructure.database.queries._resolve_partition_paths",
                 return_value=[parquet_path],
             ),
             patch(
@@ -349,8 +286,6 @@ class TestGetListeningStats:
         ):
             params = _qp(
                 conn=duckdb_with_sample_data,
-                bucket="test-bucket",
-                events_path="events/",
                 start_date=date(2024, 1, 1),
                 end_date=date(2024, 1, 3),
             )
@@ -365,18 +300,16 @@ class TestSearchTracksByName:
 
     def test_searches_by_track_name(self, duckdb_with_sample_data, mocker):
         """トラック名で検索。"""
-        # Arrange: get_parquet_pathをモックしてローカルパスを返す
+        # Arrange: build_dataset_globをモックしてローカルパスを返す
         parquet_path = duckdb_with_sample_data.test_parquet_path
         mocker.patch(
-            "backend.infrastructure.database.queries.get_parquet_path",
+            "backend.infrastructure.database.queries.build_dataset_glob",
             return_value=parquet_path,
         )
 
         # Act: トラック名で検索
         params = _qp(
             conn=duckdb_with_sample_data,
-            bucket="test_bucket",
-            events_path="events/",
             start_date=date(2024, 1, 1),
             end_date=date(2024, 12, 31),
         )
@@ -388,18 +321,16 @@ class TestSearchTracksByName:
 
     def test_searches_by_artist_name(self, duckdb_with_sample_data, mocker):
         """アーティスト名で検索。"""
-        # Arrange: get_parquet_pathをモックしてローカルパスを返す
+        # Arrange: build_dataset_globをモックしてローカルパスを返す
         parquet_path = duckdb_with_sample_data.test_parquet_path
         mocker.patch(
-            "backend.infrastructure.database.queries.get_parquet_path",
+            "backend.infrastructure.database.queries.build_dataset_glob",
             return_value=parquet_path,
         )
 
         # Act: アーティスト名で検索
         params = _qp(
             conn=duckdb_with_sample_data,
-            bucket="test_bucket",
-            events_path="events/",
             start_date=date(2024, 1, 1),
             end_date=date(2024, 12, 31),
         )
@@ -411,18 +342,16 @@ class TestSearchTracksByName:
 
     def test_case_insensitive_search(self, duckdb_with_sample_data, mocker):
         """大文字小文字を区別しない検索。"""
-        # Arrange: get_parquet_pathをモックしてローカルパスを返す
+        # Arrange: build_dataset_globをモックしてローカルパスを返す
         parquet_path = duckdb_with_sample_data.test_parquet_path
         mocker.patch(
-            "backend.infrastructure.database.queries.get_parquet_path",
+            "backend.infrastructure.database.queries.build_dataset_glob",
             return_value=parquet_path,
         )
 
         # Act: 小文字と大文字の両方で検索
         params = _qp(
             conn=duckdb_with_sample_data,
-            bucket="test_bucket",
-            events_path="events/",
             start_date=date(2024, 1, 1),
             end_date=date(2024, 12, 31),
         )

--- a/egograph/backend/tests/unit/database/test_queries.py
+++ b/egograph/backend/tests/unit/database/test_queries.py
@@ -13,7 +13,6 @@ from backend.infrastructure.database import (
     get_listening_stats,
     get_parquet_path,
     get_top_tracks,
-    search_tracks_by_name,
 )
 from backend.validators import to_utc_range
 
@@ -293,71 +292,3 @@ class TestGetListeningStats:
 
         query = mock_execute.call_args.args[1]
         assert "%G-W%V" in query
-
-
-class TestSearchTracksByName:
-    """search_tracks_by_name のテスト。"""
-
-    def test_searches_by_track_name(self, duckdb_with_sample_data, mocker):
-        """トラック名で検索。"""
-        # Arrange: build_dataset_globをモックしてローカルパスを返す
-        parquet_path = duckdb_with_sample_data.test_parquet_path
-        mocker.patch(
-            "backend.infrastructure.database.queries.build_dataset_glob",
-            return_value=parquet_path,
-        )
-
-        # Act: トラック名で検索
-        params = _qp(
-            conn=duckdb_with_sample_data,
-            start_date=date(2024, 1, 1),
-            end_date=date(2024, 12, 31),
-        )
-        result = search_tracks_by_name(params, query="Song A", limit=20)
-
-        # Assert: "Song A"が見つかることを検証
-        assert len(result) > 0
-        assert result[0]["track_name"] == "Song A"
-
-    def test_searches_by_artist_name(self, duckdb_with_sample_data, mocker):
-        """アーティスト名で検索。"""
-        # Arrange: build_dataset_globをモックしてローカルパスを返す
-        parquet_path = duckdb_with_sample_data.test_parquet_path
-        mocker.patch(
-            "backend.infrastructure.database.queries.build_dataset_glob",
-            return_value=parquet_path,
-        )
-
-        # Act: アーティスト名で検索
-        params = _qp(
-            conn=duckdb_with_sample_data,
-            start_date=date(2024, 1, 1),
-            end_date=date(2024, 12, 31),
-        )
-        result = search_tracks_by_name(params, query="Artist X", limit=20)
-
-        # Assert: Artist XはSong Aなので見つかることを検証
-        assert len(result) > 0
-        assert result[0]["artist"] == "Artist X"
-
-    def test_case_insensitive_search(self, duckdb_with_sample_data, mocker):
-        """大文字小文字を区別しない検索。"""
-        # Arrange: build_dataset_globをモックしてローカルパスを返す
-        parquet_path = duckdb_with_sample_data.test_parquet_path
-        mocker.patch(
-            "backend.infrastructure.database.queries.build_dataset_glob",
-            return_value=parquet_path,
-        )
-
-        # Act: 小文字と大文字の両方で検索
-        params = _qp(
-            conn=duckdb_with_sample_data,
-            start_date=date(2024, 1, 1),
-            end_date=date(2024, 12, 31),
-        )
-        result_lower = search_tracks_by_name(params, query="song a", limit=20)
-        result_upper = search_tracks_by_name(params, query="SONG A", limit=20)
-
-        # Assert: 大文字小文字に関わらず同じ結果が返されることを検証
-        assert len(result_lower) == len(result_upper)
-        assert result_lower[0]["track_name"] == result_upper[0]["track_name"]

--- a/egograph/backend/tests/unit/database/test_query_params.py
+++ b/egograph/backend/tests/unit/database/test_query_params.py
@@ -1,0 +1,219 @@
+"""QueryParams と execute_query のテスト。"""
+
+from dataclasses import FrozenInstanceError
+from datetime import date, datetime
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from backend.config import R2Config
+from backend.infrastructure.database.query_params import (
+    QueryParams,
+    _normalize_value,
+    execute_query,
+)
+
+
+class TestQueryParams:
+    """QueryParams dataclass のテスト。"""
+
+    def test_query_params_fields(self):
+        """QueryParams が必要なフィールドを持つことを確認。"""
+        # Arrange
+        r2_config = R2Config.model_construct()
+        conn = MagicMock()
+
+        # Act
+        params = QueryParams(
+            conn=conn,
+            r2_config=r2_config,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            utc_start=datetime(2024, 1, 1),
+            utc_end=datetime(2024, 2, 1),
+        )
+
+        # Assert
+        assert params.conn is conn
+        assert params.r2_config is r2_config
+        assert params.start_date == date(2024, 1, 1)
+        assert params.end_date == date(2024, 1, 31)
+        assert params.utc_start == datetime(2024, 1, 1)
+        assert params.utc_end == datetime(2024, 2, 1)
+        assert params.tz_name == "UTC"
+
+    def test_query_params_frozen(self):
+        """frozen=True によりインスタンスの変更が禁止されることを確認。"""
+        # Arrange
+        r2_config = R2Config.model_construct()
+        conn = MagicMock()
+        params = QueryParams(
+            conn=conn,
+            r2_config=r2_config,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            utc_start=datetime(2024, 1, 1),
+            utc_end=datetime(2024, 2, 1),
+        )
+
+        # Act & Assert
+        with pytest.raises(FrozenInstanceError):
+            params.tz_name = "Asia/Tokyo"
+
+    def test_query_params_r2_config_required(self):
+        """r2_config を省略すると TypeError が発生することを確認。"""
+        # Arrange
+        conn = MagicMock()
+
+        # Act & Assert
+        with pytest.raises(TypeError):
+            QueryParams(  # type: ignore[call-arg]
+                conn=conn,
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 1, 31),
+                utc_start=datetime(2024, 1, 1),
+                utc_end=datetime(2024, 2, 1),
+            )
+
+
+class TestNormalizeValue:
+    """_normalize_value のテスト。"""
+
+    def test_normalize_ndarray(self):
+        """np.ndarray をリストに変換。"""
+        # Arrange
+        arr = np.array([1, 2, 3])
+
+        # Act
+        result = _normalize_value(arr)
+
+        # Assert
+        assert result == [1, 2, 3]
+        assert isinstance(result, list)
+
+    def test_normalize_integer(self):
+        """np.integer を int に変換。"""
+        # Arrange
+        val = np.int64(42)
+
+        # Act
+        result = _normalize_value(val)
+
+        # Assert
+        assert result == 42
+        assert isinstance(result, int)
+
+    def test_normalize_float(self):
+        """np.floating を float に変換。"""
+        # Arrange
+        val = np.float64(3.14)
+
+        # Act
+        result = _normalize_value(val)
+
+        # Assert
+        assert result == 3.14
+        assert isinstance(result, float)
+
+    def test_normalize_bool(self):
+        """np.bool_ を bool に変換。"""
+        # Arrange
+        val = np.bool_(True)
+
+        # Act
+        result = _normalize_value(val)
+
+        # Assert
+        assert result is True
+        assert isinstance(result, bool)
+
+    def test_normalize_plain_types_unchanged(self):
+        """Python標準型は変換されずそのまま返る。"""
+        # Arrange
+        values = [42, 3.14, True, "hello", None, [1, 2, 3], {"a": 1}]
+
+        # Act & Assert
+        for val in values:
+            assert _normalize_value(val) is val
+
+
+class TestExecuteQuery:
+    """execute_query のテスト。"""
+
+    def test_execute_query_normal(self):
+        """通常のクエリ実行で辞書のリストが返ることを確認。"""
+        # Arrange
+        mock_conn = MagicMock()
+        mock_result = MagicMock()
+        mock_df = pd.DataFrame({"id": [1, 2], "name": ["Alice", "Bob"]})
+        mock_result.df.return_value = mock_df
+        mock_conn.execute.return_value = mock_result
+
+        # Act
+        result = execute_query(mock_conn, "SELECT * FROM users")
+
+        # Assert
+        mock_conn.execute.assert_called_once_with("SELECT * FROM users", [])
+        assert result == [
+            {"id": 1, "name": "Alice"},
+            {"id": 2, "name": "Bob"},
+        ]
+
+    def test_execute_query_numpy_conversion(self):
+        """numpy 型が Python 標準型に変換されることを確認。"""
+        # Arrange
+        mock_conn = MagicMock()
+        mock_result = MagicMock()
+        mock_df = pd.DataFrame(
+            {
+                "id": np.int64([1, 2]),
+                "score": np.float64([95.5, 87.3]),
+                "is_active": np.bool_([True, False]),
+                "tags": [np.array(["a", "b"]), np.array(["c"])],
+            }
+        )
+        mock_result.df.return_value = mock_df
+        mock_conn.execute.return_value = mock_result
+
+        # Act
+        result = execute_query(mock_conn, "SELECT * FROM data")
+
+        # Assert
+        assert len(result) == 2
+        assert result[0] == {
+            "id": 1,
+            "score": 95.5,
+            "is_active": True,
+            "tags": ["a", "b"],
+        }
+        assert result[1] == {
+            "id": 2,
+            "score": 87.3,
+            "is_active": False,
+            "tags": ["c"],
+        }
+        # 型が正しく変換されていることを確認
+        assert isinstance(result[0]["id"], int)
+        assert isinstance(result[0]["score"], float)
+        assert isinstance(result[0]["is_active"], bool)
+        assert isinstance(result[0]["tags"], list)
+
+    def test_execute_query_empty_result(self):
+        """結果が空の場合、空リストが返ることを確認。"""
+        # Arrange
+        mock_conn = MagicMock()
+        mock_result = MagicMock()
+        mock_df = pd.DataFrame()
+        mock_result.df.return_value = mock_df
+        mock_conn.execute.return_value = mock_result
+
+        # Act
+        result = execute_query(mock_conn, "SELECT * FROM empty_table")
+
+        # Assert
+        mock_conn.execute.assert_called_once_with(
+            "SELECT * FROM empty_table", []
+        )
+        assert result == []

--- a/egograph/backend/tests/unit/database/test_query_params.py
+++ b/egograph/backend/tests/unit/database/test_query_params.py
@@ -155,7 +155,7 @@ class TestExecuteQuery:
         result = execute_query(mock_conn, "SELECT * FROM users")
 
         # Assert
-        mock_conn.execute.assert_called_once_with("SELECT * FROM users", [])
+        mock_conn.execute.assert_called_once_with("SELECT * FROM users", ())
         assert result == [
             {"id": 1, "name": "Alice"},
             {"id": 2, "name": "Bob"},
@@ -214,6 +214,6 @@ class TestExecuteQuery:
 
         # Assert
         mock_conn.execute.assert_called_once_with(
-            "SELECT * FROM empty_table", []
+            "SELECT * FROM empty_table", ()
         )
         assert result == []

--- a/egograph/backend/tests/unit/repositories/test_github_repository.py
+++ b/egograph/backend/tests/unit/repositories/test_github_repository.py
@@ -18,20 +18,14 @@ class TestGitHubRepository:
         prs_parquet_path = github_with_sample_data.test_prs_parquet_path
 
         with patch(
-            "backend.infrastructure.repositories.github_repository.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=github_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
-            with patch(
-                "backend.infrastructure.database.github_queries.build_partition_paths",
-                return_value=[prs_parquet_path],
-            ):
-                # Act
-                repo = GitHubRepository(mock_r2_config())
-                result = repo.get_pull_requests(date(2024, 1, 1), date(2024, 1, 31))
+            "backend.infrastructure.database.github_queries.build_partition_paths",
+            return_value=[prs_parquet_path],
+        ):
+            # Act
+            repo = GitHubRepository(mock_r2_config())
+            result = repo.get_pull_requests(
+                github_with_sample_data, date(2024, 1, 1), date(2024, 1, 31)
+            )
 
         # Assert
         assert len(result) > 0
@@ -47,27 +41,20 @@ class TestGitHubRepository:
         prs_parquet_path = github_with_sample_data.test_prs_parquet_path
 
         with patch(
-            "backend.infrastructure.repositories.github_repository.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=github_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
-            with patch(
-                "backend.infrastructure.database.github_queries.build_partition_paths",
-                return_value=[prs_parquet_path],
-            ):
-                # Act
-                repo = GitHubRepository(mock_r2_config())
-                result = repo.get_pull_requests(
-                    date(2024, 1, 1),
-                    date(2024, 1, 31),
-                    owner="test_owner",
-                    repo="test_repo",
-                    state="open",
-                    limit=10,
-                )
+            "backend.infrastructure.database.github_queries.build_partition_paths",
+            return_value=[prs_parquet_path],
+        ):
+            # Act
+            repo = GitHubRepository(mock_r2_config())
+            result = repo.get_pull_requests(
+                github_with_sample_data,
+                date(2024, 1, 1),
+                date(2024, 1, 31),
+                owner="test_owner",
+                repo="test_repo",
+                state="open",
+                limit=10,
+            )
 
         # Assert
         assert isinstance(result, list)
@@ -82,20 +69,14 @@ class TestGitHubRepository:
         commits_parquet_path = github_with_sample_data.test_commits_parquet_path
 
         with patch(
-            "backend.infrastructure.repositories.github_repository.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=github_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
-            with patch(
-                "backend.infrastructure.database.github_queries.build_partition_paths",
-                return_value=[commits_parquet_path],
-            ):
-                # Act
-                repo = GitHubRepository(mock_r2_config())
-                result = repo.get_commits(date(2024, 1, 1), date(2024, 1, 31))
+            "backend.infrastructure.database.github_queries.build_partition_paths",
+            return_value=[commits_parquet_path],
+        ):
+            # Act
+            repo = GitHubRepository(mock_r2_config())
+            result = repo.get_commits(
+                github_with_sample_data, date(2024, 1, 1), date(2024, 1, 31)
+            )
 
         # Assert
         assert len(result) > 0
@@ -111,26 +92,19 @@ class TestGitHubRepository:
         commits_parquet_path = github_with_sample_data.test_commits_parquet_path
 
         with patch(
-            "backend.infrastructure.repositories.github_repository.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=github_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
-            with patch(
-                "backend.infrastructure.database.github_queries.build_partition_paths",
-                return_value=[commits_parquet_path],
-            ):
-                # Act
-                repo = GitHubRepository(mock_r2_config())
-                result = repo.get_commits(
-                    date(2024, 1, 1),
-                    date(2024, 1, 31),
-                    owner="test_owner",
-                    repo="test_repo",
-                    limit=10,
-                )
+            "backend.infrastructure.database.github_queries.build_partition_paths",
+            return_value=[commits_parquet_path],
+        ):
+            # Act
+            repo = GitHubRepository(mock_r2_config())
+            result = repo.get_commits(
+                github_with_sample_data,
+                date(2024, 1, 1),
+                date(2024, 1, 31),
+                owner="test_owner",
+                repo="test_repo",
+                limit=10,
+            )
 
         # Assert
         assert isinstance(result, list)
@@ -145,20 +119,12 @@ class TestGitHubRepository:
         repos_parquet_path = github_with_sample_data.test_repos_parquet_path
 
         with patch(
-            "backend.infrastructure.repositories.github_repository.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=github_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
-            with patch(
-                "backend.infrastructure.database.github_queries.get_repos_parquet_path",
-                return_value=repos_parquet_path,
-            ):
-                # Act
-                repo = GitHubRepository(mock_r2_config())
-                result = repo.get_repositories()
+            "backend.infrastructure.database.github_queries.get_repos_parquet_path",
+            return_value=repos_parquet_path,
+        ):
+            # Act
+            repo = GitHubRepository(mock_r2_config())
+            result = repo.get_repositories(github_with_sample_data)
 
         # Assert
         assert len(result) > 0
@@ -174,20 +140,14 @@ class TestGitHubRepository:
         repos_parquet_path = github_with_sample_data.test_repos_parquet_path
 
         with patch(
-            "backend.infrastructure.repositories.github_repository.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=github_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
-            with patch(
-                "backend.infrastructure.database.github_queries.get_repos_parquet_path",
-                return_value=repos_parquet_path,
-            ):
-                # Act
-                repo = GitHubRepository(mock_r2_config())
-                result = repo.get_repositories(owner="test_owner")
+            "backend.infrastructure.database.github_queries.get_repos_parquet_path",
+            return_value=repos_parquet_path,
+        ):
+            # Act
+            repo = GitHubRepository(mock_r2_config())
+            result = repo.get_repositories(
+                github_with_sample_data, owner="test_owner"
+            )
 
         # Assert
         assert isinstance(result, list)
@@ -205,26 +165,21 @@ class TestGitHubRepository:
         commits_parquet_path = github_with_sample_data.test_commits_parquet_path
 
         with patch(
-            "backend.infrastructure.repositories.github_repository.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=github_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
+            "backend.infrastructure.database.github_queries.build_partition_paths",
+            return_value=[prs_parquet_path],
+        ):
             with patch(
-                "backend.infrastructure.database.github_queries.build_partition_paths",
-                return_value=[prs_parquet_path],
+                "backend.infrastructure.database.github_queries._resolve_commit_partition_paths",
+                return_value=[commits_parquet_path],
             ):
-                with patch(
-                    "backend.infrastructure.database.github_queries._resolve_commit_partition_paths",
-                    return_value=[commits_parquet_path],
-                ):
-                    # Act
-                    repo = GitHubRepository(mock_r2_config())
-                    result = repo.get_activity_stats(
-                        date(2024, 1, 1), date(2024, 1, 31), granularity="day"
-                    )
+                # Act
+                repo = GitHubRepository(mock_r2_config())
+                result = repo.get_activity_stats(
+                    github_with_sample_data,
+                    date(2024, 1, 1),
+                    date(2024, 1, 31),
+                    granularity="day",
+                )
 
         # Assert
         assert isinstance(result, list)
@@ -241,26 +196,20 @@ class TestGitHubRepository:
         commits_parquet_path = github_with_sample_data.test_commits_parquet_path
 
         with patch(
-            "backend.infrastructure.repositories.github_repository.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=github_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
+            "backend.infrastructure.database.github_queries.build_partition_paths",
+            return_value=[prs_parquet_path],
+        ):
             with patch(
-                "backend.infrastructure.database.github_queries.build_partition_paths",
-                return_value=[prs_parquet_path],
+                "backend.infrastructure.database.github_queries._resolve_commit_partition_paths",
+                return_value=[commits_parquet_path],
             ):
-                with patch(
-                    "backend.infrastructure.database.github_queries._resolve_commit_partition_paths",
-                    return_value=[commits_parquet_path],
-                ):
-                    # Act
-                    repo = GitHubRepository(mock_r2_config())
-                    result = repo.get_repo_summary_stats(
-                        date(2024, 1, 1), date(2024, 1, 31)
-                    )
+                # Act
+                repo = GitHubRepository(mock_r2_config())
+                result = repo.get_repo_summary_stats(
+                    github_with_sample_data,
+                    date(2024, 1, 1),
+                    date(2024, 1, 31),
+                )
 
         # Assert
         assert isinstance(result, list)

--- a/egograph/backend/tests/unit/repositories/test_github_repository.py
+++ b/egograph/backend/tests/unit/repositories/test_github_repository.py
@@ -1,7 +1,7 @@
 """GitHub Repository層のテスト（REDフェーズ）。"""
 
 from datetime import date
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from pydantic import SecretStr
 

--- a/egograph/backend/tests/unit/repositories/test_youtube_queries.py
+++ b/egograph/backend/tests/unit/repositories/test_youtube_queries.py
@@ -8,6 +8,7 @@ import pytest
 
 from backend.config import R2Config
 from backend.infrastructure.database.parquet_paths import build_partition_paths
+from backend.infrastructure.database.query_params import QueryParams
 from backend.infrastructure.database.youtube_queries import (
     DEFAULT_WATCH_EVENTS_LIMIT,
     _build_enriched_cte,
@@ -22,7 +23,6 @@ from backend.infrastructure.database.youtube_queries import (
     get_watch_events_parquet_path,
     get_watching_stats,
 )
-from backend.infrastructure.database.query_params import QueryParams
 from backend.tests.fixtures.youtube import patch_youtube_paths
 from backend.validators import to_utc_range
 
@@ -121,7 +121,9 @@ class TestBuildPartitionPaths:
         start = datetime(2024, 1, 1)
         end = datetime(2024, 2, 1)
 
-        paths = build_partition_paths(mock_r2_config, "events", "youtube/watch_events", start, end)
+        paths = build_partition_paths(
+            mock_r2_config, "events", "youtube/watch_events", start, end
+        )
 
         assert len(paths) == 2  # Jan + Feb
         assert "year=2024/month=01" in paths[0]
@@ -131,7 +133,9 @@ class TestBuildPartitionPaths:
         start = datetime(2024, 11, 15)
         end = datetime(2025, 2, 1)
 
-        paths = build_partition_paths(mock_r2_config, "events", "youtube/watch_events", start, end)
+        paths = build_partition_paths(
+            mock_r2_config, "events", "youtube/watch_events", start, end
+        )
 
         assert len(paths) == 4
 
@@ -140,7 +144,9 @@ class TestBuildPartitionPaths:
         start = datetime(2023, 12, 1)
         end = datetime(2024, 2, 1)
 
-        paths = build_partition_paths(mock_r2_config, "events", "youtube/watch_events", start, end)
+        paths = build_partition_paths(
+            mock_r2_config, "events", "youtube/watch_events", start, end
+        )
 
         assert len(paths) == 3
         assert "year=2023/month=12" in paths[0]

--- a/egograph/backend/tests/unit/repositories/test_youtube_queries.py
+++ b/egograph/backend/tests/unit/repositories/test_youtube_queries.py
@@ -6,11 +6,11 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
 
+from backend.config import R2Config
+from backend.infrastructure.database.parquet_paths import build_partition_paths
 from backend.infrastructure.database.youtube_queries import (
     DEFAULT_WATCH_EVENTS_LIMIT,
-    YouTubeQueryParams,
     _build_enriched_cte,
-    _generate_partition_paths,
     _parquet_file_exists,
     _resolve_watch_event_paths,
     execute_query,
@@ -22,23 +22,33 @@ from backend.infrastructure.database.youtube_queries import (
     get_watch_events_parquet_path,
     get_watching_stats,
 )
+from backend.infrastructure.database.query_params import QueryParams
 from backend.tests.fixtures.youtube import patch_youtube_paths
 from backend.validators import to_utc_range
 
 
 def _yqp(**overrides):
-    """テスト用 YouTubeQueryParams ファクトリ。"""
+    """テスト用 QueryParams ファクトリ。"""
     defaults = dict(
-        bucket="test-bucket",
-        events_path="events/",
-        master_path="master/",
         tz_name="UTC",
     )
     defaults.update(overrides)
     sd = defaults.pop("start_date")
     ed = defaults.pop("end_date")
+    # r2_config が指定されていなければ、個別フィールドから構築
+    if "r2_config" not in defaults:
+        defaults["r2_config"] = R2Config.model_construct(
+            endpoint_url="https://test.r2.cloudflarestorage.com",
+            access_key_id="test_key",
+            secret_access_key="test_secret",
+            bucket_name=defaults.pop("bucket", "test-bucket"),
+            raw_path="raw/",
+            events_path=defaults.pop("events_path", "events/"),
+            master_path=defaults.pop("master_path", "master/"),
+            local_parquet_root=None,
+        )
     utc_start, utc_end = to_utc_range(sd, ed, timezone.utc)
-    return YouTubeQueryParams(
+    return QueryParams(
         start_date=sd,
         end_date=ed,
         utc_start=utc_start,
@@ -47,24 +57,30 @@ def _yqp(**overrides):
     )
 
 
-class TestYouTubeQueryParams:
-    """YouTubeQueryParams dataclassのテスト。"""
+class TestQueryParams:
+    """QueryParams dataclassのテスト。"""
 
     def test_creates_params(self, duckdb_conn):
-        """YouTubeQueryParamsを作成。"""
+        """QueryParamsを作成。"""
         # Arrange & Act
         params = _yqp(
             conn=duckdb_conn,
-            bucket="test-bucket",
-            events_path="events/",
-            master_path="master/",
+            r2_config=R2Config.model_construct(
+                endpoint_url="https://test.r2.cloudflarestorage.com",
+                access_key_id="test_key",
+                secret_access_key="test_secret",
+                bucket_name="test-bucket",
+                raw_path="raw/",
+                events_path="events/",
+                master_path="master/",
+                local_parquet_root=None,
+            ),
             start_date=date(2024, 1, 1),
             end_date=date(2024, 1, 31),
         )
 
         # Assert
-        assert params.bucket == "test-bucket"
-        assert params.events_path == "events/"
+        assert params.r2_config.bucket_name == "test-bucket"
         assert params.start_date == date(2024, 1, 1)
         assert params.end_date == date(2024, 1, 31)
 
@@ -97,55 +113,34 @@ class TestGetParquetPaths:
         assert path == "s3://my-bucket/master/youtube/channels/data.parquet"
 
 
-class TestGeneratePartitionPaths:
-    """_generate_partition_paths のテスト。"""
+class TestBuildPartitionPaths:
+    """build_partition_paths のテスト。"""
 
-    def test_generates_single_month_path(self):
+    def test_generates_single_month_path(self, mock_r2_config):
         """1ヶ月分のパスを生成。"""
-        bucket = "my-bucket"
-        events_path = "events/"
         start = datetime(2024, 1, 1)
         end = datetime(2024, 2, 1)
 
-        paths = _generate_partition_paths(bucket, events_path, start, end)
+        paths = build_partition_paths(mock_r2_config, "events", "youtube/watch_events", start, end)
 
         assert len(paths) == 2  # Jan + Feb
-        assert (
-            paths[0]
-            == "s3://my-bucket/events/youtube/watch_events/year=2024/month=01/**/*.parquet"
-        )
+        assert "year=2024/month=01" in paths[0]
 
-    def test_generates_multiple_month_paths(self):
+    def test_generates_multiple_month_paths(self, mock_r2_config):
         """複数月のパスを生成。"""
-        bucket = "test-bucket"
-        events_path = "data/"
         start = datetime(2024, 11, 15)
         end = datetime(2025, 2, 1)
 
-        paths = _generate_partition_paths(bucket, events_path, start, end)
+        paths = build_partition_paths(mock_r2_config, "events", "youtube/watch_events", start, end)
 
         assert len(paths) == 4
-        assert (
-            paths[0]
-            == "s3://test-bucket/data/youtube/watch_events/year=2024/month=11/**/*.parquet"
-        )
-        assert (
-            paths[1]
-            == "s3://test-bucket/data/youtube/watch_events/year=2024/month=12/**/*.parquet"
-        )
-        assert (
-            paths[2]
-            == "s3://test-bucket/data/youtube/watch_events/year=2025/month=01/**/*.parquet"
-        )
 
-    def test_handles_year_boundary(self):
+    def test_handles_year_boundary(self, mock_r2_config):
         """年をまたぐ期間を正しく処理。"""
-        bucket = "bucket"
-        events_path = "events/"
         start = datetime(2023, 12, 1)
         end = datetime(2024, 2, 1)
 
-        paths = _generate_partition_paths(bucket, events_path, start, end)
+        paths = build_partition_paths(mock_r2_config, "events", "youtube/watch_events", start, end)
 
         assert len(paths) == 3
         assert "year=2023/month=12" in paths[0]
@@ -155,35 +150,31 @@ class TestGeneratePartitionPaths:
 class TestResolveWatchEventPaths:
     """_resolve_watch_event_paths のテスト。"""
 
-    def test_falls_back_to_dataset_glob_when_no_partition_matches(self):
-        """月パーティションが未作成なら dataset glob にフォールバック。"""
-        conn = Mock()
-        execute_result = Mock()
-        execute_result.fetchone.return_value = (0,)
-        conn.execute.return_value = execute_result
+    def test_delegates_to_build_partition_paths(self, mock_r2_config):
+        """build_partition_paths に委譲する。"""
         params = _yqp(
-            conn=conn,
-            bucket="test-bucket",
-            events_path="events/",
-            master_path="master/",
+            conn=Mock(),
+            r2_config=mock_r2_config,
             start_date=date(2024, 1, 1),
             end_date=date(2024, 1, 31),
         )
-        with (
-            patch(
-                "backend.infrastructure.database.youtube_queries._generate_partition_paths",
-                return_value=[
-                    "s3://test/events/youtube/watch_events/year=2024/month=01/**/*.parquet"
-                ],
-            ),
-            patch(
-                "backend.infrastructure.database.youtube_queries.get_watch_events_parquet_path",
-                return_value="s3://test/events/youtube/watch_events/**/*.parquet",
-            ),
-        ):
+        expected = [
+            "s3://test/events/youtube/watch_events/year=2024/month=01/**/*.parquet"
+        ]
+        with patch(
+            "backend.infrastructure.database.youtube_queries.build_partition_paths",
+            return_value=expected,
+        ) as mock_func:
             paths = _resolve_watch_event_paths(params)
 
-        assert paths == ["s3://test/events/youtube/watch_events/**/*.parquet"]
+        assert paths == expected
+        mock_func.assert_called_once_with(
+            mock_r2_config,
+            data_domain="events",
+            dataset_path="youtube/watch_events",
+            utc_start=params.utc_start,
+            utc_end=params.utc_end,
+        )
 
 
 class TestExecuteQuery:

--- a/egograph/backend/tests/unit/repositories/test_youtube_queries.py
+++ b/egograph/backend/tests/unit/repositories/test_youtube_queries.py
@@ -20,7 +20,6 @@ from backend.infrastructure.database.youtube_queries import (
     get_top_videos,
     get_videos_parquet_path,
     get_watch_events,
-    get_watch_events_parquet_path,
     get_watching_stats,
 )
 from backend.tests.fixtures.youtube import patch_youtube_paths
@@ -87,14 +86,6 @@ class TestQueryParams:
 
 class TestGetParquetPaths:
     """Parquetパス生成関数のテスト。"""
-
-    def test_get_watch_events_parquet_path(self):
-        """視聴イベントのS3パスパターンを生成。"""
-        # Arrange & Act
-        path = get_watch_events_parquet_path("my-bucket", "events/")
-
-        # Assert
-        assert path == "s3://my-bucket/events/youtube/watch_events/**/*.parquet"
 
     def test_get_videos_parquet_path(self):
         """動画マスターのS3パスパターンを生成。"""

--- a/egograph/backend/tests/unit/repositories/test_youtube_repository.py
+++ b/egograph/backend/tests/unit/repositories/test_youtube_repository.py
@@ -1,7 +1,7 @@
 """YouTube Repository層のテスト。"""
 
 from datetime import date
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from pydantic import SecretStr
 
@@ -28,18 +28,12 @@ class TestYouTubeRepository:
 
     def test_get_watch_events(self, youtube_with_sample_data):
         """視聴イベントを取得。"""
-        with patch(
-            "backend.infrastructure.database.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=youtube_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
-            with patch_youtube_paths(youtube_with_sample_data):
-                # Act
-                repo = YouTubeRepository(_mock_r2_config())
-                result = repo.get_watch_events(date(2024, 1, 1), date(2024, 1, 3))
+        with patch_youtube_paths(youtube_with_sample_data):
+            # Act
+            repo = YouTubeRepository(_mock_r2_config())
+            result = repo.get_watch_events(
+                youtube_with_sample_data, date(2024, 1, 1), date(2024, 1, 3)
+            )
 
         # Assert
         assert len(result) > 0
@@ -48,20 +42,15 @@ class TestYouTubeRepository:
 
     def test_get_watching_stats(self, youtube_with_sample_data):
         """視聴統計を取得。"""
-        with patch(
-            "backend.infrastructure.database.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=youtube_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
-            with patch_youtube_paths(youtube_with_sample_data):
-                # Act
-                repo = YouTubeRepository(_mock_r2_config())
-                result = repo.get_watching_stats(
-                    date(2024, 1, 1), date(2024, 1, 3), granularity="day"
-                )
+        with patch_youtube_paths(youtube_with_sample_data):
+            # Act
+            repo = YouTubeRepository(_mock_r2_config())
+            result = repo.get_watching_stats(
+                youtube_with_sample_data,
+                date(2024, 1, 1),
+                date(2024, 1, 3),
+                granularity="day",
+            )
 
         # Assert
         assert len(result) > 0
@@ -71,18 +60,12 @@ class TestYouTubeRepository:
 
     def test_get_top_videos(self, youtube_with_sample_data):
         """トップ動画を取得。"""
-        with patch(
-            "backend.infrastructure.database.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=youtube_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
-            with patch_youtube_paths(youtube_with_sample_data):
-                # Act
-                repo = YouTubeRepository(_mock_r2_config())
-                result = repo.get_top_videos(date(2024, 1, 1), date(2024, 1, 3))
+        with patch_youtube_paths(youtube_with_sample_data):
+            # Act
+            repo = YouTubeRepository(_mock_r2_config())
+            result = repo.get_top_videos(
+                youtube_with_sample_data, date(2024, 1, 1), date(2024, 1, 3)
+            )
 
         # Assert
         assert len(result) > 0
@@ -91,18 +74,12 @@ class TestYouTubeRepository:
 
     def test_get_top_channels(self, youtube_with_sample_data):
         """トップチャンネルを取得。"""
-        with patch(
-            "backend.infrastructure.database.DuckDBConnection"
-        ) as mock_conn_class:
-            mock_conn = MagicMock()
-            mock_conn.__enter__ = MagicMock(return_value=youtube_with_sample_data)
-            mock_conn.__exit__ = MagicMock(return_value=False)
-            mock_conn_class.return_value = mock_conn
-
-            with patch_youtube_paths(youtube_with_sample_data):
-                # Act
-                repo = YouTubeRepository(_mock_r2_config())
-                result = repo.get_top_channels(date(2024, 1, 1), date(2024, 1, 3))
+        with patch_youtube_paths(youtube_with_sample_data):
+            # Act
+            repo = YouTubeRepository(_mock_r2_config())
+            result = repo.get_top_channels(
+                youtube_with_sample_data, date(2024, 1, 1), date(2024, 1, 3)
+            )
 
         # Assert
         assert len(result) > 0

--- a/egograph/backend/tests/unit/repositories/test_youtube_repository.py
+++ b/egograph/backend/tests/unit/repositories/test_youtube_repository.py
@@ -1,7 +1,6 @@
 """YouTube Repository層のテスト。"""
 
 from datetime import date
-from unittest.mock import patch
 
 from pydantic import SecretStr
 


### PR DESCRIPTION
## 概要

Backend データアクセス層の包括的なリファクタリング。分散していたクエリパラメータ構築・接続管理・依存注入を統一し、保守性とテスト容易性を向上させる。

設計書: `docs/20.backend/data-access-layer-refactoring.md`

## 変更内容

### Step 1: QueryParams 統合 (`query_params.py` 新設)
- `QueryParams` frozen dataclass + `execute_query` + `_normalize_value` を新設
- 各 `*_queries.py` に散在していたパラメータ構築・値正規化ロジックを一元化

### Step 2: 重複削除 (`*_queries.py`)
- `queries.py`, `github_queries.py`, `youtube_queries.py`, `browser_history_queries.py` から重複コードを削除
- `__init__.py` エクスポート更新

### Step 3: Repository 接続注入 + DI
- 4 Repository に `conn` 引数注入、`with DuckDBConnection` 削除
- `dependencies.py` に DI 関数 4 つ追加

### Step 4: API 層 Repository DI 統一
- API 層 4 ファイルを Repository DI に統一
- backward-compat alias 削除

### Step 5: テスト修正・検証
- 統合テストの mock パスを修正（`patch()` → `app.dependency_overrides`）
- `test_compacted_parquet_reads.py` の `QueryParams` 構築を修正
- ruff format/fix 適用

## テスト結果

- 単体テスト 224 件: **PASS**
- 統合テスト 31 件: **PASS**
- 合計 255 件: **ALL GREEN**
- ruff check: 新規エラーなし（既存 E501 のみ）

## コミット構成

| Hash | Type | Description |
|------|------|-------------|
| `b9ebced` | feat | QueryParams 統合 + テスト 11 件 |
| `da27a92` | refactor | 重複削除（queries, github, youtube, browser_history） |
| `79a1e85` | test | テスト更新（統一 QueryParams 対応） |
| `ab3e4a0` | refactor | Repository conn 注入 + DI 関数 |
| `6c57420` | refactor | API 層 Repository DI 化 |
| `e468b8f` | style | ruff format |
| `5a73ab7` | fix | 統合テスト mock パス修正 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * データ取得の内部実装を統一し、各種データ（Spotify/GitHub/YouTube/ブラウザ履歴）の取得処理を共通リポジトリ／共通パラメータへ切り替えました。依存注入とクエリ実行の仕組みを整理し、保守性とテストの安定性を向上させました。ユーザー向けの挙動や API 応答フォーマットに変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->