### PR TITLE
Browser History / YouTube から reload 由来データを除外する

### DIFF
--- a/docs/30.pipelines/browser-history.md
+++ b/docs/30.pipelines/browser-history.md
@@ -196,6 +196,35 @@ Chromium の `chrome.history` API は、同じ URL に対して短時間に複�
 
 この優先順位により、`link` の直後に `reload` が来た場合でも、page view の代表 transition は `link` になる。
 
+### 7.5 提供時のデフォルトフィルタ (`include_reload`)
+
+page view の `transition` カラムは原事実として保持するが、API / MCP / LLM ツール経由で取得する際は、ブラウザ起動時にまとめて再読込される `transition='reload'` の page_view を既定で除外する。
+
+#### 仕様
+
+- パラメータ: `include_reload: bool | None` (クエリ文字列 / ツール input 共通)
+- 動作: `true` を渡したときのみ reload を含める。`null` / `false` / 省略時は reload を除外
+- 適用対象: `GET /v1/data/browser-history/page-views`, `GET /v1/data/browser-history/top-domains`, LLM ツール `get_page_views` / `get_top_domains`
+- データ層は触らない（生 parquet・compacted parquet ともに従来通り reload を含む）
+
+#### 観測データ（2026-06, home-windows-pc / edge / Default, n=1078）
+
+| 指標 | 値 |
+|---|---|
+| 全 page_view 数 | 1078 |
+| `transition='reload'` 数 | 266 (24.7%) |
+| reload のうち「起動バースト」(1分以内に 3URL 以上リロード) | 171 (64.3%) |
+| 起動バースト件数 | 14 |
+| 最大起動バースト規模 | 22 URL / 24 秒 |
+
+起動バースト代表: 2026-06-01 09:56:24-48 に 22 URL 全てが reload。バースト内ドメイン Top は YouTube (37), GitHub (29), dev-server (20)。
+
+#### 採用理由
+
+- **事実保全**: 案1（拡張機能側で除外）は再評価困難、案3（別 dataset）は構成が複雑。`events` には reload を含む page_view を残しつつ、提供層でフィルタする案2（採用）が再評価可能性・構造簡潔性のバランスに優れる
+- **既定で除外**: 機械的に「起動直後に再読込された」だけの事象は LLM にとってノイズでしかない。特殊分析時のみ `include_reload=true` で opt-in
+- **top-domains 集計でも除外**: 「よく見ているサイト」は reload 込みの数字より、明確な意図を持って訪れた数字の方が解釈しやすい
+
 ---
 
 ## 11. 実装時の考慮事項

--- a/docs/30.pipelines/youtube.md
+++ b/docs/30.pipelines/youtube.md
@@ -121,6 +121,27 @@ watch event として扱うのは、動画を一意に特定できる URL のみ
 - `channel_id`, `channel_name` を確定し、必要に応じて `video_title` を補正する
 - `channel_id` をキーにチャンネル metadata を取得する
 
+### 3.5 watch_event 化ルール: `transition='reload'` の除外
+
+`extract_youtube_watch_events` は Browser History page_view のうち `transition='reload'` のものを watch_event に変換しない。YouTube 起動時にまとめて再生されるリロード由来の再生履歴を排除するため。
+
+#### 仕様
+
+- 抽出時（`pipelines/sources/youtube/extraction.py: extract_youtube_watch_events`）に page_view をスキップ
+- スキーマ・過去データ・公開 parquet は無変更
+- REST API / LLM ツールに `include_reload` パラメータは設けない（消費時に確定しているため）
+- 既存 fixture に `transition` 列が無い場合（後方互換）は `None` として扱うため、リロード判定は発火しない
+
+#### 観測データ（2026-06 抜粋）
+
+| 指標 | 値 |
+|---|---|
+| YouTube 関連 page_view | 273 |
+| `transition='reload'` 数 | 47 (17.2%) |
+| 同一動画の同日 reload 重複例 | `6d9FRcJ8e1g` が 06-02 に 6 回出現（うち reload 3 回） |
+
+YouTube 起動時のリロード再生は、ユーザーの視聴意図が弱いイベント（バッファリング再読込等）が多く、watch 統計（`watch_event_count`、top_videos / top_channels）からも除外する方が人間の見え方と整合する。
+
 ---
 
 ## 4. Parquetスキーマ

--- a/egograph/backend/api/browser_history_data.py
+++ b/egograph/backend/api/browser_history_data.py
@@ -40,6 +40,13 @@ def get_page_views_endpoint(
     ),
     browser: str | None = Query(None, description="フィルタ対象のブラウザ"),
     profile: str | None = Query(None, description="フィルタ対象のプロファイル"),
+    include_reload: bool | None = Query(
+        None,
+        description=(
+            "true のとき transition='reload' の page_view を含める。"
+            "既定は null/false で、ブラウザ起動時のリロードを除外する。"
+        ),
+    ),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
     repository: BrowserHistoryRepository = Depends(get_browser_history_repository),
     _api_key: None = Depends(verify_api_key_docs),
@@ -57,6 +64,7 @@ def get_page_views_endpoint(
         end,
         browser=browser,
         profile=profile,
+        include_reload=include_reload,
         limit=validated_limit,
     )
 
