### PR TITLE
Improve Google Health OAuth diagnostics

### DIFF
--- a/docs/plan/plan-google-health-oauth-ops.md
+++ b/docs/plan/plan-google-health-oauth-ops.md
@@ -1,0 +1,275 @@
+# Google Health 認証障害の診断性改善 Plan
+
+## 目的
+
+Google Health 取り込みで認証が切れたときに、原因をコードと運用から一意に判断できるようにする。
+
+今回の主因は Google Auth Platform が `テスト中` だったことによる refresh token の7日失効と判断する。これは運用設定で解消済み。コード側で直すべき本質は、refresh 失敗時に原因情報を捨てているため、次回障害時に同じ調査を繰り返す構造である。
+
+## 現状
+
+本番で確認した状態:
+
+- `google_health_connections.status = revoked`
+- `last_error_message = access token refresh failed`
+- `google_health_ingest_workflow` は `google_health_active_connection_not_found` で失敗
+- Google Auth Platform は `テスト中` だった
+- connection 作成から revoked 更新まで約7日
+
+該当コード:
+
+- `egograph/pipelines/sources/google_health/client.py`
+  - `_refresh_token()` が refresh 失敗時に `access token refresh failed` だけを保存する
+  - Google OAuth error body を捨てている
+- `egograph/pipelines/sources/google_health/workflow.py`
+  - connection が active でない場合に `google_health_active_connection_not_found` を投げる
+- `egograph/pipelines/api/google_health.py`
+  - 手動run作成時は active connection がなければ 409 を返す
+
+## 方針
+
+1. refresh 失敗の OAuth error body を安全に要約する
+2. 要約を `last_error_message` に保存する
+3. connection status は、OAuth error の意味に基づいて更新する
+4. 一時障害では connection を inactive にしない
+5. workflow 側の前提条件エラー文だけ具体化する
+6. Activity系 null は、認証復旧後に1回だけ実データで切り分ける。コード変更はまだしない
+
+## 実装タスク
+
+### Task 1: OAuth error body の安全な要約関数を追加する
+
+対象: `egograph/pipelines/sources/google_health/client.py`
+
+追加する関数:
+
+```python
+def _oauth_error_summary(response: Response) -> str:
+    ...
+```
+
+仕様:
+
+- 返り値は1行文字列
+- 最大長は 500 文字程度に切る
+- JSON bodyの場合、以下だけ使う
+  - HTTP status
+  - `error`
+  - `error_subtype`
+- `error_description` は意図的に保存しない。provider 側が自由に書ける free text であり、機密値が混入する可能性があるため
+- JSONでない場合は body を保存しない
+- token、code、secret、authorization header は絶対に含めない
+- `error` / `error_subtype` の値は field ごとの明示的許可リストに完全一致する
+  場合だけ保存する。許可リスト外の値 (token / code / 自由文等) は、
+  field 名ごと要約から除外する。
+  - `error` 許可リスト: `invalid_request` / `invalid_client` / `invalid_grant`
+    / `unauthorized_client` / `unsupported_grant_type` / `invalid_scope`
+  - `error_subtype` 許可リスト: `invalid_rapt`
+  - 短い token や authorization code は OAuth 仕様の identifier 形状を満たし
+    得るため、形状ではなく許可リストで制限する。provider 由来の文字列を
+    無条件で信頼しない。秘密情報混入を防ぐための防御線。
+
+出力例:
+
+```text
+oauth_refresh_failed: status=400 error=invalid_grant
+```
+
+```text
+oauth_refresh_failed: status=401 error=invalid_client
+```
+
+```text
+oauth_refresh_failed: status=500
+```
+
+実装上の制約:
+
+- `response.text` を丸ごと保存しない
+- 未知fieldを保存しない
+- 例外が出ても診断関数自体で落とさない
+
+### Task 2: `_refresh_token()` の status 更新メッセージを置き換える
+
+対象: `egograph/pipelines/sources/google_health/client.py`
+
+現状:
+
+```python
+self._repository.update_connection_status(
+    connection_id,
+    status,
+    "access token refresh failed",
+)
+raise GoogleHealthAuthenticationError("google_health_token_refresh_failed")
+```
+
+変更後:
+
+```python
+error_summary = _oauth_error_summary(response)
+status = _refresh_failure_connection_status(response)
+if status is not None:
+    self._repository.update_connection_status(
+        connection_id,
+        status,
+        error_summary,
+    )
+raise GoogleHealthAuthenticationError(error_summary)
+```
+
+status 方針:
+
+- `invalid_grant`: `ConnectionStatus.REVOKED`
+- `invalid_client` / `unauthorized_client`: `ConnectionStatus.ERROR`
+- 429 / 5xx: connection status は更新しない
+- JSONでない4xx: `ConnectionStatus.ERROR`
+- `error` 値が `error` field の明示的許可リスト (Task 1 と同一) に一致しない場合は
+  未分類扱い。結果として未知の 4xx と同じく `ConnectionStatus.ERROR` になる。
+  許可リスト外の値で既知の error 名との完全一致を試みない。
+
+一時障害で connection を `error` に落とさない。ここを誤ると、Google側の一時障害やrate limitで永続的に ingest が止まり、手動再認証ではなくDB状態修復が必要になる。
+
+細かい分類enumは追加しない。現時点では過剰。判断に必要な情報は `last_error_message` と status 遷移で足りる。
+
+### Task 3: workflow の active connection 不在エラーを具体化する
+
+対象: `egograph/pipelines/sources/google_health/workflow.py`
+
+現状:
+
+```python
+if connection is None or connection.status is not ConnectionStatus.ACTIVE:
+    raise RuntimeError("google_health_active_connection_not_found")
+```
+
+変更後:
+
+```python
+if connection is None:
+    raise RuntimeError("google_health_active_connection_not_found")
+if connection.status is not ConnectionStatus.ACTIVE:
+    raise RuntimeError(
+        "google_health_active_connection_not_found: "
+        f"status={connection.status.value}"
+    )
+```
+
+目的:
+
+- run一覧だけで `revoked` / `expired` / `error` を判別できる
+- DBを直接見なくても再認証が必要か判断できる
+
+`last_error_message` まで例外に混ぜない。長くなり、秘密情報混入の検査対象が増えるため。
+
+### Task 4: connection API のレスポンスは維持する
+
+対象: `egograph/pipelines/api/google_health.py`
+
+変更しない。
+
+理由:
+
+- すでに `status` と `last_error_message` を返している
+- 診断情報は Task 2 で `last_error_message` に入る
+- API契約を変える必要がない
+
+### Task 5: テストを追加する
+
+対象:
+
+- `egograph/pipelines/tests/unit/google_health/test_client.py`
+- `egograph/pipelines/tests/unit/google_health/test_workflow.py`
+
+必要なテスト:
+
+1. refresh 400 `invalid_grant` の診断保存
+
+条件:
+
+- token refresh response が 400
+- body:
+
+```json
+{
+  "error": "invalid_grant",
+  "error_description": "Token has been expired or revoked."
+}
+```
+
+期待:
+
+- connection status が `revoked`
+- `last_error_message` が以下を含む
+  - `oauth_refresh_failed`
+  - `status=400`
+  - `error=invalid_grant`
+- `error_description` の値 (`Token has been expired or revoked.`) を含まない
+- token文字列を含まない
+
+2. refresh 401 `invalid_client` の診断保存
+
+期待:
+
+- connection status が `error`
+- `last_error_message` に `error=invalid_client`
+
+3. refresh 500 は connection status を変えない
+
+期待:
+
+- connection status は `active` のまま
+- 例外メッセージは `oauth_refresh_failed: status=500`
+
+4. refresh 429 は connection status を変えない
+
+期待:
+
+- connection status は `active` のまま
+- 例外メッセージは `oauth_refresh_failed: status=429`
+
+5. 許可リスト外の `error` / `error_subtype` 値は要約から除外する
+
+条件:
+
+- refresh response が 400 で `error` / `error_subtype` が許可リスト (Task 1 と同一) 外の値
+  - 自由文・文字種違反 (例: `refresh_token=secret; code=authz-code-123`)
+  - 許可リスト外の identifier 形状値 (例: `authz-code-123`)。
+    短い token や authorization code も identifier 形状になり得るため、
+    形状ではなく許可リストで弾く
+
+期待:
+
+- 例外メッセージ・`last_error_message` ともに当該値を含まず、`oauth_refresh_failed: status=400` のみ残る
+
+6. inactive connection の workflow error に status が入る
+
+条件:
+
+- repository が `ConnectionStatus.REVOKED` の connection を返す
+
+期待:
+
+```text
+google_health_active_connection_not_found: status=revoked
+```
+
+## 完了条件
+
+- refresh失敗時に `last_error_message` だけで OAuth error の種類が分かる
+- token、authorization code、client secret がログ・DBに保存されない
+- 一時的なOAuth障害やrate limitで connection が inactive にならない
+- invalid_grant のときだけ connection が `revoked` になる
+- 既存API契約を壊していない
+- unit test が通る
+- 再認証後、connection / smoke-test / `steps` + `sleep` manual run の結果を確認できる
+
+## 実装順序
+
+1. `_oauth_error_summary()` を追加
+2. `_refresh_token()` の保存メッセージを差し替え
+3. refresh failure の status 遷移を error body ベースに変更
+4. workflow の inactive connection error を具体化
+5. unit test 追加
+6. test 実行
+7. 本番再認証後に運用確認

