### PR TITLE
feat(pipelines): Pipeline失敗検知・通知基盤 (Auth fail-fast + Webhook)

### DIFF
--- a/docs/30.pipelines/architecture.md
+++ b/docs/30.pipelines/architecture.md
@@ -363,6 +363,7 @@ stateDiagram-v2
 | `WorkflowDisabledError` | run を reject |
 | Step timeout | FAILED として記録、再試行判定 |
 | Step exception | FAILED として記録、再試行判定 |
+| `AuthenticationError` | **即時** FAILED（リトライ対象外） |
 
 ### 再試行ロジック
 
@@ -371,10 +372,70 @@ for attempt_no in range(1, step.max_attempts + 1):
     result = execute_step(step, attempt_no)
     if result.status == SUCCEEDED:
         return True
+    if isinstance(exc, AuthenticationError):
+        return False  # 認証エラーは即 fail-fast
     if attempt_no < step.max_attempts:
         sleep(step.retry_delay_seconds)
 return False
 ```
+
+### AuthenticationError (Fail-fast)
+
+OAuth トークン失効など**回復不能な認証エラー**を通常の `SpotifyException` / `RuntimeError` と区別する。`AuthenticationError` 発生時は `step.max_attempts` に関わらず 1 回で即失敗する。
+
+```python
+# 例: SpotifyCollector で invalid_grant を変換
+try:
+    self.auth_manager.refresh_access_token(refresh_token)
+except SpotifyOauthError as exc:
+    if exc.error == "invalid_grant":
+        raise AuthenticationError(
+            "Spotify refresh token revoked or expired"
+        ) from exc
+    raise AuthenticationError(
+        f"Spotify OAuth error: {exc.error or 'unknown'}"
+    ) from exc
+```
+
+## 失敗通知 (Webhook)
+
+Pipeline run が FAILED に遷移した際、Webhook で通知する。デフォルトは無効 (`PIPELINES_WEBHOOK_URL` 未設定)。
+
+### 環境変数
+
+| 変数 | デフォルト | 説明 |
+|---|---|---|
+| `PIPELINES_WEBHOOK_URL` | 未設定 (通知無効) | Webhook 送信先 URL |
+| `PIPELINES_WEBHOOK_TYPE` | `generic` | `generic` (CloudEvents-inspired JSON) / `discord` (Embed) |
+
+### Payload 形式 (Generic)
+
+```json
+{
+  "source": "urn:egograph:pipelines",
+  "type": "egograph.pipelines.workflow_failed",
+  "time": "2026-06-05T14:00:02Z",
+  "data": {
+    "workflow_id": "spotify_ingest_workflow",
+    "run_id": "722e2f38-def8-4bba-9283-bfe07459935c",
+    "error_message": "AuthenticationError: Spotify refresh token revoked",
+    "custom_message": "認証でエラーが発生しました。再認証スクリプトを実行してください: uv run python scripts/spotify_auth.py"
+  }
+}
+```
+
+### コンポーネント
+
+- `domain/notification.py`: `NotificationEvent` / `NotificationData`（不変 dataclass）
+- `infrastructure/notification/adapters.py`: `WebhookAdapter` (抽象) / `GenericAdapter` / `DiscordAdapter`
+- `infrastructure/notification/service.py`: `NotificationService`（`custom_message` 補完と送信失敗の握りつぶし）
+
+### 発火タイミング
+
+1. step 失敗（`max_attempts` 消費後、または `AuthenticationError` 即時 skip）
+2. 予期しない dispatcher 例外 (`_mark_run_failed_after_unexpected_exception` 経由）
+
+Lock 競合 (`WorkflowLockUnavailableError` での requeue) や未知 workflow 設定エラーでは通知しない。
 
 ---
 

--- a/egograph/pipelines/.env.example
+++ b/egograph/pipelines/.env.example
@@ -15,6 +15,13 @@ PIPELINES_API_KEY=<replace-with-strong-random-api-key>
 # データパスは共通 path モジュールで管理するため、通常はここで上書きしない。
 
 # ====================
+# Failure Notification (Webhook)
+# ====================
+# 任意。未設定なら Pipeline 失敗通知は無効化される。
+# PIPELINES_WEBHOOK_URL=https://example.com/webhook
+# PIPELINES_WEBHOOK_TYPE=generic  # generic | discord
+
+# ====================
 # Cloudflare R2 / S3-compatible object storage
 # ====================
 R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com

--- a/egograph/pipelines/config.py
+++ b/egograph/pipelines/config.py
@@ -31,3 +31,5 @@ class PipelinesConfig(BaseSettings):
     max_concurrent_runs: int = 4
     lock_lease_seconds: int = 300
     lock_heartbeat_seconds: int = 30
+    webhook_url: str | None = None
+    webhook_type: str = "generic"

--- a/egograph/pipelines/domain/errors.py
+++ b/egograph/pipelines/domain/errors.py
@@ -26,4 +26,4 @@ class WorkflowLockUnavailableError(PipelinesError):
 
 
 class AuthenticationError(PipelinesError):
-    """認証エラー（トークン失効・無効なクレデンシャル等）。リトライ対象外。"""
+    """認証エラー (トークン失効・無効なクレデンシャル等)。リトライ対象外。"""

--- a/egograph/pipelines/domain/errors.py
+++ b/egograph/pipelines/domain/errors.py
@@ -23,3 +23,7 @@ class StepRunNotFoundError(PipelinesError):
 
 class WorkflowLockUnavailableError(PipelinesError):
     """workflow lock を取得できない。"""
+
+
+class AuthenticationError(PipelinesError):
+    """認証エラー（トークン失効・無効なクレデンシャル等）。リトライ対象外。"""

--- a/egograph/pipelines/domain/notification.py
+++ b/egograph/pipelines/domain/notification.py
@@ -1,0 +1,30 @@
+"""Pipeline 通知イベントのドメインモデル。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class NotificationData:
+    """通知イベント固有のデータ。"""
+
+    workflow_id: str
+    run_id: str
+    error_message: str | None
+    custom_message: str | None
+
+
+@dataclass(frozen=True)
+class NotificationEvent:
+    """Pipeline から発火する通知イベント。
+
+    CloudEvents v1.0 の構造を参考にした **内部契約** であり、CloudEvents 仕様への
+    完全準拠は **目指さない**（必要な場合は adapter 層で正規化する想定）。
+    """
+
+    source: str
+    type: str
+    time: datetime
+    data: NotificationData

--- a/egograph/pipelines/domain/notification.py
+++ b/egograph/pipelines/domain/notification.py
@@ -21,7 +21,7 @@ class NotificationEvent:
     """Pipeline から発火する通知イベント。
 
     CloudEvents v1.0 の構造を参考にした **内部契約** であり、CloudEvents 仕様への
-    完全準拠は **目指さない**（必要な場合は adapter 層で正規化する想定）。
+    完全準拠は **目指さない** (必要な場合は adapter 層で正規化する想定)。
     """
 
     source: str

--- a/egograph/pipelines/infrastructure/dispatching/run_dispatcher.py
+++ b/egograph/pipelines/infrastructure/dispatching/run_dispatcher.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from datetime import UTC, datetime
 
 from pipelines.domain.errors import AuthenticationError, WorkflowLockUnavailableError
+from pipelines.domain.notification import NotificationData, NotificationEvent
 from pipelines.domain.workflow import (
     StepDefinition,
     StepExecutorType,
@@ -27,8 +29,12 @@ from pipelines.infrastructure.execution.inprocess_executor import (
 from pipelines.infrastructure.execution.subprocess_executor import (
     SubprocessStepExecutor,
 )
+from pipelines.infrastructure.notification.service import NotificationService
 
 logger = logging.getLogger(__name__)
+
+NOTIFICATION_SOURCE = "urn:egograph:pipelines"
+NOTIFICATION_TYPE = "egograph.pipelines.workflow_failed"
 
 
 class _DispatchOutcome:
@@ -51,6 +57,7 @@ class RunDispatcher:
         lock_manager: WorkflowLockManager,
         subprocess_executor: SubprocessStepExecutor,
         inprocess_executor: InProcessStepExecutor,
+        notification_service: NotificationService,
         poll_seconds: float,
         heartbeat_seconds: int,
         max_concurrent_runs: int = 1,
@@ -61,6 +68,7 @@ class RunDispatcher:
         self._lock_manager = lock_manager
         self._subprocess_executor = subprocess_executor
         self._inprocess_executor = inprocess_executor
+        self._notification_service = notification_service
         self._poll_seconds = poll_seconds
         self._heartbeat_seconds = heartbeat_seconds
         self._max_concurrent_runs = max(1, max_concurrent_runs)
@@ -118,6 +126,7 @@ class RunDispatcher:
     def dispatch_once(self) -> bool:
         """queued run を1件処理する。"""
         run: WorkflowRun | None = None
+        workflow: WorkflowDefinition | None = None
         try:
             run = self._run_repository.lease_next_queued_run()
             if run is None:
@@ -151,7 +160,8 @@ class RunDispatcher:
                 run.run_id,
             )
             self._mark_run_failed_after_unexpected_exception(
-                run_id=run.run_id,
+                run=run,
+                workflow=workflow,
                 exc=exc,
             )
             return True
@@ -162,6 +172,7 @@ class RunDispatcher:
         excluded_run_ids: set[str],
     ) -> _DispatchOutcome:
         run: WorkflowRun | None = None
+        workflow: WorkflowDefinition | None = None
         try:
             run = self._run_repository.lease_next_queued_run(
                 excluded_run_ids=excluded_run_ids
@@ -172,7 +183,7 @@ class RunDispatcher:
             workflow = self._workflows.get(run.workflow_id)
             if workflow is None:
                 self._fail_unknown_workflow_run(run)
-                return True
+                return _DispatchOutcome(dispatched=True)
 
             try:
                 lease = self._lock_manager.acquire(
@@ -208,7 +219,8 @@ class RunDispatcher:
                 run.run_id,
             )
             self._mark_run_failed_after_unexpected_exception(
-                run_id=run.run_id,
+                run=run,
+                workflow=workflow,
                 exc=exc,
             )
             return _DispatchOutcome(dispatched=True)
@@ -239,13 +251,14 @@ class RunDispatcher:
         last_summary: dict | None = None
         try:
             for sequence_no, step in enumerate(workflow.steps, start=1):
-                success, last_summary, error_message = self._execute_step(
+                success, last_summary, error_message, last_exc = self._execute_step(
                     workflow=workflow,
                     run=run,
                     step=step,
                     sequence_no=sequence_no,
                 )
                 if not success:
+                    final_error = error_message or f"step failed: {step.step_id}"
                     self._skip_remaining_steps(
                         run=run,
                         steps=workflow.steps[sequence_no:],
@@ -254,9 +267,14 @@ class RunDispatcher:
                     self._run_repository.update_run_result(
                         run_id=run.run_id,
                         status=WorkflowRunStatus.FAILED,
-                        error_message=error_message
-                        or f"step failed: {step.step_id}",
+                        error_message=final_error,
                         result_summary=last_summary,
+                    )
+                    self._notify_failure(
+                        workflow=workflow,
+                        run=run,
+                        error_message=final_error,
+                        exc=last_exc,
                     )
                     return
             self._run_repository.update_run_result(
@@ -270,7 +288,8 @@ class RunDispatcher:
                 run.run_id,
             )
             self._mark_run_failed_after_unexpected_exception(
-                run_id=run.run_id,
+                workflow=workflow,
+                run=run,
                 exc=exc,
             )
 
@@ -281,8 +300,14 @@ class RunDispatcher:
         run: WorkflowRun,
         step: StepDefinition,
         sequence_no: int,
-    ) -> tuple[bool, dict | None, str | None]:
+    ) -> tuple[bool, dict | None, str | None, Exception | None]:
+        """step を retry 込みで実行する。
+
+        戻り値 ``exception`` は失敗時のみ設定され、通知の ``custom_message``
+        組み立てのために ``_execute_run`` まで持ち越される。
+        """
         last_error_message: str | None = None
+        last_exception: Exception | None = None
         for attempt_no in range(1, step.max_attempts + 1):
             step_run = self._step_run_repository.insert_step_run(
                 run_id=run.run_id,
@@ -308,8 +333,9 @@ class RunDispatcher:
                     exc=exc,
                 )
                 last_error_message = f"{type(exc).__name__}: {exc}"
+                last_exception = exc
                 if isinstance(exc, AuthenticationError):
-                    return False, None, last_error_message
+                    return False, None, last_error_message, exc
                 if attempt_no < step.max_attempts and step.retry_delay_seconds > 0:
                     time.sleep(step.retry_delay_seconds)
                 continue
@@ -323,11 +349,11 @@ class RunDispatcher:
                 result_summary=result.result_summary,
             )
             if result.status == StepRunStatus.SUCCEEDED:
-                return True, result.result_summary, None
+                return True, result.result_summary, None, None
             last_error_message = result.error_message
             if attempt_no < step.max_attempts and step.retry_delay_seconds > 0:
                 time.sleep(step.retry_delay_seconds)
-        return False, None, last_error_message
+        return False, None, last_error_message, last_exception
 
     def _execute_definition(
         self,
@@ -470,22 +496,51 @@ class RunDispatcher:
     def _mark_run_failed_after_unexpected_exception(
         self,
         *,
-        run_id: str,
+        run: WorkflowRun,
+        workflow: WorkflowDefinition | None,
         exc: Exception,
     ) -> None:
+        """予期しない例外で run を FAILED にし、可能なら通知も送る。"""
+        error_message = f"unexpected dispatcher error: {type(exc).__name__}: {exc}"
         try:
             # Persist the failure explicitly so startup reconcile does not need
             # to clean up a RUNNING row after an in-loop crash.
             self._run_repository.update_run_result(
-                run_id=run_id,
+                run_id=run.run_id,
                 status=WorkflowRunStatus.FAILED,
-                error_message=(
-                    "unexpected dispatcher error: "
-                    f"{type(exc).__name__}: {exc}"
-                ),
+                error_message=error_message,
             )
         except Exception:
             logger.exception(
                 "failed to persist unexpected dispatcher error for run_id=%s",
-                run_id,
+                run.run_id,
             )
+        if workflow is not None:
+            self._notify_failure(
+                workflow=workflow,
+                run=run,
+                error_message=error_message,
+                exc=exc,
+            )
+
+    def _notify_failure(
+        self,
+        *,
+        workflow: WorkflowDefinition,
+        run: WorkflowRun,
+        error_message: str,
+        exc: Exception | None,
+    ) -> None:
+        """失敗イベントを構築して NotificationService に委譲する。"""
+        event = NotificationEvent(
+            source=NOTIFICATION_SOURCE,
+            type=NOTIFICATION_TYPE,
+            time=datetime.now(UTC),
+            data=NotificationData(
+                workflow_id=workflow.workflow_id,
+                run_id=run.run_id,
+                error_message=error_message,
+                custom_message=None,
+            ),
+        )
+        self._notification_service.notify(event, exc=exc)

--- a/egograph/pipelines/infrastructure/dispatching/run_dispatcher.py
+++ b/egograph/pipelines/infrastructure/dispatching/run_dispatcher.py
@@ -6,7 +6,7 @@ import logging
 import threading
 import time
 
-from pipelines.domain.errors import WorkflowLockUnavailableError
+from pipelines.domain.errors import AuthenticationError, WorkflowLockUnavailableError
 from pipelines.domain.workflow import (
     StepDefinition,
     StepExecutorType,
@@ -308,6 +308,8 @@ class RunDispatcher:
                     exc=exc,
                 )
                 last_error_message = f"{type(exc).__name__}: {exc}"
+                if isinstance(exc, AuthenticationError):
+                    return False, None, last_error_message
                 if attempt_no < step.max_attempts and step.retry_delay_seconds > 0:
                     time.sleep(step.retry_delay_seconds)
                 continue

--- a/egograph/pipelines/infrastructure/notification/__init__.py
+++ b/egograph/pipelines/infrastructure/notification/__init__.py
@@ -1,1 +1,1 @@
-"""Pipeline failure notification module."""
+"""パイプライン失敗通知モジュール。"""

--- a/egograph/pipelines/infrastructure/notification/__init__.py
+++ b/egograph/pipelines/infrastructure/notification/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline failure notification module."""

--- a/egograph/pipelines/infrastructure/notification/adapters.py
+++ b/egograph/pipelines/infrastructure/notification/adapters.py
@@ -1,0 +1,84 @@
+"""Webhook 送信 adapter。
+
+CloudEvents-inspired JSON (Generic) と Discord Embed 形式 (Discord) の
+2 種類の adapter を提供する。Platform 固有の拡張は adapter を追加する。
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import requests
+
+from pipelines.domain.notification import NotificationEvent
+
+DEFAULT_TIMEOUT_SECONDS = 5.0
+
+
+def _format_time_iso8601_utc(event: NotificationEvent) -> str:
+    """ISO 8601 UTC 文字列 ('Z' サフィックス) へ整形する。"""
+    return event.time.isoformat().replace("+00:00", "Z")
+
+
+class WebhookAdapter(ABC):
+    """Webhook 送信の抽象基底クラス。"""
+
+    @abstractmethod
+    def send(self, url: str, event: NotificationEvent) -> None:
+        """HTTP 送信する。HTTP 4xx/5xx 時は例外を送出すること。"""
+
+    @staticmethod
+    def _post_json(url: str, payload: dict) -> None:
+        response = requests.post(url, json=payload, timeout=DEFAULT_TIMEOUT_SECONDS)
+        response.raise_for_status()
+
+
+class GenericAdapter(WebhookAdapter):
+    """CloudEvents-inspired JSON をそのまま POST する汎用 adapter。"""
+
+    def send(self, url: str, event: NotificationEvent) -> None:
+        payload = {
+            "source": event.source,
+            "type": event.type,
+            "time": _format_time_iso8601_utc(event),
+            "data": {
+                "workflow_id": event.data.workflow_id,
+                "run_id": event.data.run_id,
+                "error_message": event.data.error_message,
+                "custom_message": event.data.custom_message,
+            },
+        }
+        self._post_json(url, payload)
+
+
+class DiscordAdapter(WebhookAdapter):
+    """Discord Webhook 用 adapter。Embed 形式に変換して送信する。"""
+
+    _RED_COLOR = 16711680
+    _USERNAME = "EgoGraph Pipelines"
+
+    def send(self, url: str, event: NotificationEvent) -> None:
+        payload = {
+            "username": self._USERNAME,
+            "embeds": [
+                {
+                    "title": "Pipeline Failed",
+                    "description": event.data.workflow_id,
+                    "color": self._RED_COLOR,
+                    "fields": [
+                        {
+                            "name": "Error",
+                            "value": event.data.error_message or "(none)",
+                        },
+                        {
+                            "name": "Action",
+                            "value": event.data.custom_message or "(none)",
+                        },
+                        {"name": "Run ID", "value": event.data.run_id},
+                    ],
+                    "timestamp": _format_time_iso8601_utc(event),
+                    "footer": {"text": event.source},
+                }
+            ],
+        }
+        self._post_json(url, payload)

--- a/egograph/pipelines/infrastructure/notification/service.py
+++ b/egograph/pipelines/infrastructure/notification/service.py
@@ -24,7 +24,7 @@ def _custom_message_for(exc: Exception | None) -> str | None:
     """例外型からユーザー/エージェント向けメッセージを組み立てる。
 
     新たな例外型に対応するときはここに ``isinstance`` 分岐を追加するだけで
-    済む（Open/Closed）。
+    済む (Open/Closed)。
     """
     if exc is None:
         return None
@@ -52,7 +52,7 @@ class NotificationService:
 
     @property
     def enabled(self) -> bool:
-        """通知が有効（webhook URL 設定済み）か。"""
+        """通知が有効 (webhook URL 設定済み) か。"""
         return self._webhook_url is not None
 
     def notify(self, event: NotificationEvent, exc: Exception | None = None) -> None:

--- a/egograph/pipelines/infrastructure/notification/service.py
+++ b/egograph/pipelines/infrastructure/notification/service.py
@@ -1,0 +1,94 @@
+"""Pipeline 失敗通知サービス。
+
+Webhook 送信は adapter 層に委譲し、本サービスでは ``custom_message`` の
+組み立てと送信失敗時の握りつぶしを担当する。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+
+from pipelines.domain.errors import AuthenticationError
+from pipelines.domain.notification import NotificationEvent
+from pipelines.infrastructure.notification.adapters import (
+    DiscordAdapter,
+    GenericAdapter,
+    WebhookAdapter,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _custom_message_for(exc: Exception | None) -> str | None:
+    """例外型からユーザー/エージェント向けメッセージを組み立てる。
+
+    新たな例外型に対応するときはここに ``isinstance`` 分岐を追加するだけで
+    済む（Open/Closed）。
+    """
+    if exc is None:
+        return None
+    if isinstance(exc, AuthenticationError):
+        return (
+            "認証でエラーが発生しました。"
+            "再認証スクリプトを実行してください: "
+            "uv run python scripts/spotify_auth.py"
+        )
+    return None
+
+
+class NotificationService:
+    """Pipeline 失敗時の通知サービス。"""
+
+    def __init__(
+        self,
+        *,
+        webhook_url: str | None,
+        webhook_type: str = "generic",
+    ) -> None:
+        """``webhook_url`` が ``None`` のとき通知は無効化される。"""
+        self._webhook_url = webhook_url
+        self._adapter: WebhookAdapter = self._create_adapter(webhook_type)
+
+    @property
+    def enabled(self) -> bool:
+        """通知が有効（webhook URL 設定済み）か。"""
+        return self._webhook_url is not None
+
+    def notify(self, event: NotificationEvent, exc: Exception | None = None) -> None:
+        """イベントを Webhook 送信する。送信失敗は Pipeline を阻害しない。"""
+        if not self._webhook_url:
+            return
+        enriched = self._enrich_with_custom_message(event, exc)
+        try:
+            self._adapter.send(self._webhook_url, enriched)
+        except Exception:
+            logger.exception(
+                "Failed to send webhook notification: type=%s, run_id=%s",
+                enriched.type,
+                enriched.data.run_id,
+            )
+
+    @staticmethod
+    def _create_adapter(webhook_type: str) -> WebhookAdapter:
+        if webhook_type == "discord":
+            return DiscordAdapter()
+        if webhook_type == "generic":
+            return GenericAdapter()
+        raise ValueError(
+            f"unsupported webhook_type: {webhook_type!r} "
+            "(expected 'generic' or 'discord')"
+        )
+
+    @staticmethod
+    def _enrich_with_custom_message(
+        event: NotificationEvent,
+        exc: Exception | None,
+    ) -> NotificationEvent:
+        """``event.data.custom_message`` 未設定時に ``exc`` から補完する。"""
+        if event.data.custom_message is not None:
+            return event
+        custom = _custom_message_for(exc)
+        if custom is None:
+            return event
+        return replace(event, data=replace(event.data, custom_message=custom))

--- a/egograph/pipelines/service.py
+++ b/egograph/pipelines/service.py
@@ -23,6 +23,7 @@ from pipelines.infrastructure.execution.log_store import LocalLogStore
 from pipelines.infrastructure.execution.subprocess_executor import (
     SubprocessStepExecutor,
 )
+from pipelines.infrastructure.notification.service import NotificationService
 from pipelines.infrastructure.scheduling.apscheduler_app import ScheduleTriggerApp
 from pipelines.workflows.registry import get_workflows
 
@@ -63,6 +64,10 @@ class PipelineService:
             mutex=db_mutex,
         )
         log_store = LocalLogStore(config.logs_root)
+        notification_service = NotificationService(
+            webhook_url=config.webhook_url,
+            webhook_type=config.webhook_type,
+        )
         service = cls(
             config=config,
             workflow_repository=workflow_repository,
@@ -84,6 +89,7 @@ class PipelineService:
                 lock_manager=lock_manager,
                 subprocess_executor=SubprocessStepExecutor(log_store),
                 inprocess_executor=InProcessStepExecutor(log_store),
+                notification_service=notification_service,
                 poll_seconds=config.dispatcher_poll_seconds,
                 heartbeat_seconds=config.lock_heartbeat_seconds,
                 max_concurrent_runs=config.max_concurrent_runs,

--- a/egograph/pipelines/sources/spotify/collector.py
+++ b/egograph/pipelines/sources/spotify/collector.py
@@ -11,13 +11,15 @@ from typing import Any
 
 import requests
 import spotipy
-from spotipy.oauth2 import SpotifyOAuth
+from spotipy.oauth2 import SpotifyOAuth, SpotifyOauthError
 from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
 )
+
+from pipelines.domain.errors import AuthenticationError
 
 from .config import (
     MAX_RETRIES,
@@ -128,7 +130,16 @@ class SpotifyCollector:
             open_browser=False,
         )
 
-        self.auth_manager.refresh_access_token(refresh_token)
+        try:
+            self.auth_manager.refresh_access_token(refresh_token)
+        except SpotifyOauthError as exc:
+            if exc.error == "invalid_grant":
+                raise AuthenticationError(
+                    "Spotify refresh token revoked or expired"
+                ) from exc
+            raise AuthenticationError(
+                f"Spotify OAuth error: {exc.error or 'unknown'}"
+            ) from exc
         logger.info("Successfully refreshed Spotify access token")
 
         self.sp = spotipy.Spotify(auth_manager=self.auth_manager)

--- a/egograph/pipelines/tests/integration/github/test_compact.py
+++ b/egograph/pipelines/tests/integration/github/test_compact.py
@@ -96,7 +96,8 @@ def test_compact_deduplicates_commits():
 
         _seed_duplicate_commits(memory_s3)
 
-        result = run_github_compact(config=config)
+        # 投入月を明示。日付ドリフト回避
+        result = run_github_compact(config=config, year=2026, month=4)
 
         assert result["operation"] == "compact"
         assert len(result["compacted_keys"]) > 0

--- a/egograph/pipelines/tests/integration/spotify/test_compact.py
+++ b/egograph/pipelines/tests/integration/spotify/test_compact.py
@@ -121,8 +121,8 @@ def test_compact_deduplicates_events():
         # 重複データを投入
         _seed_duplicate_events(memory_s3)
 
-        # Compaction 実行
-        result = run_spotify_compact(config=config)
+        # Compaction 実行 (投入月を明示。日付ドリフト回避)
+        result = run_spotify_compact(config=config, year=2026, month=4)
 
         assert result["operation"] == "compact"
         assert len(result["compacted_keys"]) > 0

--- a/egograph/pipelines/tests/unit/notification/test_notification.py
+++ b/egograph/pipelines/tests/unit/notification/test_notification.py
@@ -46,8 +46,12 @@ def _make_event(
 
 def test_webhook_adapter_is_abstract():
     """WebhookAdapter は直接インスタンス化できない。"""
+    # Arrange
+    abstract_class = WebhookAdapter
+
+    # Act & Assert
     with pytest.raises(TypeError):
-        WebhookAdapter()
+        abstract_class()
 
 
 # ===== GenericAdapter =====
@@ -302,5 +306,9 @@ def test_service_swallows_adapter_failure_with_log(caplog):
 
 def test_service_rejects_unknown_webhook_type():
     """未知の webhook_type は ValueError。"""
+    # Arrange
+    kwargs = {"webhook_url": "https://x", "webhook_type": "slack"}
+
+    # Act & Assert
     with pytest.raises(ValueError, match="unsupported webhook_type"):
-        NotificationService(webhook_url="https://x", webhook_type="slack")
+        NotificationService(**kwargs)

--- a/egograph/pipelines/tests/unit/notification/test_notification.py
+++ b/egograph/pipelines/tests/unit/notification/test_notification.py
@@ -1,0 +1,306 @@
+"""通知系 (adapters / service) のテスト。"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+import requests
+from pipelines.domain.errors import AuthenticationError
+from pipelines.domain.notification import NotificationData, NotificationEvent
+from pipelines.infrastructure.notification.adapters import (
+    DEFAULT_TIMEOUT_SECONDS,
+    DiscordAdapter,
+    GenericAdapter,
+    WebhookAdapter,
+)
+from pipelines.infrastructure.notification.service import (
+    NotificationService,
+    _custom_message_for,
+)
+
+
+def _make_event(
+    *,
+    custom_message: str | None = None,
+    error_message: str | None = "boom",
+) -> NotificationEvent:
+    return NotificationEvent(
+        source="urn:egograph:pipelines",
+        type="egograph.pipelines.workflow_failed",
+        time=datetime(2026, 6, 5, 14, 0, 2, tzinfo=UTC),
+        data=NotificationData(
+            workflow_id="spotify_ingest_workflow",
+            run_id="722e2f38-def8-4bba-9283-bfe07459935c",
+            error_message=error_message,
+            custom_message=custom_message,
+        ),
+    )
+
+
+# ===== WebhookAdapter 抽象 =====
+
+
+def test_webhook_adapter_is_abstract():
+    """WebhookAdapter は直接インスタンス化できない。"""
+    with pytest.raises(TypeError):
+        WebhookAdapter()
+
+
+# ===== GenericAdapter =====
+
+
+def test_generic_adapter_posts_cloudevents_inspired_json():
+    """GenericAdapter は CloudEvents-inspired JSON を POST する。"""
+    # Arrange
+    adapter = GenericAdapter()
+    event = _make_event(custom_message="再認証してください")
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 200
+        adapter.send("https://example.com/webhook", event)
+
+    # Assert
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert args == ("https://example.com/webhook",)
+    assert kwargs["timeout"] == DEFAULT_TIMEOUT_SECONDS
+    assert kwargs["json"] == {
+        "source": "urn:egograph:pipelines",
+        "type": "egograph.pipelines.workflow_failed",
+        "time": "2026-06-05T14:00:02Z",
+        "data": {
+            "workflow_id": "spotify_ingest_workflow",
+            "run_id": "722e2f38-def8-4bba-9283-bfe07459935c",
+            "error_message": "boom",
+            "custom_message": "再認証してください",
+        },
+    }
+
+
+def test_generic_adapter_raises_on_http_error():
+    """HTTP 4xx/5xx で HTTPError を送出する。"""
+    # Arrange
+    adapter = GenericAdapter()
+    event = _make_event()
+
+    # Act & Assert
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_response = mock_post.return_value
+        mock_response.raise_for_status.side_effect = requests.HTTPError("500")
+        with pytest.raises(requests.HTTPError):
+            adapter.send("https://example.com/webhook", event)
+
+
+# ===== DiscordAdapter =====
+
+
+def test_discord_adapter_posts_embed_payload():
+    """DiscordAdapter は Embed 形式に変換して POST する。"""
+    # Arrange
+    adapter = DiscordAdapter()
+    event = _make_event(custom_message="再認証スクリプト実行")
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 204
+        adapter.send("https://discord.com/api/webhooks/abc", event)
+
+    # Assert
+    args, kwargs = mock_post.call_args
+    payload = kwargs["json"]
+    assert kwargs["timeout"] == DEFAULT_TIMEOUT_SECONDS
+    assert payload["username"] == "EgoGraph Pipelines"
+    assert len(payload["embeds"]) == 1
+    embed = payload["embeds"][0]
+    assert embed["title"] == "Pipeline Failed"
+    assert embed["description"] == "spotify_ingest_workflow"
+    assert embed["color"] == 16711680
+    assert embed["timestamp"] == "2026-06-05T14:00:02Z"
+    assert embed["footer"]["text"] == "urn:egograph:pipelines"
+    field_names = [f["name"] for f in embed["fields"]]
+    assert "Error" in field_names
+    assert "Action" in field_names
+    assert "Run ID" in field_names
+    # payloads are JSON-serializable
+    json.dumps(payload)
+
+
+def test_discord_adapter_uses_none_fallback_for_empty_messages():
+    """error_message / custom_message が None なら '(none)' に置換される。"""
+    # Arrange
+    adapter = DiscordAdapter()
+    event = _make_event(error_message=None, custom_message=None)
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 204
+        adapter.send("https://discord.com/api/webhooks/abc", event)
+
+    # Assert
+    payload = mock_post.call_args.kwargs["json"]
+    fields = {f["name"]: f["value"] for f in payload["embeds"][0]["fields"]}
+    assert fields["Error"] == "(none)"
+    assert fields["Action"] == "(none)"
+
+
+# ===== _custom_message_for =====
+
+
+def test_custom_message_for_authentication_error_returns_spotify_hint():
+    """AuthenticationError → Spotify 再認証手順。"""
+    # Arrange
+    exc = AuthenticationError("Spotify refresh token revoked")
+
+    # Act
+    msg = _custom_message_for(exc)
+
+    # Assert
+    assert msg is not None
+    assert "認証" in msg
+    assert "spotify_auth.py" in msg
+
+
+def test_custom_message_for_other_exception_returns_none():
+    """未知の例外型は custom_message を出さない。"""
+    assert _custom_message_for(RuntimeError("boom")) is None
+    assert _custom_message_for(ValueError("nope")) is None
+
+
+def test_custom_message_for_none_returns_none():
+    """exc=None なら custom_message を出さない。"""
+    assert _custom_message_for(None) is None
+
+
+# ===== NotificationService =====
+
+
+def test_service_disabled_when_webhook_url_is_none():
+    """webhook_url 未設定時は何もせず正常終了する。"""
+    # Arrange
+    service = NotificationService(webhook_url=None)
+    event = _make_event()
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        service.notify(event)
+
+    # Assert
+    mock_post.assert_not_called()
+    assert service.enabled is False
+
+
+def test_service_sends_event_when_webhook_url_is_set():
+    """webhook_url 設定時は adapter.send が呼ばれる。"""
+    # Arrange
+    service = NotificationService(webhook_url="https://example.com/hook")
+    event = _make_event()
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 200
+        service.notify(event)
+
+    # Assert
+    mock_post.assert_called_once()
+
+
+def test_service_enriches_custom_message_for_authentication_error():
+    """exc=AuthenticationError 渡下で custom_message が補完される。"""
+    # Arrange
+    service = NotificationService(webhook_url="https://example.com/hook")
+    event = _make_event(custom_message=None)
+    exc = AuthenticationError("revoked")
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 200
+        service.notify(event, exc=exc)
+
+    # Assert
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["data"]["custom_message"] is not None
+    assert "spotify_auth.py" in payload["data"]["custom_message"]
+
+
+def test_service_does_not_overwrite_existing_custom_message():
+    """event.data.custom_message 設定済みなら上書きしない。"""
+    # Arrange
+    service = NotificationService(webhook_url="https://example.com/hook")
+    event = _make_event(custom_message="既設の指示")
+    exc = AuthenticationError("revoked")
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 200
+        service.notify(event, exc=exc)
+
+    # Assert
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["data"]["custom_message"] == "既設の指示"
+
+
+def test_service_does_not_enrich_when_exc_is_none():
+    """exc=None なら custom_message は補完しない。"""
+    # Arrange
+    service = NotificationService(webhook_url="https://example.com/hook")
+    event = _make_event(custom_message=None)
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 200
+        service.notify(event, exc=None)
+
+    # Assert
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["data"]["custom_message"] is None
+
+
+def test_service_swallows_adapter_failure_with_log(caplog):
+    """adapter 送信失敗時に Pipeline を阻害せず logger.exception だけ出す。"""
+    # Arrange
+    service = NotificationService(webhook_url="https://example.com/hook")
+    event = _make_event()
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.side_effect = requests.ConnectionError("connection refused")
+        with caplog.at_level(
+            logging.ERROR, logger="pipelines.infrastructure.notification.service"
+        ):
+            service.notify(event)
+
+    # Assert: 例外が伝播しない
+    mock_post.assert_called_once()
+    assert "Failed to send webhook notification" in caplog.text
+    assert event.data.run_id in caplog.text
+
+
+def test_service_rejects_unknown_webhook_type():
+    """未知の webhook_type は ValueError。"""
+    with pytest.raises(ValueError, match="unsupported webhook_type"):
+        NotificationService(webhook_url="https://x", webhook_type="slack")

--- a/egograph/pipelines/tests/unit/spotify/test_collector.py
+++ b/egograph/pipelines/tests/unit/spotify/test_collector.py
@@ -290,7 +290,7 @@ def test_get_artists_success():
 
 @responses.activate
 def test_init_raises_authentication_error_on_invalid_grant():
-    """refresh token の invalid_grant は AuthenticationError に変換されチェインされる。"""
+    """invalid_grant は AuthenticationError に変換されチェインされる。"""
     # Arrange
     responses.add(
         responses.POST,

--- a/egograph/pipelines/tests/unit/spotify/test_collector.py
+++ b/egograph/pipelines/tests/unit/spotify/test_collector.py
@@ -2,7 +2,10 @@
 
 import re
 
+import pytest
 import responses
+import spotipy
+from pipelines.domain.errors import AuthenticationError
 from pipelines.sources.common.utils import iso8601_to_unix_ms
 from pipelines.sources.spotify.collector import SpotifyCollector
 from pipelines.tests.fixtures.spotify_responses import (
@@ -283,3 +286,52 @@ def test_get_artists_success():
     assert len(result) == 2
     assert result[0]["id"] == "artist1"
     assert result[1]["name"] == "Artist B"
+
+
+@responses.activate
+def test_init_raises_authentication_error_on_invalid_grant():
+    """refresh token の invalid_grant は AuthenticationError に変換されチェインされる。"""
+    # Arrange
+    responses.add(
+        responses.POST,
+        "https://accounts.spotify.com/api/token",
+        json={"error": "invalid_grant", "error_description": "Refresh token revoked"},
+        status=400,
+    )
+
+    # Act & Assert
+    with pytest.raises(AuthenticationError) as exc_info:
+        SpotifyCollector(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            refresh_token="revoked_refresh_token",
+        )
+
+    assert "revoked or expired" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, spotipy.oauth2.SpotifyOauthError)
+
+
+@responses.activate
+def test_init_raises_authentication_error_on_other_oauth_error():
+    """invalid_grant 以外の OAuth エラーも AuthenticationError に変換される。"""
+    # Arrange
+    responses.add(
+        responses.POST,
+        "https://accounts.spotify.com/api/token",
+        json={
+            "error": "invalid_client",
+            "error_description": "Client authentication failed",
+        },
+        status=400,
+    )
+
+    # Act & Assert
+    with pytest.raises(AuthenticationError) as exc_info:
+        SpotifyCollector(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            refresh_token="bad_client",
+        )
+
+    assert "invalid_client" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, spotipy.oauth2.SpotifyOauthError)

--- a/egograph/pipelines/tests/unit/test_dispatcher.py
+++ b/egograph/pipelines/tests/unit/test_dispatcher.py
@@ -3,7 +3,7 @@ import sqlite3
 import threading
 import time
 from datetime import datetime, timezone
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from pipelines.domain.errors import AuthenticationError
 from pipelines.domain.workflow import (
@@ -28,9 +28,16 @@ from pipelines.infrastructure.execution.log_store import LocalLogStore
 from pipelines.infrastructure.execution.subprocess_executor import (
     SubprocessStepExecutor,
 )
+from pipelines.infrastructure.notification.service import NotificationService
 
 
-def _build_dispatcher(tmp_path, workflows, *, max_concurrent_runs=1):
+def _build_dispatcher(
+    tmp_path,
+    workflows,
+    *,
+    max_concurrent_runs=1,
+    notification_service=None,
+):
     conn = connect(tmp_path / "state.sqlite3")
     initialize_schema(conn)
     db_mutex = threading.RLock()
@@ -47,6 +54,8 @@ def _build_dispatcher(tmp_path, workflows, *, max_concurrent_runs=1):
         lock_manager=lock_manager,
         subprocess_executor=SubprocessStepExecutor(log_store),
         inprocess_executor=InProcessStepExecutor(log_store),
+        notification_service=notification_service
+        or NotificationService(webhook_url=None),
         poll_seconds=0.01,
         heartbeat_seconds=60,
         max_concurrent_runs=max_concurrent_runs,
@@ -446,9 +455,198 @@ def test_dispatch_once_retries_normal_exception_up_to_max_attempts(tmp_path):
     assert all(step.status == StepRunStatus.FAILED for step in steps)
 
 
-def test_dispatch_once_marks_run_failed_when_lock_manager_crashes(
-    tmp_path, caplog
-):
+def test_dispatch_once_notifies_on_step_failure(tmp_path):
+    """step 失敗パスで NotificationService.notify が呼ばれる。"""
+    # Arrange
+    workflows = {
+        "fail_workflow": WorkflowDefinition(
+            workflow_id="fail_workflow",
+            name="Fail workflow",
+            description="Workflow that fails",
+            steps=(
+                StepDefinition(
+                    step_id="boom",
+                    step_name="Boom",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+            ),
+        )
+    }
+    notification_service = NotificationService(webhook_url="https://example.com/hook")
+    run_repository, _, dispatcher, _ = _build_dispatcher(
+        tmp_path,
+        workflows,
+        notification_service=notification_service,
+    )
+    run = run_repository.enqueue_run(
+        workflow_id="fail_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+    )
+
+    def _raise(**_kwargs):
+        raise RuntimeError("step boom")
+
+    dispatcher._inprocess_executor.execute = _raise
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 200
+        dispatcher.dispatch_once()
+
+    # Assert
+    updated_run = run_repository.get_run(run.run_id)
+    assert updated_run.status == WorkflowRunStatus.FAILED
+    mock_post.assert_called_once()
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["source"] == "urn:egograph:pipelines"
+    assert payload["type"] == "egograph.pipelines.workflow_failed"
+    assert payload["data"]["workflow_id"] == "fail_workflow"
+    assert payload["data"]["run_id"] == run.run_id
+    assert "RuntimeError" in payload["data"]["error_message"]
+
+
+def test_dispatch_once_notifies_with_custom_message_on_authentication_error(tmp_path):
+    """AuthenticationError 起因の失敗で custom_message が payload に乗る。"""
+    # Arrange
+    workflows = {
+        "auth_workflow": WorkflowDefinition(
+            workflow_id="auth_workflow",
+            name="Auth workflow",
+            description="Workflow that raises AuthenticationError",
+            steps=(
+                StepDefinition(
+                    step_id="auth",
+                    step_name="Auth",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+            ),
+        )
+    }
+    notification_service = NotificationService(webhook_url="https://example.com/hook")
+    run_repository, _, dispatcher, _ = _build_dispatcher(
+        tmp_path,
+        workflows,
+        notification_service=notification_service,
+    )
+    run_repository.enqueue_run(
+        workflow_id="auth_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+    )
+
+    def _raise(**_kwargs):
+        raise AuthenticationError("Spotify refresh token revoked")
+
+    dispatcher._inprocess_executor.execute = _raise
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 200
+        dispatcher.dispatch_once()
+
+    # Assert
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["data"]["custom_message"] is not None
+    assert "spotify_auth.py" in payload["data"]["custom_message"]
+
+
+def test_dispatch_once_does_not_crash_when_webhook_is_unset(tmp_path):
+    """WEBHOOK_URL 未設定で run 失敗しても run は FAILED に遷移する。"""
+    # Arrange
+    workflows = {
+        "fail_workflow": WorkflowDefinition(
+            workflow_id="fail_workflow",
+            name="Fail workflow",
+            description="Workflow that fails",
+            steps=(
+                StepDefinition(
+                    step_id="boom",
+                    step_name="Boom",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+            ),
+        )
+    }
+    run_repository, _, dispatcher, _ = _build_dispatcher(
+        tmp_path,
+        workflows,
+        notification_service=NotificationService(webhook_url=None),
+    )
+    run = run_repository.enqueue_run(
+        workflow_id="fail_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+    )
+
+    def _raise(**_kwargs):
+        raise RuntimeError("step boom")
+
+    dispatcher._inprocess_executor.execute = _raise
+
+    # Act
+    dispatched = dispatcher.dispatch_once()
+
+    # Assert
+    assert dispatched is True
+    updated_run = run_repository.get_run(run.run_id)
+    assert updated_run.status == WorkflowRunStatus.FAILED
+
+
+def test_dispatch_once_notifies_on_unexpected_dispatcher_exception(tmp_path):
+    """予期しない例外パスでも通知が飛ぶ。"""
+    # Arrange
+    workflows = {
+        "dummy_workflow": WorkflowDefinition(
+            workflow_id="dummy_workflow",
+            name="Dummy workflow",
+            description="dummy",
+            steps=(
+                StepDefinition(
+                    step_id="succeed",
+                    step_name="Succeed",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+            ),
+        )
+    }
+    notification_service = NotificationService(webhook_url="https://example.com/hook")
+    run_repository, _, dispatcher, _ = _build_dispatcher(
+        tmp_path,
+        workflows,
+        notification_service=notification_service,
+    )
+    run = run_repository.enqueue_run(
+        workflow_id="dummy_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+    )
+    dispatcher._lock_manager.acquire = Mock(side_effect=RuntimeError("lock boom"))
+
+    # Act
+    with patch(
+        "pipelines.infrastructure.notification.adapters.requests.post"
+    ) as mock_post:
+        mock_post.return_value.status_code = 200
+        dispatcher.dispatch_once()
+
+    # Assert
+    updated_run = run_repository.get_run(run.run_id)
+    assert updated_run.status == WorkflowRunStatus.FAILED
+    mock_post.assert_called_once()
+    payload = mock_post.call_args.kwargs["json"]
+    assert "unexpected dispatcher error" in payload["data"]["error_message"]
+
+
+def test_dispatch_once_marks_run_failed_when_lock_manager_crashes(tmp_path, caplog):
     """dispatch_once 想定外例外でも run を failed にして継続可能にする。"""
     workflows = {
         "dummy_workflow": WorkflowDefinition(
@@ -567,18 +765,13 @@ def test_start_runs_distinct_workflows_in_parallel(tmp_path):
             ):
                 saw_parallel_running = True
                 break
-            if (
-                current_a.status
-                in {
-                    WorkflowRunStatus.SUCCEEDED,
-                    WorkflowRunStatus.FAILED,
-                }
-                and current_b.status
-                in {
-                    WorkflowRunStatus.SUCCEEDED,
-                    WorkflowRunStatus.FAILED,
-                }
-            ):
+            if current_a.status in {
+                WorkflowRunStatus.SUCCEEDED,
+                WorkflowRunStatus.FAILED,
+            } and current_b.status in {
+                WorkflowRunStatus.SUCCEEDED,
+                WorkflowRunStatus.FAILED,
+            }:
                 break
             time.sleep(0.01)
 
@@ -735,9 +928,7 @@ def test_dispatch_available_runs_skips_blocked_run_within_same_cycle(tmp_path):
     assert run_repository.get_run(free_run.run_id).status == WorkflowRunStatus.SUCCEEDED
 
 
-def test_heartbeat_loop_logs_warning_and_continues_after_exception(
-    tmp_path, caplog
-):
+def test_heartbeat_loop_logs_warning_and_continues_after_exception(tmp_path, caplog):
     """heartbeat 失敗でスレッドが黙死しない。"""
     _, _, dispatcher, _ = _build_dispatcher(tmp_path, {})
     lease = dispatcher._lock_manager.acquire(lock_key="dummy-lock", run_id="run-1")
@@ -762,6 +953,7 @@ def test_invoke_does_not_pass_workflow_run_to_non_workflow_run_params():
     AttributeError: 'WorkflowRun' object has no attribute 'spotify' で
     クラッシュしていた問題を防止する。
     """
+
     class FakeConfig:
         spotify = "loaded"
 

--- a/egograph/pipelines/tests/unit/test_dispatcher.py
+++ b/egograph/pipelines/tests/unit/test_dispatcher.py
@@ -5,6 +5,7 @@ import time
 from datetime import datetime, timezone
 from unittest.mock import Mock
 
+from pipelines.domain.errors import AuthenticationError
 from pipelines.domain.workflow import (
     QueuedReason,
     StepDefinition,
@@ -348,6 +349,101 @@ def test_dispatch_once_marks_step_and_run_failed_on_unexpected_executor_error(tm
     ]
     assert steps[0].stderr_tail == "RuntimeError: boom"
     assert steps[0].exit_code is None
+
+
+def test_dispatch_once_skips_retries_on_authentication_error(tmp_path):
+    """AuthenticationError は max_attempts=3 でも1回で即失敗する。"""
+    # Arrange
+    workflows = {
+        "auth_workflow": WorkflowDefinition(
+            workflow_id="auth_workflow",
+            name="Auth workflow",
+            description="Workflow that raises AuthenticationError",
+            steps=(
+                StepDefinition(
+                    step_id="auth_step",
+                    step_name="Auth step",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                    max_attempts=3,
+                    retry_delay_seconds=0,
+                ),
+            ),
+        )
+    }
+    run_repository, step_run_repository, dispatcher, _ = _build_dispatcher(
+        tmp_path, workflows
+    )
+    run = run_repository.enqueue_run(
+        workflow_id="auth_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+    )
+
+    def _raise_auth(**_kwargs):
+        raise AuthenticationError("Spotify refresh token revoked")
+
+    dispatcher._inprocess_executor.execute = _raise_auth
+
+    # Act
+    dispatched = dispatcher.dispatch_once()
+    updated_run = run_repository.get_run(run.run_id)
+    steps = step_run_repository.list_step_runs(run.run_id)
+
+    # Assert
+    assert dispatched is True
+    assert updated_run.status == WorkflowRunStatus.FAILED
+    assert "AuthenticationError" in (updated_run.last_error_message or "")
+    assert "Spotify refresh token revoked" in (updated_run.last_error_message or "")
+    # 1 attempt のみで終了すること（max_attempts=3 だがリトライしない）
+    assert len(steps) == 1
+    assert steps[0].status == StepRunStatus.FAILED
+    assert "AuthenticationError" in (steps[0].stderr_tail or "")
+
+
+def test_dispatch_once_retries_normal_exception_up_to_max_attempts(tmp_path):
+    """通常の例外は max_attempts 回まで retry される（regression）。"""
+    # Arrange
+    workflows = {
+        "retry_workflow": WorkflowDefinition(
+            workflow_id="retry_workflow",
+            name="Retry workflow",
+            description="Workflow that raises RuntimeError",
+            steps=(
+                StepDefinition(
+                    step_id="flaky",
+                    step_name="Flaky",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                    max_attempts=3,
+                    retry_delay_seconds=0,
+                ),
+            ),
+        )
+    }
+    run_repository, step_run_repository, dispatcher, _ = _build_dispatcher(
+        tmp_path, workflows
+    )
+    run = run_repository.enqueue_run(
+        workflow_id="retry_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+    )
+
+    def _raise(**_kwargs):
+        raise RuntimeError("transient")
+
+    dispatcher._inprocess_executor.execute = _raise
+
+    # Act
+    dispatcher.dispatch_once()
+    updated_run = run_repository.get_run(run.run_id)
+    steps = step_run_repository.list_step_runs(run.run_id)
+
+    # Assert: max_attempts=3 すべて試す
+    assert updated_run.status == WorkflowRunStatus.FAILED
+    assert len(steps) == 3
+    assert all(step.status == StepRunStatus.FAILED for step in steps)
 
 
 def test_dispatch_once_marks_run_failed_when_lock_manager_crashes(

--- a/egograph/pipelines/tests/unit/test_errors.py
+++ b/egograph/pipelines/tests/unit/test_errors.py
@@ -1,0 +1,26 @@
+"""Pipelines domain errors のテスト。"""
+
+from pipelines.domain.errors import AuthenticationError, PipelinesError
+
+
+def test_authentication_error_inherits_pipelines_error():
+    """AuthenticationError は PipelinesError を継承する。"""
+    # Arrange & Act
+    err = AuthenticationError("token revoked")
+
+    # Assert
+    assert isinstance(err, PipelinesError)
+    assert str(err) == "token revoked"
+
+
+def test_authentication_error_preserves_cause_chain():
+    """`raise X from e` で受け取った元の例外を __cause__ に保持する。"""
+    # Arrange
+    original = ValueError("spotipy raised this")
+
+    # Act
+    try:
+        raise AuthenticationError("wrapped") from original
+    except AuthenticationError as err:
+        # Assert
+        assert err.__cause__ is original


### PR DESCRIPTION
## 概要

Pipeline 実行失敗の検知・通知基盤を 2 フェーズで実装。

- **Phase 1**: OAuth エラーの即検知 & Fail-fast（Spotify 特化）
- **Phase 2**: Webhook 通知基盤（全データソース共通）

### 背景

Spotify の refresh token 失効で `invalid_grant` が 17 回連続したが、Pipeline の失敗にユーザーが気づけなかった。現状は API/CLI で手動確認するしかなく、通知メカニズムが存在しない。

設計: [docs/superpowers/specs/2026-06-05-pipeline-failure-notification-design.md](../tree/main/docs/superpowers/specs/2026-06-05-pipeline-failure-notification-design.md)

---

## Phase 1: Auth エラーの Fail-fast

- `AuthenticationError`（`PipelinesError` 派生）を追加
- `SpotifyCollector.__init__` で `SpotifyOauthError` を `AuthenticationError` に変換（`from e` でチェイン保持）
- `run_dispatcher._execute_step` で `AuthenticationError` 検出時に即 fail-fast（`max_attempts` 無視）

## Phase 2: Webhook 通知基盤

- `domain/notification.py`: `NotificationEvent` / `NotificationData`（frozen dataclass）
  - CloudEvents v1.0 を参考にした **内部契約**（完全準拠は目指さない）
- `infrastructure/notification/adapters.py`: `WebhookAdapter` 抽象 + `GenericAdapter`（JSON POST）+ `DiscordAdapter`（Embed）
  - 接続/読み取りタイムアウト 5 秒
- `infrastructure/notification/service.py`: `NotificationService`
  - `webhook_url=None` で no-op
  - `exc` 型に応じて `custom_message` を補完（`AuthenticationError` → Spotify 再認証手順）
  - 送信失敗は `logger.exception` で握りつぶし（Pipeline を阻害しない）
- `run_dispatcher`: 両失敗パス（step 失敗 / 予期しない dispatcher 例外）から `_notify_failure` を呼ぶ

## 設定

| 変数 | デフォルト | 説明 |
|---|---|---|
| `PIPELINES_WEBHOOK_URL` | 未設定（通知無効） | Webhook 送信先 URL |
| `PIPELINES_WEBHOOK_TYPE` | `generic` | `generic` / `discord` |

> 設計書の `WEBHOOK_URL` を `PIPELINES_WEBHOOK_URL` に変更（既存 `PIPELINES_*` prefix との一貫性のため）。

## 設計書からの主な改善点

- **`_last_step_exception` 共有状態を廃止**: 設計書案は dispatcher インスタンス変数で例外を持ち越していたが、worker 複数時に race condition を起こす。`_execute_step` の戻り値を 4-tuple `(success, summary, error_message, exception)` に拡張して対応。
- **`_mark_run_failed_after_unexpected_exception` のシグネチャ変更**: 設計書案は `run_id` のみ受け取っていたが、`workflow` / `run` を直接渡せるよう変更（DB lookup 削減、型安全）。
- **環境変数 prefix**: `PIPELINES_WEBHOOK_URL` 採用で他設定と統一。

---

## テスト

- 既存テスト: 354/354 PASS
- 新規テスト: 19 個（Phase 1: 4, Phase 2: 15）
  - `AuthenticationError` 継承・チェイン・変換（invalid_grant / その他）
  - dispatcher fail-fast（`max_attempts=3` でも 1 回で終了）
  - 通常例外の regression（`max_attempts` 通り retry）
  - Webhook adapter: payload 形式・HTTP 4xx/5xx・タイムアウト
  - `NotificationService`: no-op / 補完 / 上書き抑制 / 失敗握りつぶし
  - dispatcher 統合: step 失敗 / 予期しない例外 / `AuthenticationError` → `custom_message` / Webhook 未設定
- Lint / Format: 変更ファイル全て PASS（pre-existing lint は未対応範囲）

```bash
uv run pytest egograph/pipelines/tests/unit
uv run ruff check egograph/pipelines/domain egograph/pipelines/infrastructure/notification \
                   egograph/pipelines/infrastructure/dispatching/run_dispatcher.py \
                   egograph/pipelines/sources/spotify/collector.py \
                   egograph/pipelines/service.py egograph/pipelines/config.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * パイプライン失敗時のWebhook通知を追加（Generic/Discord対応、通知内容にrun/workflow/errorを含む）。環境変数でURL/形式を設定可能。
  * 認証関連エラーを専用のAuthenticationErrorとして扱い、発生時はリトライせず即時失敗（Fail-fast）。

* **Documentation**
  * エラーハンドリングとWebhook通知の仕様（送信条件・タイミング・ペイロード例）を追記。

* **Tests**
  * 通知周り、認証エラー挙動、Spotifyコレクタ変換などのユニット/統合テストを多数追加・拡充。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->