@@ -73,6 +81,13 @@ def get_top_domains_endpoint(
     ),
     browser: str | None = Query(None, description="フィルタ対象のブラウザ"),
     profile: str | None = Query(None, description="フィルタ対象のプロファイル"),
+    include_reload: bool | None = Query(
+        None,
+        description=(
+            "true のとき transition='reload' の page_view を含めて集計する。"
+            "既定は null/false で、ブラウザ起動時のリロードを除外する。"
+        ),
+    ),
     db_connection: duckdb.DuckDBPyConnection = Depends(get_db_connection),
     repository: BrowserHistoryRepository = Depends(get_browser_history_repository),
     _api_key: None = Depends(verify_api_key_docs),
@@ -90,5 +105,6 @@ def get_top_domains_endpoint(
         end,
         browser=browser,
         profile=profile,
+        include_reload=include_reload,
         limit=validated_limit,
     )

--- a/egograph/backend/domain/tools/browser_history/page_views.py
+++ b/egograph/backend/domain/tools/browser_history/page_views.py
@@ -44,6 +44,13 @@ class BrowserHistoryToolBase(ToolBase):
                     "type": "string",
                     "description": "プロファイル名",
                 },
+                "include_reload": {
+                    "type": "boolean",
+                    "description": (
+                        "true のとき transition='reload' の page_view を含める。"
+                        "既定は null/false で、ブラウザ起動時のリロードを除外する。"
+                    ),
+                },
                 "limit": {
                     "type": "integer",
                     "description": "取得件数",
@@ -88,6 +95,7 @@ class GetPageViewsTool(BrowserHistoryToolBase):
         end_date: str,
         browser: str | None = None,
         profile: str | None = None,
+        include_reload: bool | None = None,
         limit: int = DEFAULT_PAGE_VIEWS_LIMIT,
     ) -> list[dict[str, Any]]:
         start, end, validated_limit = self._validate_params(
@@ -97,11 +105,13 @@ class GetPageViewsTool(BrowserHistoryToolBase):
         )
 
         logger.info(
-            "Executing get_page_views: %s to %s, browser=%s, profile=%s, limit=%s",
+            "Executing get_page_views: %s to %s, browser=%s, profile=%s, "
+            "include_reload=%s, limit=%s",
             start,
             end,
             browser,
             profile,
+            include_reload,
             validated_limit,
         )
         with DuckDBConnection(self.repository.r2_config) as conn:
@@ -111,6 +121,7 @@ class GetPageViewsTool(BrowserHistoryToolBase):
                 end_date=end,
                 browser=browser,
                 profile=profile,
+                include_reload=include_reload,
                 limit=validated_limit,
             )
 
@@ -139,6 +150,7 @@ class GetTopDomainsTool(BrowserHistoryToolBase):
         end_date: str,
         browser: str | None = None,
         profile: str | None = None,
+        include_reload: bool | None = None,
         limit: int = DEFAULT_TOP_DOMAINS_LIMIT,
     ) -> list[dict[str, Any]]:
         start, end, validated_limit = self._validate_params(
@@ -148,11 +160,13 @@ class GetTopDomainsTool(BrowserHistoryToolBase):
         )
 
         logger.info(
-            "Executing get_top_domains: %s to %s, browser=%s, profile=%s, limit=%s",
+            "Executing get_top_domains: %s to %s, browser=%s, profile=%s, "
+            "include_reload=%s, limit=%s",
             start,
             end,
             browser,
             profile,
+            include_reload,
             validated_limit,
         )
         with DuckDBConnection(self.repository.r2_config) as conn:
@@ -162,5 +176,6 @@ class GetTopDomainsTool(BrowserHistoryToolBase):
                 end_date=end,
                 browser=browser,
                 profile=profile,
+                include_reload=include_reload,
                 limit=validated_limit,
             )

--- a/egograph/backend/infrastructure/database/browser_history_queries.py
+++ b/egograph/backend/infrastructure/database/browser_history_queries.py
@@ -17,15 +17,24 @@ def _resolve_partition_paths(params: QueryParams) -> list[str]:
     )
 
 
+def _exclude_reload_clause(include_reload: bool | None) -> str:
+    """include_reload が False 相当のときに付与する transition 除外句を返す。"""
+    if include_reload:
+        return ""
+    return " AND transition != 'reload'"
+
+
 def get_page_views(
     params: QueryParams,
     *,
     browser: str | None = None,
     profile: str | None = None,
+    include_reload: bool | None = None,
     limit: int = DEFAULT_PAGE_VIEWS_LIMIT,
 ) -> list[dict[str, Any]]:
     """指定期間のpage view一覧を取得する。"""
     partition_paths = _resolve_partition_paths(params)
+    reload_clause = _exclude_reload_clause(include_reload)
     sql = f"""
         SELECT
             page_view_id,
@@ -42,7 +51,7 @@ def get_page_views(
         FROM read_parquet(?)
         WHERE started_at_utc::TIMESTAMP >= ? AND started_at_utc::TIMESTAMP < ?
           AND (? IS NULL OR browser = ?)
-          AND (? IS NULL OR profile = ?)
+          AND (? IS NULL OR profile = ?){reload_clause}
         ORDER BY started_at DESC
         LIMIT ?
     """