--- a/egograph/pipelines/sources/google_health/client.py
+++ b/egograph/pipelines/sources/google_health/client.py
@@ -47,6 +47,125 @@ class GoogleHealthClientError(GoogleHealthAPIError):
     """retry 不能な 4xx error。"""
 
 
+_OAUTH_ERROR_SUMMARY_MAX_LENGTH = 500
+
+# OAuth refresh 失敗時に診断情報として使ってよい JSON field の許可リスト。
+# 意図的に限定することで token / code / secret 等の秘密情報混入を防ぐ。
+# error_description は OAuth 仕様上は許容 field だが、provider が自由に文章を
+# 制御できるため token / code / client identifier 等が混入するリスクがある。
+# そのため provider 由来の自由文は保存せず、構造化された固定値だけを記録する。
+
+# OAuth 診断 field 値の永続化許可リスト。
+# provider 由来の任意の文字列を無条件で信頼せず、field ごとに定義した明示的な
+# 固定値集合に完全一致した場合だけ保存する。短い token や authorization code は
+# OAuth 仕様の identifier 形状 (ASCII letter/digit と記号) を満たし得るため、
+# 形状 check ではなく許可リストで制限する。ここに含まれない値はすべて保存
+# 対象から除外する。keys がそのまま利用対象 field 名になる。
+_OAUTH_ERROR_ALLOWED_VALUES: dict[str, frozenset[str]] = {
+    "error": frozenset(
+        {
+            "invalid_request",
+            "invalid_client",
+            "invalid_grant",
+            "unauthorized_client",
+            "unsupported_grant_type",
+            "invalid_scope",
+        }
+    ),
+    "error_subtype": frozenset({"invalid_rapt"}),
+}
+
+# error 値と connection status の対応。一時障害(429/5xx)は含まない。
+# 許可リスト内だがここに含まれない error (invalid_request 等) は未分類扱いで
+# :attr:`ConnectionStatus.ERROR` になる。
+_OAUTH_ERROR_CONNECTION_STATUS: dict[str, ConnectionStatus] = {
+    "invalid_grant": ConnectionStatus.REVOKED,
+    "invalid_client": ConnectionStatus.ERROR,
+    "unauthorized_client": ConnectionStatus.ERROR,
+}
+
+
+def _safe_oauth_error_field(field: str, value: Any) -> str | None:
+    """OAuth 診断 field 値が明示的許可リストに含まれる場合のみ返す。
+
+    ``error`` / ``error_subtype`` は OAuth 仕様では短い identifier として
+    定義されるが、短い token や authorization code も同じ identifier 形状に
+    なり得る。そのため provider 由来の文字列を形状だけで受け入れず、
+    :data:`_OAUTH_ERROR_ALLOWED_VALUES` の field ごとの許可リストと完全一致
+    した場合だけ保存対象とする。許可リスト外の値は ``None`` を返し、
+    保存対象から除外する。
+    """
+    allowed = _OAUTH_ERROR_ALLOWED_VALUES.get(field)
+    if allowed is None or not isinstance(value, str):
+        return None
+    return value if value in allowed else None
+
+
+def _oauth_error_summary(response: Response) -> str:
+    """OAuth refresh 失敗時の安全な1行要約を返す。
+
+    - JSON body の場合は ``error`` / ``error_subtype`` だけを使う
+    - ただし値が field ごとの明示的許可リスト
+      (:data:`_OAUTH_ERROR_ALLOWED_VALUES`) に完全一致しない場合はその
+      field を要約から除外する。短い token や authorization code は
+      identifier 形状になり得るため、形状ではなく許可リストで制限する
+    - JSONでない場合は body を保存しない
+    - access token / refresh token / authorization code / client secret /
+      Authorization header / body 全体、および provider 由来の自由文
+      (``error_description``) は絶対に含めない
+    - この関数自体が例外を投げないよう、parse 失敗時は status のみ返す
+    """
+    status_code = response.status_code
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+    if not isinstance(payload, dict):
+        return f"oauth_refresh_failed: status={status_code}"[
+            :_OAUTH_ERROR_SUMMARY_MAX_LENGTH
+        ]
+    parts: list[str] = [f"oauth_refresh_failed: status={status_code}"]
+    for field in _OAUTH_ERROR_ALLOWED_VALUES:
+        safe_value = _safe_oauth_error_field(field, payload.get(field))
+        if safe_value is not None:
+            parts.append(f"{field}={safe_value}")
+    return " ".join(parts)[:_OAUTH_ERROR_SUMMARY_MAX_LENGTH]
+
+
+def _refresh_failure_connection_status(
+    response: Response,
+) -> ConnectionStatus | None:
+    """OAuth refresh 失敗時の connection status 遷移を返す。
+
+    - ``invalid_grant`` -> :attr:`ConnectionStatus.REVOKED`
+    - ``invalid_client`` / ``unauthorized_client`` -> :attr:`ConnectionStatus.ERROR`
+    - 429 / 5xx -> ``None`` (一時障害なので connection status を更新しない)
+    - JSONでない・未分類の 4xx -> :attr:`ConnectionStatus.ERROR`
+
+    分類は ``error`` 値が ``error`` field の明示的許可リスト
+    (:data:`_OAUTH_ERROR_ALLOWED_VALUES`) に完全一致し、かつ
+    :data:`_OAUTH_ERROR_CONNECTION_STATUS` に含まれる場合のみ行う。
+    許可リスト外の値、および許可リスト内だが status map にない値
+    (``invalid_request`` 等) は未分類扱いとなり、4xx なら
+    :attr:`ConnectionStatus.ERROR` になる。
+
+    一時障害で誤って connection を inactive にすると、手動再認証ではなく
+    DB状態修復が必要になるため ``None`` で更新を抑止する。
+    """
+    status_code = response.status_code
+    if status_code == 429 or status_code >= 500:
+        return None
+    try:
+        payload = response.json()
+    except ValueError:
+        return ConnectionStatus.ERROR
+    if isinstance(payload, dict):
+        error = _safe_oauth_error_field("error", payload.get("error"))
+        if error is not None:
+            return _OAUTH_ERROR_CONNECTION_STATUS.get(error, ConnectionStatus.ERROR)
+    return ConnectionStatus.ERROR
+
+
 class GoogleHealthAPIClient:
     """token refresh と retry を備えた Google Health API client。"""
 