@@ -67,11 +76,13 @@ def get_top_domains(
     *,
     browser: str | None = None,
     profile: str | None = None,
+    include_reload: bool | None = None,
     limit: int = DEFAULT_TOP_DOMAINS_LIMIT,
 ) -> list[dict[str, Any]]:
     """指定期間のdomain別ランキングを取得する。"""
     partition_paths = _resolve_partition_paths(params)
-    sql = """
+    reload_clause = _exclude_reload_clause(include_reload)
+    sql = f"""
         WITH filtered_page_views AS (
             SELECT
                 NULLIF(regexp_extract(url, '^[a-zA-Z]+://([^/?#]+)', 1), '') AS domain,
@@ -79,7 +90,7 @@ def get_top_domains(
             FROM read_parquet(?)
             WHERE started_at_utc::TIMESTAMP >= ? AND started_at_utc::TIMESTAMP < ?
               AND (? IS NULL OR browser = ?)
-              AND (? IS NULL OR profile = ?)
+              AND (? IS NULL OR profile = ?){reload_clause}
         )
         SELECT
             domain,

--- a/egograph/backend/infrastructure/database/browser_history_queries.py
+++ b/egograph/backend/infrastructure/database/browser_history_queries.py
@@ -6,6 +6,8 @@ from backend.constants import DEFAULT_PAGE_VIEWS_LIMIT, DEFAULT_TOP_DOMAINS_LIMI
 from backend.infrastructure.database.parquet_paths import build_partition_paths
 from backend.infrastructure.database.query_params import QueryParams, execute_query
 
+_RELOAD_FILTER_CLAUSE = " AND (? OR transition IS DISTINCT FROM 'reload')"
+
 
 def _resolve_partition_paths(params: QueryParams) -> list[str]:
     return build_partition_paths(
@@ -15,13 +17,6 @@ def _resolve_partition_paths(params: QueryParams) -> list[str]:
         utc_start=params.utc_start,
         utc_end=params.utc_end,
     )
-
-
-def _exclude_reload_clause(include_reload: bool | None) -> str:
-    """include_reload が False 相当のときに付与する transition 除外句を返す。"""
-    if include_reload:
-        return ""
-    return " AND transition != 'reload'"
 
 
 def get_page_views(
@@ -34,7 +29,6 @@ def get_page_views(
 ) -> list[dict[str, Any]]:
     """指定期間のpage view一覧を取得する。"""
     partition_paths = _resolve_partition_paths(params)
-    reload_clause = _exclude_reload_clause(include_reload)
     sql = f"""
         SELECT
             page_view_id,
@@ -51,7 +45,7 @@ def get_page_views(
         FROM read_parquet(?)
         WHERE started_at_utc::TIMESTAMP >= ? AND started_at_utc::TIMESTAMP < ?
           AND (? IS NULL OR browser = ?)
-          AND (? IS NULL OR profile = ?){reload_clause}
+          AND (? IS NULL OR profile = ?){_RELOAD_FILTER_CLAUSE}
         ORDER BY started_at DESC
         LIMIT ?
     """
@@ -66,6 +60,7 @@ def get_page_views(
             browser,
             profile,
             profile,
+            bool(include_reload),
             limit,
         ],
     )
@@ -81,7 +76,6 @@ def get_top_domains(
 ) -> list[dict[str, Any]]:
     """指定期間のdomain別ランキングを取得する。"""
     partition_paths = _resolve_partition_paths(params)
-    reload_clause = _exclude_reload_clause(include_reload)
     sql = f"""
         WITH filtered_page_views AS (
             SELECT
@@ -90,7 +84,7 @@ def get_top_domains(
             FROM read_parquet(?)
             WHERE started_at_utc::TIMESTAMP >= ? AND started_at_utc::TIMESTAMP < ?
               AND (? IS NULL OR browser = ?)
-              AND (? IS NULL OR profile = ?){reload_clause}
+              AND (? IS NULL OR profile = ?){_RELOAD_FILTER_CLAUSE}
         )
         SELECT
             domain,
@@ -113,6 +107,7 @@ def get_top_domains(
             browser,
             profile,
             profile,
+            bool(include_reload),
             limit,
         ],
     )

--- a/egograph/backend/infrastructure/repositories/browser_history_repository.py
+++ b/egograph/backend/infrastructure/repositories/browser_history_repository.py
@@ -50,6 +50,7 @@ class BrowserHistoryRepository:
         end_date: date,
         browser: str | None,
         profile: str | None,
+        include_reload: bool | None,
         limit: int,
         query_func,
         log_label: str,
@@ -59,16 +60,18 @@ class BrowserHistoryRepository:
             params,
             browser=browser,
             profile=profile,
+            include_reload=include_reload,
             limit=limit,
         )
         logger.info(
             "Retrieved %s: start_date=%s, end_date=%s, browser=%s, "
-            "profile=%s, limit=%s, count=%s",
+            "profile=%s, include_reload=%s, limit=%s, count=%s",
             log_label,
             start_date,
             end_date,
             browser,
             profile,
+            include_reload,
             limit,
             len(result),
         )
@@ -82,6 +85,7 @@ class BrowserHistoryRepository:
         *,
         browser: str | None = None,
         profile: str | None = None,
+        include_reload: bool | None = None,
         limit: int,
     ) -> list[dict[str, Any]]:
         """指定期間のpage view一覧を取得する。"""
@@ -91,6 +95,7 @@ class BrowserHistoryRepository:
             end_date=end_date,
             browser=browser,
             profile=profile,
+            include_reload=include_reload,
             limit=limit,
             query_func=get_page_views,
             log_label="page views",
@@ -104,6 +109,7 @@ class BrowserHistoryRepository:
         *,
         browser: str | None = None,
         profile: str | None = None,
+        include_reload: bool | None = None,
         limit: int,
     ) -> list[dict[str, Any]]:
         """指定期間のdomainランキングを取得する。"""
@@ -113,6 +119,7 @@ class BrowserHistoryRepository:
             end_date=end_date,
             browser=browser,
             profile=profile,
+            include_reload=include_reload,
             limit=limit,
             query_func=get_top_domains,
             log_label="top domains",

--- a/egograph/backend/tests/integration/test_browser_history_data_api.py
+++ b/egograph/backend/tests/integration/test_browser_history_data_api.py
@@ -56,6 +56,23 @@ class TestPageViewsEndpoint:
         assert response.status_code == 200
         assert mock_repo.get_page_views.call_args.kwargs["include_reload"] is True
 
+    def test_get_page_views_includes_reload_false_propagates(
+        self, test_client, mock_db_and_parquet
+    ):
+        """?include_reload=false もリポジトリまで伝播する。"""
+        mock_repo = MagicMock()
+        mock_repo.get_page_views.return_value = []
+        test_client.app.dependency_overrides[
+            get_browser_history_repository
+        ] = lambda: mock_repo
+        response = test_client.get(
+            "/v1/data/browser-history/page-views?start_date=2026-03-20&end_date=2026-03-22&include_reload=false",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        assert mock_repo.get_page_views.call_args.kwargs["include_reload"] is False
+
     def test_get_page_views_requires_api_key(self, test_client):
         response = test_client.get(
             "/v1/data/browser-history/page-views?start_date=2026-03-20&end_date=2026-03-22"
@@ -115,6 +132,23 @@ class TestTopDomainsEndpoint:
 
         assert response.status_code == 200
         assert mock_repo.get_top_domains.call_args.kwargs["include_reload"] is True
+
+    def test_get_top_domains_includes_reload_false_propagates(
+        self, test_client, mock_db_and_parquet
+    ):
+        """?include_reload=false も top-domains でリポジトリまで伝播する。"""
+        mock_repo = MagicMock()
+        mock_repo.get_top_domains.return_value = []
+        test_client.app.dependency_overrides[
+            get_browser_history_repository
+        ] = lambda: mock_repo
+        response = test_client.get(
+            "/v1/data/browser-history/top-domains?start_date=2026-03-20&end_date=2026-03-22&include_reload=false",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        assert mock_repo.get_top_domains.call_args.kwargs["include_reload"] is False
 
     def test_get_top_domains_requires_dates(self, test_client):
         response = test_client.get(

--- a/egograph/backend/tests/integration/test_browser_history_data_api.py
+++ b/egograph/backend/tests/integration/test_browser_history_data_api.py
@@ -37,6 +37,24 @@ class TestPageViewsEndpoint:
         data = response.json()
         assert data[0]["page_view_id"] == "pv_1"
         assert data[0]["browser"] == "edge"
+        assert mock_repo.get_page_views.call_args.kwargs["include_reload"] is None
+
+    def test_get_page_views_includes_reload_with_query_param(
+        self, test_client, mock_db_and_parquet
+    ):
+        """?include_reload=true を渡すとリポジトリまで伝播する。"""
+        mock_repo = MagicMock()
+        mock_repo.get_page_views.return_value = []
+        test_client.app.dependency_overrides[
+            get_browser_history_repository
+        ] = lambda: mock_repo
+        response = test_client.get(
+            "/v1/data/browser-history/page-views?start_date=2026-03-20&end_date=2026-03-22&include_reload=true",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        assert mock_repo.get_page_views.call_args.kwargs["include_reload"] is True
 
     def test_get_page_views_requires_api_key(self, test_client):
         response = test_client.get(
@@ -79,6 +97,24 @@ class TestTopDomainsEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert data == mock_result
+        assert mock_repo.get_top_domains.call_args.kwargs["include_reload"] is None
+
+    def test_get_top_domains_includes_reload_with_query_param(
+        self, test_client, mock_db_and_parquet
+    ):
+        """?include_reload=true を top-domains でも伝播する。"""
+        mock_repo = MagicMock()
+        mock_repo.get_top_domains.return_value = []
+        test_client.app.dependency_overrides[
+            get_browser_history_repository
+        ] = lambda: mock_repo
+        response = test_client.get(
+            "/v1/data/browser-history/top-domains?start_date=2026-03-20&end_date=2026-03-22&include_reload=true",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+
+        assert response.status_code == 200
+        assert mock_repo.get_top_domains.call_args.kwargs["include_reload"] is True
 
     def test_get_top_domains_requires_dates(self, test_client):
         response = test_client.get(

--- a/egograph/backend/tests/unit/database/test_browser_history_queries.py
+++ b/egograph/backend/tests/unit/database/test_browser_history_queries.py
@@ -91,12 +91,78 @@ class TestGetPageViews:
                 params,
                 browser="edge",
                 profile="Default",
+                include_reload=True,
                 limit=10,
             )
 
         assert [row["page_view_id"] for row in result] == ["pv_5", "pv_2", "pv_1"]
         assert all(row["browser"] == "edge" for row in result)
         assert all(row["profile"] == "Default" for row in result)
+
+    def test_excludes_reload_when_include_reload_is_none(
+        self, browser_history_with_sample_data
+    ):
+        """include_reload=None の既定で reload 由来の page_view は除外される。"""
+        parquet_path = browser_history_with_sample_data.test_page_views_parquet_path
+
+        with patch(
+            "backend.infrastructure.database.browser_history_queries._resolve_partition_paths",
+            return_value=[parquet_path],
+        ):
+            params = _bqp(
+                conn=browser_history_with_sample_data,
+                start_date=date(2026, 3, 20),
+                end_date=date(2026, 3, 22),
+            )
+
+            result = get_page_views(params, limit=10)
+
+        page_view_ids = [row["page_view_id"] for row in result]
+        assert "pv_2" not in page_view_ids
+        assert all(row["transition"] != "reload" for row in result)
+        assert len(result) == 4
+
+    def test_excludes_reload_when_include_reload_is_false(
+        self, browser_history_with_sample_data
+    ):
+        """明示的に include_reload=False を渡しても reload は除外される。"""
+        parquet_path = browser_history_with_sample_data.test_page_views_parquet_path
+
+        with patch(
+            "backend.infrastructure.database.browser_history_queries._resolve_partition_paths",
+            return_value=[parquet_path],
+        ):
+            params = _bqp(
+                conn=browser_history_with_sample_data,
+                start_date=date(2026, 3, 20),
+                end_date=date(2026, 3, 22),
+            )
+
+            result = get_page_views(params, include_reload=False, limit=10)
+
+        assert "pv_2" not in [row["page_view_id"] for row in result]
+
+    def test_includes_reload_when_include_reload_is_true(
+        self, browser_history_with_sample_data
+    ):
+        """include_reload=True で reload を含む全件が返る。"""
+        parquet_path = browser_history_with_sample_data.test_page_views_parquet_path
+
+        with patch(
+            "backend.infrastructure.database.browser_history_queries._resolve_partition_paths",
+            return_value=[parquet_path],
+        ):
+            params = _bqp(
+                conn=browser_history_with_sample_data,
+                start_date=date(2026, 3, 20),
+                end_date=date(2026, 3, 22),
+            )
+
+            result = get_page_views(params, include_reload=True, limit=10)
+
+        page_view_ids = [row["page_view_id"] for row in result]
+        assert "pv_2" in page_view_ids
+        assert len(result) == 5
 
 
 class TestGetTopDomains:
@@ -116,7 +182,7 @@ class TestGetTopDomains:
                 end_date=date(2026, 3, 22),
             )
 
-            result = get_top_domains(params, limit=10)
+            result = get_top_domains(params, include_reload=True, limit=10)
 
         assert result[0] == {
             "domain": "github.com",
@@ -144,6 +210,7 @@ class TestGetTopDomains:
                 params,
                 browser="edge",
                 profile="Default",
+                include_reload=True,
                 limit=10,
             )
 
@@ -159,3 +226,28 @@ class TestGetTopDomains:
                 "unique_urls": 1,
             },
         ]
+
+    def test_top_domains_excludes_reload_by_default(
+        self, browser_history_with_sample_data
+    ):
+        """top_domains 集計の既定で transition='reload' の page_view は除外される。"""
+        parquet_path = browser_history_with_sample_data.test_page_views_parquet_path
+
+        with patch(
+            "backend.infrastructure.database.browser_history_queries._resolve_partition_paths",
+            return_value=[parquet_path],
+        ):
+            params = _bqp(
+                conn=browser_history_with_sample_data,
+                start_date=date(2026, 3, 20),
+                end_date=date(2026, 3, 22),
+            )
+
+            result = get_top_domains(params, limit=10)
+
+        github = next(row for row in result if row["domain"] == "github.com")
+        assert github == {
+            "domain": "github.com",
+            "page_view_count": 2,
+            "unique_urls": 2,
+        }

--- a/egograph/backend/tests/unit/database/test_browser_history_queries.py
+++ b/egograph/backend/tests/unit/database/test_browser_history_queries.py
@@ -3,6 +3,7 @@
 from datetime import date, timezone
 from unittest.mock import patch
 
+import pandas as pd
 from pydantic import SecretStr
 
 from backend.config import R2Config
@@ -251,3 +252,64 @@ class TestGetTopDomains:
             "page_view_count": 2,
             "unique_urls": 2,
         }
+
+    def test_keeps_rows_with_null_transition_when_reload_excluded(
+        self, browser_history_with_sample_data, tmp_path
+    ):
+        """transition が NULL の行も reload 除外時に保持される。"""
+        null_row_path = tmp_path / "browser_history_with_null.parquet"
+        pd.DataFrame(
+            {
+                "page_view_id": ["pv_link", "pv_reload", "pv_null"],
+                "started_at_utc": pd.to_datetime(
+                    [
+                        "2026-03-22 09:00:00+00:00",
+                        "2026-03-22 10:00:00+00:00",
+                        "2026-03-22 11:00:00+00:00",
+                    ],
+                    utc=True,
+                ),
+                "ended_at_utc": pd.to_datetime(
+                    [
+                        "2026-03-22 09:00:01+00:00",
+                        "2026-03-22 10:00:02+00:00",
+                        "2026-03-22 11:00:03+00:00",
+                    ],
+                    utc=True,
+                ),
+                "url": [
+                    "https://example.com/a",
+                    "https://example.com/b",
+                    "https://example.com/c",
+                ],
+                "title": ["A", "B", "C"],
+                "browser": ["edge", "edge", "edge"],
+                "profile": ["Default", "Default", "Default"],
+                "source_device": ["home-pc", "home-pc", "home-pc"],
+                "transition": ["link", "reload", None],
+                "visit_span_count": [1, 1, 1],
+                "synced_at_utc": pd.to_datetime(
+                    ["2026-03-22 12:00:00+00:00"] * 3, utc=True
+                ),
+                "ingested_at_utc": pd.to_datetime(
+                    ["2026-03-22 12:01:00+00:00"] * 3, utc=True
+                ),
+            }
+        ).to_parquet(null_row_path)
+
+        with patch(
+            "backend.infrastructure.database.browser_history_queries._resolve_partition_paths",
+            return_value=[str(null_row_path)],
+        ):
+            params = _bqp(
+                conn=browser_history_with_sample_data,
+                start_date=date(2026, 3, 22),
+                end_date=date(2026, 3, 23),
+            )
+
+            result = get_page_views(params, include_reload=False, limit=10)
+
+        page_view_ids = [row["page_view_id"] for row in result]
+        assert "pv_reload" not in page_view_ids
+        assert "pv_link" in page_view_ids
+        assert "pv_null" in page_view_ids

--- a/egograph/backend/tests/unit/tools/browser_history/test_page_views.py
+++ b/egograph/backend/tests/unit/tools/browser_history/test_page_views.py
@@ -37,6 +37,8 @@ class TestGetPageViewsTool:
         assert "browser" in schema["properties"]
         assert "profile" in schema["properties"]
         assert "limit" in schema["properties"]
+        assert "include_reload" in schema["properties"]
+        assert schema["properties"]["include_reload"]["type"] == "boolean"
 
     @patch("backend.domain.tools.browser_history.page_views.DuckDBConnection")
     def test_execute_validates_and_delegates(self, MockConn):
@@ -62,6 +64,24 @@ class TestGetPageViewsTool:
         assert call_args.kwargs["browser"] == "edge"
         assert call_args.kwargs["profile"] == "Default"
         assert call_args.kwargs["limit"] == 20
+        assert call_args.kwargs["include_reload"] is None
+
+    @patch("backend.domain.tools.browser_history.page_views.DuckDBConnection")
+    def test_execute_passes_include_reload_true(self, MockConn):
+        """include_reload=True をリポジトリまで伝播する。"""
+        MockConn.return_value = _mock_conn_ctx()
+
+        repository = MagicMock()
+        repository.get_page_views.return_value = []
+        tool = GetPageViewsTool(repository)
+
+        tool.execute(
+            start_date="2026-03-20",
+            end_date="2026-03-22",
+            include_reload=True,
+        )
+
+        assert repository.get_page_views.call_args.kwargs["include_reload"] is True
 
     def test_execute_with_invalid_date_raises_error(self):
         tool = GetPageViewsTool(MagicMock())
@@ -88,6 +108,8 @@ class TestGetTopDomainsTool:
         assert "browser" in schema["properties"]
         assert "profile" in schema["properties"]
         assert "limit" in schema["properties"]
+        assert "include_reload" in schema["properties"]
+        assert schema["properties"]["include_reload"]["type"] == "boolean"
 
     @patch("backend.domain.tools.browser_history.page_views.DuckDBConnection")
     def test_execute_validates_and_delegates(self, MockConn):
@@ -111,6 +133,24 @@ class TestGetTopDomainsTool:
         assert call_args.kwargs["browser"] == "edge"
         assert call_args.kwargs["profile"] == "Default"
         assert call_args.kwargs["limit"] == 10
+        assert call_args.kwargs["include_reload"] is None
+
+    @patch("backend.domain.tools.browser_history.page_views.DuckDBConnection")
+    def test_execute_passes_include_reload_true(self, MockConn):
+        """top_domains でも include_reload=True をリポジトリまで伝播する。"""
+        MockConn.return_value = _mock_conn_ctx()
+
+        repository = MagicMock()
+        repository.get_top_domains.return_value = []
+        tool = GetTopDomainsTool(repository)
+
+        tool.execute(
+            start_date="2026-03-20",
+            end_date="2026-03-22",
+            include_reload=True,
+        )
+
+        assert repository.get_top_domains.call_args.kwargs["include_reload"] is True
 
     def test_execute_with_invalid_date_raises_error(self):
         tool = GetTopDomainsTool(MagicMock())

--- a/egograph/backend/tests/unit/tools/browser_history/test_page_views.py
+++ b/egograph/backend/tests/unit/tools/browser_history/test_page_views.py
@@ -83,6 +83,23 @@ class TestGetPageViewsTool:
 
         assert repository.get_page_views.call_args.kwargs["include_reload"] is True
 
+    @patch("backend.domain.tools.browser_history.page_views.DuckDBConnection")
+    def test_execute_passes_include_reload_false(self, MockConn):
+        """include_reload=False をリポジトリまで伝播する。"""
+        MockConn.return_value = _mock_conn_ctx()
+
+        repository = MagicMock()
+        repository.get_page_views.return_value = []
+        tool = GetPageViewsTool(repository)
+
+        tool.execute(
+            start_date="2026-03-20",
+            end_date="2026-03-22",
+            include_reload=False,
+        )
+
+        assert repository.get_page_views.call_args.kwargs["include_reload"] is False
+
     def test_execute_with_invalid_date_raises_error(self):
         tool = GetPageViewsTool(MagicMock())
 
@@ -151,6 +168,23 @@ class TestGetTopDomainsTool:
         )
 
         assert repository.get_top_domains.call_args.kwargs["include_reload"] is True
+
+    @patch("backend.domain.tools.browser_history.page_views.DuckDBConnection")
+    def test_execute_passes_include_reload_false(self, MockConn):
+        """top_domains でも include_reload=False をリポジトリまで伝播する。"""
+        MockConn.return_value = _mock_conn_ctx()
+
+        repository = MagicMock()
+        repository.get_top_domains.return_value = []
+        tool = GetTopDomainsTool(repository)
+
+        tool.execute(
+            start_date="2026-03-20",
+            end_date="2026-03-22",
+            include_reload=False,
+        )
+
+        assert repository.get_top_domains.call_args.kwargs["include_reload"] is False
 
     def test_execute_with_invalid_date_raises_error(self):
         tool = GetTopDomainsTool(MagicMock())

--- a/egograph/pipelines/sources/youtube/extraction.py
+++ b/egograph/pipelines/sources/youtube/extraction.py
@@ -70,6 +70,8 @@ def extract_youtube_watch_events(page_view_rows: list[dict]) -> list[dict]:
     events: list[dict] = []
 
     for row in page_view_rows:
+        if row.get("transition") == "reload":
+            continue
         url = row.get("url", "")
         title = row.get("title")
         normalized = normalize_youtube_url(url)

--- a/egograph/pipelines/sources/youtube/storage.py
+++ b/egograph/pipelines/sources/youtube/storage.py
@@ -153,6 +153,7 @@ class YouTubeStorage:
             "url",
             "title",
             "source_device",
+            "transition",
             "ingested_at_utc",
         ]
         rows: list[dict[str, Any]] = []

--- a/egograph/pipelines/tests/unit/youtube/test_extraction.py
+++ b/egograph/pipelines/tests/unit/youtube/test_extraction.py
@@ -70,7 +70,7 @@ def test_mixed_input_filters_only_reload():
 
 
 def test_no_transition_field_is_kept():
-    """page_view に transition が無い場合（後方互換）は除外しない。"""
+    """page_view に transition が無い場合 (後方互換) は除外しない。"""
     row = _row(page_view_id="pv-legacy")
     del row["transition"]
 

--- a/egograph/pipelines/tests/unit/youtube/test_extraction.py
+++ b/egograph/pipelines/tests/unit/youtube/test_extraction.py
@@ -1,0 +1,80 @@
+"""YouTube watch event 抽出ロジックの単体テスト。"""
+
+from datetime import datetime, timezone
+
+from pipelines.sources.youtube.extraction import extract_youtube_watch_events
+
+
+def _row(
+    *,
+    page_view_id: str,
+    transition: str | None = "link",
+    url: str = "https://www.youtube.com/watch?v=video-1",
+    title: str = "Sample Video - YouTube",
+    sync_id: str = "sync-1",
+) -> dict:
+    return {
+        "sync_id": sync_id,
+        "page_view_id": page_view_id,
+        "started_at_utc": datetime(2026, 4, 21, 12, 0, tzinfo=timezone.utc),
+        "url": url,
+        "title": title,
+        "source_device": "desktop",
+        "transition": transition,
+        "ingested_at_utc": datetime(2026, 4, 21, 12, 5, tzinfo=timezone.utc),
+    }
+
+
+def test_excludes_reload_page_views():
+    """transition='reload' の page_view は watch_event に変換されない。"""
+    rows = [_row(page_view_id="pv-reload", transition="reload")]
+
+    result = extract_youtube_watch_events(rows)
+
+    assert result == []
+
+
+def test_includes_link_typed_page_views():
+    """transition='link' / 'typed' は通常通り watch_event になる。"""
+    rows = [
+        _row(page_view_id="pv-link", transition="link"),
+        _row(
+            page_view_id="pv-typed",
+            transition="typed",
+            url="https://www.youtube.com/watch?v=video-2",
+        ),
+    ]
+
+    result = extract_youtube_watch_events(rows)
+
+    assert len(result) == 2
+    assert {event["source_event_id"] for event in result} == {"pv-link", "pv-typed"}
+
+
+def test_mixed_input_filters_only_reload():
+    """link/reload 混在入力で reload のみスキップされる。"""
+    rows = [
+        _row(page_view_id="pv-link-1", transition="link"),
+        _row(page_view_id="pv-reload-1", transition="reload"),
+        _row(
+            page_view_id="pv-link-2",
+            transition="link",
+            url="https://www.youtube.com/watch?v=video-3",
+        ),
+        _row(page_view_id="pv-reload-2", transition="reload"),
+    ]
+
+    result = extract_youtube_watch_events(rows)
+
+    assert [event["source_event_id"] for event in result] == ["pv-link-1", "pv-link-2"]
+
+
+def test_no_transition_field_is_kept():
+    """page_view に transition が無い場合（後方互換）は除外しない。"""
+    row = _row(page_view_id="pv-legacy")
+    del row["transition"]
+
+    result = extract_youtube_watch_events([row])
+
+    assert len(result) == 1
+    assert result[0]["source_event_id"] == "pv-legacy"


### PR DESCRIPTION
## 概要

ブラウザ起動時のリロード (`transition='reload'`) 由来の page_view / watch_event を、**提供時に既定で除外**する。散在する personal data を集約するという EgoGraph の目的に対し、ノイズを「捨てない」ではなく「提供時にフィルタする」ことで、データの完全性と分析品質を両立する。

## 動機（観測データ）

`/root/workspace/compacted_events_browser_history_page_views_year=2026_month=06_data.parquet` (n=1078) を 2026-06 に実観測:

| 指標 | 値 |
|---|---|
| 全 page_view | 1078 |
| `transition='reload'` | 266 (**24.7%**) |
| reload のうち「起動バースト」(1分以内に 3URL 以上リロード) | 171 (**64.3%**) |
| 起動バースト件数 | 14 |
| 最大起動バースト規模 | 22 URL / 24 秒 |

起動バースト代表: 2026-06-01 09:56:24-48 に 22 URL 全てが reload。バースト内ドメイン Top は YouTube (37), GitHub (29), dev-server (20)。

YouTube 関連 page_view (n=273) では 47 件 (**17.2%**) が reload。同一動画重複の代表例として `6d9FRcJ8e1g` が 06-02 に 6 回出現（うち reload 3 回）。

## 設計判断

### 責務分離

| データソース | 性質 | 除外する場所 |
|---|---|---|
| **browser_history** | 元データ層 | API / MCP 層（`include_reload` パラメータ） |
| **youtube** | 派生消費層 | watch event 抽出時 |

- browser_history は `events` parquet に reload を含む原事実を残し、提供層でフィルタ。`include_reload` の既定は `null`（=reload 除外）
- youtube は watch event 抽出関数 `extract_youtube_watch_events` で reload 由来 page_view をスキップ。スキーマ・過去データは無変更。API / ツールに `include_reload` パラメータは追加しない（消費時に確定するため再評価する手段がない＝意味がない）

### 過去データは触らない

- events / compacted parquet は reload を含む従来状態を維持
- スキーマ変更なし（transition カラム追加なし）
- 新規取り込み分から挙動が変わる

## 変更内容

| ファイル | 変更 |
|---|---|
| `egograph/backend/infrastructure/database/browser_history_queries.py` | `_exclude_reload_clause` ヘルパ追加。`get_page_views` / `get_top_domains` に `include_reload` 追加 |
| `egograph/backend/infrastructure/repositories/browser_history_repository.py` | 2 メソッドに `include_reload` 引数追加 |
| `egograph/backend/api/browser_history_data.py` | 2 エンドポイントに `include_reload` クエリパラメータ追加 |
| `egograph/backend/domain/tools/browser_history/page_views.py` | 2 ツールの schema / execute に `include_reload` |
| `egograph/pipelines/sources/youtube/extraction.py` | `extract_youtube_watch_events` で reload スキップ |
| `egograph/pipelines/sources/youtube/storage.py` | `load_browser_history_page_views` の `required_columns` に `transition` 追加 |
| `docs/30.pipelines/browser-history.md` | §7.5 「提供時のデフォルトフィルタ (`include_reload`)」追加 |
| `docs/30.pipelines/youtube.md` | §3.5 「watch_event 化ルール: reload 除外」追加 |
| 各種テスト 15 件追加 | queries 4 / tools 4 / api 3 / extraction 4 |

## 後方互換性

- `include_reload` パラメータは None デフォルト → 既存クライアントは無修正で挙動変化
- `true` を渡すと従来通り reload を含む全件を返す
- YouTube 側は消費時に確定するため、パラメータなし。既存テスト fixture に `transition` 列が無い場合は `.get()` が None を返し、reload 判定は発火しない（後方互換維持）

## 動作確認

```bash
# 44 tests pass (queries + tools + api + youtube extraction + storage)
uv run pytest egograph/backend/tests/unit/database/test_browser_history_queries.py \
                egograph/backend/tests/unit/tools/browser_history/test_page_views.py \
                egograph/backend/tests/integration/test_browser_history_data_api.py \
                egograph/pipelines/tests/unit/youtube/
# => 44 passed

# Ruff: 変更ファイルにエラーなし
uv run ruff check <changed files>
# => All checks passed!
```

## 影響範囲

- 既存の `test_aggregates_domain_counts` / `test_filters_top_domains` / `test_filters_by_browser_and_profile` は `include_reload=True` を明示する形に更新（reload 除外によって既存の集計値が変わるため、テストの意図＝「browser/profile フィルタ」「集計ロジック」を維持するために opt-in）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブラウザ履歴のページビューとトップドメイン取得時に、`include_reload` パラメータを追加し、リロード遷移の行の除外/包含を制御可能に
  * YouTube 動画イベント抽出時にリロード遷移を既定で除外し、ノイズを削減

* **テスト**
  * 新パラメータの伝播と除外動作を検証するテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->