@@ -210,17 +329,15 @@ class GoogleHealthAPIClient:
             )
         response = self._request_token_refresh(current_token.refresh_token)
         if response.status_code >= 400:
-            status = (
-                ConnectionStatus.REVOKED
-                if response.status_code in (400, 401)
-                else ConnectionStatus.ERROR
-            )
-            self._repository.update_connection_status(
-                connection_id,
-                status,
-                "access token refresh failed",
-            )
-            raise GoogleHealthAuthenticationError("google_health_token_refresh_failed")
+            error_summary = _oauth_error_summary(response)
+            status = _refresh_failure_connection_status(response)
+            if status is not None:
+                self._repository.update_connection_status(
+                    connection_id,
+                    status,
+                    error_summary,
+                )
+            raise GoogleHealthAuthenticationError(error_summary)
         payload = response.json()
         access_token = payload.get("access_token")
         expires_in = payload.get("expires_in")

--- a/egograph/pipelines/sources/google_health/workflow.py
+++ b/egograph/pipelines/sources/google_health/workflow.py
@@ -66,8 +66,13 @@ def _execute_google_health_ingest(
     """解決済みadapterを使ってGoogle Health取り込みを実行する。"""
     request = _parse_request(run, dependencies.timezone)
     connection = dependencies.repository.get_connection()
-    if connection is None or connection.status is not ConnectionStatus.ACTIVE:
+    if connection is None:
         raise RuntimeError("google_health_active_connection_not_found")
+    if connection.status is not ConnectionStatus.ACTIVE:
+        raise RuntimeError(
+            "google_health_active_connection_not_found: "
+            f"status={connection.status.value}"
+        )
 
     records: dict[str, list[dict]] = {
         "daily_metrics": [],
@@ -205,8 +210,13 @@ def _execute_google_health_compact(
     """同期結果を基に成功したdata typeだけをcompactする。"""
     request = _parse_request(run, dependencies.timezone)
     connection = dependencies.repository.get_connection()
-    if connection is None or connection.status is not ConnectionStatus.ACTIVE:
+    if connection is None:
         raise RuntimeError("google_health_active_connection_not_found")
+    if connection.status is not ConnectionStatus.ACTIVE:
+        raise RuntimeError(
+            "google_health_active_connection_not_found: "
+            f"status={connection.status.value}"
+        )
 
     cursors = dependencies.repository.list_sync_results_for_run(
         connection.connection_id,

--- a/egograph/pipelines/tests/unit/google_health/test_client.py
+++ b/egograph/pipelines/tests/unit/google_health/test_client.py
@@ -13,7 +13,7 @@ from pipelines.sources.google_health.client import (
     GoogleHealthAuthenticationError,
     GoogleHealthRateLimitError,
 )
-from pipelines.sources.google_health.models import OAuthToken
+from pipelines.sources.google_health.models import ConnectionStatus, OAuthToken
 from pipelines.sources.google_health.repository import GoogleHealthRepository
 from pipelines.sources.google_health.token_cipher import TokenCipher
 
@@ -351,7 +351,14 @@ def test_refresh_rejection_marks_connection_revoked(tmp_path):
         tmp_path,
         expired=True,
     )
-    session = FakeSession([FakeResponse({}, status_code=400)])
+    session = FakeSession(
+        [
+            FakeResponse(
+                {"error": "invalid_grant"},
+                status_code=400,
+            )
+        ]
+    )
     client = GoogleHealthAPIClient(
         repository,
         cipher,
@@ -367,3 +374,292 @@ def test_refresh_rejection_marks_connection_revoked(tmp_path):
     updated = repository.get_connection()
     assert updated is not None
     assert updated.status.value == "revoked"
+
+
+def test_refresh_invalid_grant_persists_safe_diagnostics(tmp_path):
+    """refresh 400 invalid_grant は安全な診断を保存し connection を revoked にする。"""
+    # Arrange
+    repository, cipher, connection = _repository_with_token(tmp_path, expired=True)
+    session = FakeSession(
+        [
+            FakeResponse(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "Token has been expired or revoked.",
+                },
+                status_code=400,
+            )
+        ]
+    )
+    client = GoogleHealthAPIClient(
+        repository,
+        cipher,
+        client_id="client-id",
+        client_secret="client-secret",
+        session=session,
+    )
+
+    # Act & Assert
+    with pytest.raises(GoogleHealthAuthenticationError) as exc_info:
+        client.list_data_points(connection.connection_id, "steps")
+
+    summary = str(exc_info.value)
+    assert "oauth_refresh_failed" in summary
+    assert "status=400" in summary
+    assert "error=invalid_grant" in summary
+    # provider 由来の error_description は例外メッセージに保存しない
+    assert "Token has been expired or revoked" not in summary
+    # 秘密情報が例外メッセージに混入しない
+    assert "refresh-token" not in summary
+    assert "client-secret" not in summary
+
+    updated = repository.get_connection()
+    assert updated is not None
+    assert updated.status == ConnectionStatus.REVOKED
+    assert updated.last_error_message is not None
+    assert "oauth_refresh_failed" in updated.last_error_message
+    assert "error=invalid_grant" in updated.last_error_message
+    # provider 由来の error_description は DB の last_error_message にも保存しない
+    assert "Token has been expired or revoked" not in updated.last_error_message
+    # 秘密情報が DB の last_error_message に混入しない
+    assert "refresh-token" not in updated.last_error_message
+
+
+def test_refresh_error_description_with_token_like_text_is_not_persisted(tmp_path):
+    """error_description に token 的文字列が含まれていても保存・伝播しない。"""
+    # Arrange
+    repository, cipher, connection = _repository_with_token(tmp_path, expired=True)
+    sensitive_description = "refresh_token=refresh-token; code=authz-code-123"
+    session = FakeSession(
+        [
+            FakeResponse(
+                {
+                    "error": "invalid_grant",
+                    "error_description": sensitive_description,
+                },
+                status_code=400,
+            )
+        ]
+    )
+    client = GoogleHealthAPIClient(
+        repository,
+        cipher,
+        client_id="client-id",
+        client_secret="client-secret",
+        session=session,
+    )
+
+    # Act & Assert
+    with pytest.raises(GoogleHealthAuthenticationError) as exc_info:
+        client.list_data_points(connection.connection_id, "steps")
+
+    summary = str(exc_info.value)
+    assert "error=invalid_grant" in summary
+    # error_description に含まれる token 的文字列は例外メッセージに漏れない
+    assert "refresh-token" not in summary
+    assert "authz-code-123" not in summary
+    assert sensitive_description not in summary
+
+    updated = repository.get_connection()
+    assert updated is not None
+    assert updated.last_error_message is not None
+    # DB の last_error_message にも token 的文字列は漏れない
+    assert "refresh-token" not in updated.last_error_message
+    assert "authz-code-123" not in updated.last_error_message
+    assert sensitive_description not in updated.last_error_message
+
+
+def test_refresh_token_like_error_value_is_not_persisted(tmp_path):
+    """許可リスト外の error / error_subtype 値は保存・伝播しない。
+
+    provider が ``error`` / ``error_subtype`` に許可リスト外の文字列
+    (token / code / 自由文など) を送ってきた場合、それを例外メッセージや
+    ``last_error_message`` に保存しないことを保証する。
+    """
+    # Arrange
+    repository, cipher, connection = _repository_with_token(tmp_path, expired=True)
+    # "=" / ";" / 空白を含む自由文 (許可リスト外)
+    malicious_error = "refresh_token=secret-refresh-token; code=authz-code-123"
+    # 許可リスト外の長い token 的文字列
+    malicious_error_subtype = "ya29." + "a" * 200
+    session = FakeSession(
+        [
+            FakeResponse(
+                {
+                    "error": malicious_error,
+                    "error_subtype": malicious_error_subtype,
+                },
+                status_code=400,
+            )
+        ]
+    )
+    client = GoogleHealthAPIClient(
+        repository,
+        cipher,
+        client_id="client-id",
+        client_secret="client-secret",
+        session=session,
+    )
+
+    # Act & Assert
+    with pytest.raises(GoogleHealthAuthenticationError) as exc_info:
+        client.list_data_points(connection.connection_id, "steps")
+
+    summary = str(exc_info.value)
+    assert "oauth_refresh_failed" in summary
+    assert "status=400" in summary
+    # 許可リスト外の値は要約から除外されるため field 名自体登場しない
+    assert "error=" not in summary
+    assert "error_subtype=" not in summary
+    # token 的文字列は例外メッセージに漏れない
+    assert malicious_error not in summary
+    assert malicious_error_subtype not in summary
+    assert "secret-refresh-token" not in summary
+    assert "authz-code-123" not in summary
+
+    updated = repository.get_connection()
+    assert updated is not None
+    # 分類不能なので 4xx 扱いで ERROR になる
+    assert updated.status == ConnectionStatus.ERROR
+    assert updated.last_error_message is not None
+    assert "oauth_refresh_failed" in updated.last_error_message
+    assert "status=400" in updated.last_error_message
+    # token 的文字列は DB の last_error_message にも漏れない
+    assert "error=" not in updated.last_error_message
+    assert "error_subtype=" not in updated.last_error_message
+    assert malicious_error not in updated.last_error_message
+    assert malicious_error_subtype not in updated.last_error_message
+    assert "secret-refresh-token" not in updated.last_error_message
+    assert "authz-code-123" not in updated.last_error_message
+
+
+def test_refresh_identifier_shaped_non_allowlisted_value_is_not_persisted(tmp_path):
+    """許可リスト外の identifier 形状値 (token/code 類似) は保存・伝播しない。
+
+    ``error`` / ``error_subtype`` が OAuth 仕様の identifier 形状
+    (ASCII letter/digit と記号のみの短い文字列) を満たしていても、明示的
+    許可リストに含まれなければ保存対象から除外する。短い authorization
+    code や token の断片は identifier 形状になり得るため、形状ではなく
+    許可リストで制限する。
+    """
+    # Arrange
+    repository, cipher, connection = _repository_with_token(tmp_path, expired=True)
+    # identifier 形状だが許可リスト外の token/code 的文字列
+    token_like_error = "authz-code-123"
+    token_like_subtype = "ya29-short-token"
+    session = FakeSession(
+        [
+            FakeResponse(
+                {
+                    "error": token_like_error,
+                    "error_subtype": token_like_subtype,
+                },
+                status_code=400,
+            )
+        ]
+    )
+    client = GoogleHealthAPIClient(
+        repository,
+        cipher,
+        client_id="client-id",
+        client_secret="client-secret",
+        session=session,
+    )
+
+    # Act & Assert
+    with pytest.raises(GoogleHealthAuthenticationError) as exc_info:
+        client.list_data_points(connection.connection_id, "steps")
+
+    summary = str(exc_info.value)
+    assert "oauth_refresh_failed" in summary
+    assert "status=400" in summary
+    # 許可リスト外の値は要約から除外されるため field 名自体登場しない
+    assert "error=" not in summary
+    assert "error_subtype=" not in summary
+    # token/code 的文字列は例外メッセージに漏れない
+    assert token_like_error not in summary
+    assert token_like_subtype not in summary
+
+    updated = repository.get_connection()
+    assert updated is not None
+    # 許可リスト外なので未分類 4xx 扱いで ERROR になる
+    assert updated.status == ConnectionStatus.ERROR
+    assert updated.last_error_message is not None
+    assert "oauth_refresh_failed" in updated.last_error_message
+    assert "status=400" in updated.last_error_message
+    # token/code 的文字列は DB の last_error_message にも漏れない
+    assert "error=" not in updated.last_error_message
+    assert "error_subtype=" not in updated.last_error_message
+    assert token_like_error not in updated.last_error_message
+    assert token_like_subtype not in updated.last_error_message
+
+
+def test_refresh_invalid_client_marks_error(tmp_path):
+    """refresh 401 invalid_client は connection を error にする。"""
+    # Arrange
+    repository, cipher, connection = _repository_with_token(tmp_path, expired=True)
+    session = FakeSession([FakeResponse({"error": "invalid_client"}, status_code=401)])
+    client = GoogleHealthAPIClient(
+        repository,
+        cipher,
+        client_id="client-id",
+        client_secret="client-secret",
+        session=session,
+    )
+
+    # Act & Assert
+    with pytest.raises(GoogleHealthAuthenticationError) as exc_info:
+        client.list_data_points(connection.connection_id, "steps")
+
+    assert "error=invalid_client" in str(exc_info.value)
+    updated = repository.get_connection()
+    assert updated is not None
+    assert updated.status == ConnectionStatus.ERROR
+
+
+def test_refresh_server_error_keeps_connection_active(tmp_path):
+    """refresh 5xx は connection status を更新せず安全な診断で例外を投げる。"""
+    # Arrange
+    repository, cipher, connection = _repository_with_token(tmp_path, expired=True)
+    session = FakeSession([FakeResponse({}, status_code=500)] * 3)
+    client = GoogleHealthAPIClient(
+        repository,
+        cipher,
+        client_id="client-id",
+        client_secret="client-secret",
+        session=session,
+        sleep=lambda _: None,
+    )
+
+    # Act & Assert
+    with pytest.raises(GoogleHealthAuthenticationError) as exc_info:
+        client.list_data_points(connection.connection_id, "steps")
+
+    assert "oauth_refresh_failed: status=500" in str(exc_info.value)
+    updated = repository.get_connection()
+    assert updated is not None
+    assert updated.status == ConnectionStatus.ACTIVE
+
+
+def test_refresh_rate_limit_keeps_connection_active(tmp_path):
+    """refresh 429 は connection status を更新せず安全な診断で例外を投げる。"""
+    # Arrange
+    repository, cipher, connection = _repository_with_token(tmp_path, expired=True)
+    session = FakeSession([FakeResponse({}, status_code=429)] * 3)
+    client = GoogleHealthAPIClient(
+        repository,
+        cipher,
+        client_id="client-id",
+        client_secret="client-secret",
+        session=session,
+        sleep=lambda _: None,
+    )
+
+    # Act & Assert
+    with pytest.raises(GoogleHealthAuthenticationError) as exc_info:
+        client.list_data_points(connection.connection_id, "steps")
+
+    assert "oauth_refresh_failed: status=429" in str(exc_info.value)
+    updated = repository.get_connection()
+    assert updated is not None
+    assert updated.status == ConnectionStatus.ACTIVE

--- a/egograph/pipelines/tests/unit/google_health/test_workflow.py
+++ b/egograph/pipelines/tests/unit/google_health/test_workflow.py
@@ -3,6 +3,7 @@
 from datetime import UTC, date, datetime
 from zoneinfo import ZoneInfo
 
+import pytest
 from pipelines.domain.workflow import (
     QueuedReason,
     TriggerType,
@@ -51,13 +52,14 @@ def _run(data_types):
 
 
 class FakeRepository:
-    def __init__(self):
+    def __init__(self, connection_status=ConnectionStatus.ACTIVE):
         self.sync_results = []
+        self.connection_status = connection_status
 
     def get_connection(self):
         return GoogleHealthConnection(
             connection_id="google-health-primary",
-            status=ConnectionStatus.ACTIVE,
+            status=self.connection_status,
             scopes=(),
             created_at=datetime(2026, 6, 1, tzinfo=UTC),
             updated_at=datetime(2026, 6, 1, tzinfo=UTC),
@@ -332,3 +334,22 @@ def test_parse_repair_request_uses_scheduled_time_in_configured_timezone():
     assert request.date_from == date(2026, 5, 20)
     assert request.date_to == date(2026, 6, 3)
     assert request.data_types
+
+
+def test_inactive_connection_workflow_error_includes_status(monkeypatch):
+    """inactive connection の ingest workflow error に status が含まれる。"""
+    # Arrange
+    repository = FakeRepository(connection_status=ConnectionStatus.REVOKED)
+    writer = FakeWriter()
+    monkeypatch.setattr(
+        "pipelines.sources.google_health.workflow._build_dependencies",
+        lambda: _dependencies(repository, writer),
+    )
+
+    # Act & Assert
+    with pytest.raises(RuntimeError) as exc_info:
+        run_google_health_ingest(_run(["steps"]))
+
+    message = str(exc_info.value)
+    assert "google_health_active_connection_not_found" in message
+    assert "status=revoked" in message


### PR DESCRIPTION
## Summary
- Persist safe Google Health OAuth refresh diagnostics without storing provider free text or token-like values
- Keep transient refresh failures such as 429/5xx from marking the connection inactive
- Include inactive connection status in Google Health workflow precondition errors
- Add a focused implementation plan and unit coverage for diagnostic safety

## Tests
- uv run ruff check egograph/pipelines/sources/google_health/client.py egograph/pipelines/sources/google_health/workflow.py egograph/pipelines/tests/unit/google_health/test_client.py egograph/pipelines/tests/unit/google_health/test_workflow.py
- uv run ruff format --check egograph/pipelines/sources/google_health/client.py egograph/pipelines/sources/google_health/workflow.py egograph/pipelines/tests/unit/google_health/test_client.py egograph/pipelines/tests/unit/google_health/test_workflow.py
- uv run python -m pytest egograph/pipelines/tests/unit/google_health/ -q

## Notes
- docs/data-sources/google-health.md had pre-existing local changes and was intentionally left out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Google Health 認証失敗時の診断情報を安全に要約して保存し、機密の混入を防止。
  * エラー種別に応じて接続ステータスを適切に更新（失効は失効へ／429/5xx は維持）。
  * アクティブでない接続時のエラーメッセージに現在の状態（status）を含めるよう改善。
* **Documentation**
  * OAuth エラー要約・ステータス反映方針を整理した計画ドキュメントを追加。
* **Tests**
  * 接続状態遷移と安全性（機密/許可外情報の非保存）を検証するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->