### PR TITLE
[codex] add shared dataset catalog

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main]
     paths:
+      - "egograph/dataset_catalog/**"
       - "egograph/backend/**"
   pull_request:
     branches: [main]
     paths:
+      - "egograph/dataset_catalog/**"
       - "egograph/backend/**"
 
 jobs:

--- a/.github/workflows/ci-pipelines.yml
+++ b/.github/workflows/ci-pipelines.yml
@@ -5,10 +5,12 @@ on:
   push:
     branches: [main]
     paths:
+      - 'egograph/dataset_catalog/**'
       - 'egograph/pipelines/**'
   pull_request:
     branches: [main]
     paths:
+      - 'egograph/dataset_catalog/**'
       - 'egograph/pipelines/**'
 
 jobs:

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -5,9 +5,11 @@ on:
   push:
     branches: [main]
     paths:
+      - "egograph/dataset_catalog/**"
       - "egograph/backend/**"
       - "pyproject.toml"
       - "uv.lock"
+      - "Dockerfile"
       - ".github/workflows/deploy-backend.yml"
 
 jobs:

--- a/.github/workflows/deploy-pipelines.yml
+++ b/.github/workflows/deploy-pipelines.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "egograph/dataset_catalog/**"
       - "egograph/pipelines/**"
       - "pyproject.toml"
       - "uv.lock"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 RUN pip install --no-cache-dir uv
 
 COPY pyproject.toml uv.lock /app/
+COPY egograph/dataset_catalog /app/egograph/dataset_catalog
 COPY egograph/backend /app/egograph/backend
 COPY egograph/pipelines /app/egograph/pipelines
 

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -77,12 +77,15 @@ Google HealthはRepositoryが接続の生成・破棄をカプセル化し、RES
 
 ### Parquet パス解決
 
-データは月次パーティション（`year=YYYY/month=MM/data.parquet`）で格納されている。
+データセットの物理配置は `dataset_catalog.DatasetDefinition.partition_policy` に従う。イベント系の多くは月次パーティション（`year=YYYY/month=MM/data.parquet`）だが、snapshot dataset は固定ファイル、recursive dataset は配下の Parquet を再帰 glob で読む。
 
-- `build_partition_paths()`: 指定期間の月次パーティションパスを構築
-- `build_dataset_glob()`: データセット全体の glob パターンを構築
+- `dataset_catalog.DatasetDefinition`: dataset id、domain、path、partition、時刻列、compaction 方針を定義
+- `build_partition_paths(config, dataset, utc_start, utc_end)`: 月次 dataset の指定期間に対応する compacted partition path を構築
+- `build_dataset_glob(config, dataset)`: dataset 全体の glob パターンを構築。GitHub repositories のような recursive dataset や、YouTube master のような snapshot dataset も catalog の path を基準に解決する
 
-ローカル優先ロジック: `local_parquet_root` が設定されており、該当パスにファイルが存在すればローカルパスを使用。なければ R2 (s3://) パスを使用。
+ローカル優先ロジック: `local_parquet_root` が設定されており、catalog から導出した該当 local path に Parquet が存在すればローカルパスを使用。なければ同じ catalog 定義から導出した R2 (s3://) パスを使用する。
+
+Dataset Catalog の詳細は [dataset-catalog.md](./dataset-catalog.md) を参照。
 
 ### データソース
 

--- a/docs/architecture/data-strategy.md
+++ b/docs/architecture/data-strategy.md
@@ -202,6 +202,20 @@ s3://{bucket}/
 
 ## 5. 運用ルール
 
+### 5.0 Dataset Catalog
+
+Pipelines が生成し Backend が読む Parquet dataset の物理契約は `dataset_catalog` を正とする。
+
+対象:
+
+- events / master の canonical path
+- monthly / snapshot / recursive の partition 方針
+- dedupe key / sort key
+- event time column
+- compaction strategy
+
+詳細は [dataset-catalog.md](./dataset-catalog.md) を参照。
+
 ### 5.1 判断フローチャート
 
 新しいデータを追加する際は、以下の順で判定する。

--- a/docs/architecture/dataset-catalog.md
+++ b/docs/architecture/dataset-catalog.md
@@ -1,0 +1,67 @@
+# Dataset Catalog
+
+> 最終更新: 2026-06-25
+
+Dataset Catalog は、Pipelines が書き込む Parquet dataset と Backend が読み取る Parquet dataset の共有契約である。
+
+## 目的
+
+EgoGraph の中核境界は「Pipelines が R2 に Parquet を生成し、Backend が DuckDB で読む」ことである。この境界に必要な path、partition、dedupe key、event time column、compaction strategy を `dataset_catalog` に集約する。
+
+これにより、データソース追加時に write path と read path のどちらか片方だけを更新して壊れる状態を避ける。
+
+## 配置
+
+```text
+egograph/dataset_catalog/
+├── __init__.py
+└── catalog.py
+```
+
+Python workspace では `backend` と `pipelines` の両方から `dataset_catalog` として import する。
+
+## Catalog が持つもの
+
+| 項目 | 役割 |
+|---|---|
+| `dataset_id` | 安定した論理ID。例: `spotify.plays` |
+| `provider` | データソース単位。例: `spotify` |
+| `domain` | R2 domain。`events` または `master` |
+| `path` | domain 配下の canonical path |
+| `partition_policy` | `monthly` / `snapshot` / `recursive` |
+| `compaction_strategy` | `append_dedupe` / `range_replace` / `snapshot_upsert` / `none` |
+| `event_time_column` | 期間抽出・partition 判定の基準列 |
+| `dedupe_key` | append-dedupe compaction の一意キー |
+| `sort_key` | 重複時に残す行を決める順序列 |
+| `snapshot_file_name` | snapshot dataset の固定ファイル名 |
+
+## 使用箇所
+
+### Backend
+
+- `backend.infrastructure.database.parquet_paths`
+  - `DatasetDefinition` から compacted local path / R2 path / glob を組み立てる
+- `backend.infrastructure.database.*_queries`
+  - 読み取り対象 dataset を catalog 定義から参照する
+
+### Pipelines
+
+- `pipelines.sources.common.compaction`
+  - `DatasetDefinition` から compacted key を組み立てる
+- `pipelines.sources.*.pipeline`
+  - provider ごとの monthly compaction 対象を `monthly_compaction_datasets()` から取得する
+- `pipelines.sources.google_health.writer`
+  - range replace 対象 dataset と date column を catalog から参照する
+
+## 追加ルール
+
+新しい Parquet dataset を追加する場合は、最初に catalog へ `DatasetDefinition` を追加する。
+
+その後、以下を同じ PR で更新する。
+
+1. Pipelines の保存・compaction 実装
+2. Backend の read path / query 実装
+3. `docs/data-sources/` の該当データソース文書
+4. Catalog と path resolver の unit test
+
+dataset path や dedupe key を各 source module に直接重複定義しない。source 固有の処理手順は source module に残してよいが、dataset の物理契約は catalog を正とする。

--- a/docs/architecture/dataset-catalog.md
+++ b/docs/architecture/dataset-catalog.md
@@ -6,7 +6,7 @@ Dataset Catalog は、Pipelines が書き込む Parquet dataset と Backend が�
 
 ## 目的
 
-EgoGraph の中核境界は「Pipelines が R2 に Parquet を生成し、Backend が DuckDB で読む」ことである。この境界に必要な path、partition、dedupe key、event time column、compaction strategy を `dataset_catalog` に集約する。
+EgoGraph の中核境界は「Pipelines が R2 に Parquet を生成し、Backend が DuckDB で読む」ことである。この境界に必要な path、partition、dedupe key、time column、compaction strategy を `dataset_catalog` に集約する。
 
 これにより、データソース追加時に write path と read path のどちらか片方だけを更新して壊れる状態を避ける。
 
@@ -30,10 +30,21 @@ Python workspace では `backend` と `pipelines` の両方から `dataset_catal
 | `path` | domain 配下の canonical path |
 | `partition_policy` | `monthly` / `snapshot` / `recursive` |
 | `compaction_strategy` | `append_dedupe` / `range_replace` / `snapshot_upsert` / `none` |
-| `event_time_column` | 期間抽出・partition 判定の基準列 |
+| `time_column` | 期間抽出・partition 判定の基準列（events なら event time、master なら updated_at） |
 | `dedupe_key` | append-dedupe compaction の一意キー |
-| `sort_key` | 重複時に残す行を決める順序列 |
+| `sort_key` | 重複時に残す行を決める順序列。dedupe_key と従属関係にある値は決定性を失うため注意 |
 | `snapshot_file_name` | snapshot dataset の固定ファイル名 |
+
+## source と compacted の path 非対称性
+
+`DatasetDefinition` の path 系メソッドは source / compacted で domain 扱いが異なる。
+
+- `source_prefix(root)` / `source_partition_prefix(root, ...)` / `source_glob(root)`
+  - source 側は events / master で root が分かれている（`events_path` / `master_path`）。
+  - よって戻り値に domain は含まない。root の選択は `source_root(events_path, master_path)` で行う。
+- `compacted_prefix(compacted_root)` / `compacted_partition_key(compacted_root, ...)`
+  - compacted 側は単一 root 配下に domain ごとの階層を持つ。
+  - よって戻り値に `{domain}/` を含む。
 
 ## 使用箇所
 

--- a/docs/deploy/backend.md
+++ b/docs/deploy/backend.md
@@ -194,6 +194,17 @@ sudo systemctl status egograph-backend
 main への push をトリガーに本番へデプロイする。
 ワークフローは `.github/workflows/deploy-backend.yml` を使用。
 
+### 6.0 トリガー条件
+
+以下のパスに変更があった場合、main への push で自動デプロイされる:
+
+- `egograph/backend/**`
+- `egograph/dataset_catalog/**`
+- `pyproject.toml`
+- `uv.lock`
+- `Dockerfile`
+- `.github/workflows/deploy-backend.yml`
+
 ### 6.1 事前準備
 
 - LXC に SSH 鍵を配置

--- a/docs/deploy/pipelines.md
+++ b/docs/deploy/pipelines.md
@@ -103,6 +103,7 @@ main への push をトリガーに本番へデプロイする。
 以下のパスに変更があった場合、main への push で自動デプロイされる：
 
 - `egograph/pipelines/**`
+- `egograph/dataset_catalog/**`
 - `pyproject.toml`
 - `uv.lock`
 - `.github/workflows/deploy-pipelines.yml`

--- a/docs/plan/plan-dataset-catalog.md
+++ b/docs/plan/plan-dataset-catalog.md
@@ -1,0 +1,76 @@
+# Dataset Catalog 導入計画
+
+Howはあくまで参考であり、よりよい設計方針があれば各自で判断し採用する
+
+## 目的
+
+Pipelines の write path と Backend の read path に分散している Parquet dataset の契約を、共有 catalog として明文化する。保存先 path、partition、compaction key、event time column を一箇所に寄せ、今後のデータソース追加・schema evolution・compaction 変更で崩れにくい土台を作る。
+
+## スコープ
+
+- 対象は既存の Parquet dataset 契約に限定する。
+- REST / MCP capability 抽象化は行わない。
+- 既存の保存形式・公開 API・R2 layout は変更しない。
+- `docs/data-sources/google-health.md` など既存の未コミット変更は触らない。
+
+## 設計方針
+
+1. 共有 package として `dataset_catalog` を追加する。
+   - Backend / Pipelines の両方から import できる `egograph/dataset_catalog` 配下に置く。
+   - Docker build でも含まれるよう `Dockerfile` の COPY 対象に追加する。
+
+2. catalog は「契約」を表現し、処理 orchestration は持たせない。
+   - dataset id
+   - storage domain
+   - canonical path
+   - partition policy
+   - compaction strategy
+   - dedupe key
+   - sort key
+   - event time column
+   - snapshot file name
+
+3. Backend と Pipelines の既存実装へ段階的に接続する。
+   - Backend の compacted path 解決は `DatasetDefinition` を受け取る API を追加する。
+   - 各 query module の dataset path 直書きを catalog 参照へ置き換える。
+   - Pipelines の monthly compaction 対象リストを catalog 参照へ置き換える。
+   - Google Health の range replace は date column mapping を catalog から参照する。
+
+4. 旧 API は残さず catalog-aware API へ置き換える。
+   - `build_partition_paths(data_domain, dataset_path, ...)` のような文字列指定 API は削除する。
+   - Backend / Pipelines / tests は `DatasetDefinition` を受け取る新 API に揃える。
+
+## 実装タスク
+
+1. WT作成
+   - `origin/main` から `feat/dataset-catalog` の git worktree を作成する。
+   - 既存 worktree の未コミット変更は取り込まない。
+2. 実装(TDD)
+   - Catalog / path resolver の unit test を先に追加する。
+   - `dataset_catalog` package を追加する。
+   - Backend path resolver と query modules を catalog-aware に置き換える。
+   - Pipelines compaction / writer の dataset metadata を catalog 参照に置き換える。
+   - 関連 docs を更新する。
+3. 検証
+   - `ruff`, backend/pipelines の関連 pytest、必要に応じて全体 pytest を実行する。
+4. 自己レビュー
+   - 不要な抽象、残った文字列重複、旧 API の残存、docs の不足を確認する。
+5. コミット(意味ごとに分離)
+   - 原則 `feat: add shared dataset catalog` にまとめる。
+   - docs だけ独立させる意味が出た場合は `docs: document dataset catalog` を分ける。
+6. PR作成
+   - push 後、draft PR を作成する。
+
+## 検証計画
+
+- `uv run ruff check .`
+- `uv run pytest egograph/backend/tests/unit/database/test_parquet_paths.py`
+- `uv run pytest egograph/backend/tests/unit/database/test_queries.py egograph/backend/tests/unit/database/test_browser_history_queries.py egograph/backend/tests/unit/repositories/test_google_health_queries.py egograph/backend/tests/unit/repositories/test_youtube_queries.py`
+- `uv run pytest egograph/pipelines/tests/unit/test_compaction.py egograph/pipelines/tests/unit/test_bootstrap_compact.py egograph/pipelines/tests/unit/spotify/test_storage.py egograph/pipelines/tests/unit/github/test_storage.py egograph/pipelines/tests/unit/browser_history/test_storage.py egograph/pipelines/tests/unit/youtube/test_storage_compact.py egograph/pipelines/tests/unit/google_health/test_writer.py`
+- 変更範囲が広がる場合は `uv run pytest egograph/backend/tests egograph/pipelines/tests/unit`
+
+## PR 方針
+
+- ブランチ: `feat/dataset-catalog`
+- コミット: `feat: add shared dataset catalog`
+- PR description は日本語で、設計意図・変更範囲・検証結果・自己レビュー結果を記載する。

--- a/egograph/backend/api/health.py
+++ b/egograph/backend/api/health.py
@@ -3,6 +3,7 @@
 import logging
 
 import duckdb
+from dataset_catalog import datasets
 from fastapi import APIRouter, Depends
 
 from backend.config import BackendConfig
@@ -59,8 +60,7 @@ async def health_check(
         # DuckDB + R2接続のテスト（軽量なクエリで確認）
         parquet_path = build_dataset_glob(
             config.r2,
-            data_domain="events",
-            dataset_path="spotify/plays",
+            datasets.SPOTIFY_PLAYS,
         )
 
         with db_connection as conn:

--- a/egograph/backend/infrastructure/database/browser_history_queries.py
+++ b/egograph/backend/infrastructure/database/browser_history_queries.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from dataset_catalog import datasets
+
 from backend.constants import DEFAULT_PAGE_VIEWS_LIMIT, DEFAULT_TOP_DOMAINS_LIMIT
 from backend.infrastructure.database.parquet_paths import build_partition_paths
 from backend.infrastructure.database.query_params import QueryParams, execute_query
@@ -12,8 +14,7 @@ _RELOAD_FILTER_CLAUSE = " AND (? OR transition IS DISTINCT FROM 'reload')"
 def _resolve_partition_paths(params: QueryParams) -> list[str]:
     return build_partition_paths(
         params.r2_config,
-        data_domain="events",
-        dataset_path="browser_history/page_views",
+        datasets.BROWSER_HISTORY_PAGE_VIEWS,
         utc_start=params.utc_start,
         utc_end=params.utc_end,
     )

--- a/egograph/backend/infrastructure/database/github_queries.py
+++ b/egograph/backend/infrastructure/database/github_queries.py
@@ -3,14 +3,12 @@
 import logging
 from typing import Any
 
+from dataset_catalog import datasets
+
 from backend.infrastructure.database.parquet_paths import build_partition_paths
 from backend.infrastructure.database.query_params import QueryParams, execute_query
 
 logger = logging.getLogger(__name__)
-
-
-# Parquetパスパターン
-GITHUB_REPOS_PATH = "s3://{bucket}/{master_path}github/repositories/**/*.parquet"
 
 
 def get_repos_parquet_path(bucket: str, master_path: str) -> str:
@@ -23,14 +21,13 @@ def get_repos_parquet_path(bucket: str, master_path: str) -> str:
     Returns:
         S3パスパターン（例: s3://egograph/master/github/repositories/**/*.parquet）
     """
-    return GITHUB_REPOS_PATH.format(bucket=bucket, master_path=master_path)
+    return f"s3://{bucket}/{datasets.GITHUB_REPOSITORIES.source_glob(master_path)}"
 
 
 def _resolve_pr_partition_paths(params: QueryParams) -> list[str]:
     return build_partition_paths(
         params.r2_config,
-        data_domain="events",
-        dataset_path="github/pull_requests",
+        datasets.GITHUB_PULL_REQUESTS,
         utc_start=params.utc_start,
         utc_end=params.utc_end,
     )
@@ -39,8 +36,7 @@ def _resolve_pr_partition_paths(params: QueryParams) -> list[str]:
 def _resolve_commit_partition_paths(params: QueryParams) -> list[str]:
     return build_partition_paths(
         params.r2_config,
-        data_domain="events",
-        dataset_path="github/commits",
+        datasets.GITHUB_COMMITS,
         utc_start=params.utc_start,
         utc_end=params.utc_end,
     )

--- a/egograph/backend/infrastructure/database/google_health_queries.py
+++ b/egograph/backend/infrastructure/database/google_health_queries.py
@@ -3,6 +3,8 @@
 from datetime import date
 from typing import Any
 
+from dataset_catalog import datasets
+
 from backend.infrastructure.database.parquet_paths import build_dataset_glob
 from backend.infrastructure.database.query_params import QueryParams
 
@@ -11,8 +13,7 @@ def _resolve_daily_metric_paths(params: QueryParams) -> list[str]:
     """存在するdaily_metricsから対象月のParquetだけを解決する。"""
     dataset_glob = build_dataset_glob(
         params.r2_config,
-        data_domain="events",
-        dataset_path="google_health/daily_metrics",
+        datasets.GOOGLE_HEALTH_DAILY_METRICS,
     )
     rows = params.conn.execute(
         "SELECT file FROM glob(?) ORDER BY file",

--- a/egograph/backend/infrastructure/database/parquet_paths.py
+++ b/egograph/backend/infrastructure/database/parquet_paths.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
 
+from dataset_catalog import DatasetDefinition
+
 from backend.config import R2Config
 
 COMPACTED_ROOT = "compacted/"
@@ -39,15 +41,12 @@ def _iter_months(utc_start: datetime, utc_end: datetime) -> list[PartitionRef]:
 
 def _build_local_compacted_file(
     local_root: str,
-    data_domain: str,
-    dataset_path: str,
+    dataset: DatasetDefinition,
     partition: PartitionRef,
 ) -> Path:
     return (
         Path(local_root)
-        / "compacted"
-        / data_domain
-        / dataset_path
+        / dataset.compacted_prefix(COMPACTED_ROOT)
         / f"year={partition.year}"
         / f"month={partition.month:02d}"
         / "data.parquet"
@@ -56,20 +55,20 @@ def _build_local_compacted_file(
 
 def _build_r2_compacted_file(
     config: R2Config,
-    data_domain: str,
-    dataset_path: str,
+    dataset: DatasetDefinition,
     partition: PartitionRef,
 ) -> str:
-    return (
-        f"s3://{config.bucket_name}/{COMPACTED_ROOT}{data_domain}/{dataset_path}/"
-        f"year={partition.year}/month={partition.month:02d}/data.parquet"
+    key = dataset.compacted_partition_key(
+        COMPACTED_ROOT,
+        year=partition.year,
+        month=partition.month,
     )
+    return f"s3://{config.bucket_name}/{key}"
 
 
 def build_partition_paths(
     config: R2Config,
-    data_domain: str,
-    dataset_path: str,
+    dataset: DatasetDefinition,
     utc_start: datetime,
     utc_end: datetime,
 ) -> list[str]:
@@ -78,7 +77,9 @@ def build_partition_paths(
     for partition in _iter_months(utc_start, utc_end):
         local_path = (
             _build_local_compacted_file(
-                config.local_parquet_root, data_domain, dataset_path, partition
+                config.local_parquet_root,
+                dataset,
+                partition,
             )
             if config.local_parquet_root
             else None
@@ -87,27 +88,24 @@ def build_partition_paths(
             paths.append(str(local_path))
             continue
 
-        paths.append(
-            _build_r2_compacted_file(config, data_domain, dataset_path, partition)
-        )
+        paths.append(_build_r2_compacted_file(config, dataset, partition))
 
     return paths
 
 
 def build_dataset_glob(
     config: R2Config,
-    data_domain: str,
-    dataset_path: str,
+    dataset: DatasetDefinition,
 ) -> str:
     """Build all-data glob for compacted datasets."""
     if config.local_parquet_root:
-        local_root = (
-            Path(config.local_parquet_root) / "compacted" / data_domain / dataset_path
+        local_root = Path(config.local_parquet_root) / dataset.compacted_prefix(
+            COMPACTED_ROOT
         )
         if any(local_root.rglob("*.parquet")):
             return str(local_root / "**" / "*.parquet")
 
     return (
-        f"s3://{config.bucket_name}/{COMPACTED_ROOT}{data_domain}/"
-        f"{dataset_path}/**/*.parquet"
+        f"s3://{config.bucket_name}/"
+        f"{dataset.compacted_prefix(COMPACTED_ROOT)}**/*.parquet"
     )

--- a/egograph/backend/infrastructure/database/queries.py
+++ b/egograph/backend/infrastructure/database/queries.py
@@ -3,6 +3,8 @@
 import logging
 from typing import Any
 
+from dataset_catalog import datasets
+
 from backend.constants import (
     DEFAULT_TOP_TRACKS_LIMIT,
     MS_TO_MINUTES_FACTOR,
@@ -15,10 +17,6 @@ from backend.infrastructure.database.query_params import QueryParams, execute_qu
 logger = logging.getLogger(__name__)
 
 
-# Parquetパスパターン
-SPOTIFY_PLAYS_PATH = "s3://{bucket}/{events_path}spotify/plays/**/*.parquet"
-
-
 def get_parquet_path(bucket: str, events_path: str) -> str:
     """Spotify再生履歴のS3パスパターンを生成します。
 
@@ -29,14 +27,13 @@ def get_parquet_path(bucket: str, events_path: str) -> str:
     Returns:
         S3パスパターン（例: s3://egograph/events/spotify/plays/**/*.parquet）
     """
-    return SPOTIFY_PLAYS_PATH.format(bucket=bucket, events_path=events_path)
+    return f"s3://{bucket}/{datasets.SPOTIFY_PLAYS.source_glob(events_path)}"
 
 
 def _resolve_partition_paths(params: QueryParams) -> list[str]:
     return build_partition_paths(
         params.r2_config,
-        data_domain="events",
-        dataset_path="spotify/plays",
+        datasets.SPOTIFY_PLAYS,
         utc_start=params.utc_start,
         utc_end=params.utc_end,
     )

--- a/egograph/backend/infrastructure/database/youtube_queries.py
+++ b/egograph/backend/infrastructure/database/youtube_queries.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 import duckdb
+from dataset_catalog import datasets
 
 from backend.constants import DEFAULT_TOP_TRACKS_LIMIT
 from backend.infrastructure.database.parquet_paths import build_partition_paths
@@ -13,27 +14,24 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_WATCH_EVENTS_LIMIT = 100_000
 
-YOUTUBE_VIDEOS_PATH = "s3://{bucket}/{master_path}youtube/videos/data.parquet"
-YOUTUBE_CHANNELS_PATH = "s3://{bucket}/{master_path}youtube/channels/data.parquet"
 WATCHED_AT_UTC_EXPR = "make_timestamp(epoch_us(watched_at_utc))"
 WATCHED_AT_UTC_W_EXPR = "make_timestamp(epoch_us(w.watched_at_utc))"
 
 
 def get_videos_parquet_path(bucket: str, master_path: str) -> str:
     """YouTube動画マスターのS3パスパターンを生成します。"""
-    return YOUTUBE_VIDEOS_PATH.format(bucket=bucket, master_path=master_path)
+    return f"s3://{bucket}/{datasets.YOUTUBE_VIDEOS.source_snapshot_key(master_path)}"
 
 
 def get_channels_parquet_path(bucket: str, master_path: str) -> str:
     """YouTubeチャンネルマスターのS3パスパターンを生成します。"""
-    return YOUTUBE_CHANNELS_PATH.format(bucket=bucket, master_path=master_path)
+    return f"s3://{bucket}/{datasets.YOUTUBE_CHANNELS.source_snapshot_key(master_path)}"
 
 
 def _resolve_watch_event_paths(params: QueryParams) -> list[str]:
     return build_partition_paths(
         params.r2_config,
-        data_domain="events",
-        dataset_path="youtube/watch_events",
+        datasets.YOUTUBE_WATCH_EVENTS,
         utc_start=params.utc_start,
         utc_end=params.utc_end,
     )

--- a/egograph/backend/infrastructure/logging/sanitizers.py
+++ b/egograph/backend/infrastructure/logging/sanitizers.py
@@ -46,8 +46,8 @@ def sanitize_exception(exc: Exception) -> str:
 class InfraSanitizingFilter(logging.Filter):
     """ログレコードからインフラ情報を自動的にマスクする logging.Filter。
 
-    - record.msg をサニタイズする
-    - record.args をクリアし、未サニタイズ値での再フォーマットを防止する
+    - record.msg を args 展開済みの完全メッセージにしてからサニタイズする
+    - record.args をクリアし、再フォーマットを防止する
     - record.exc_info がある場合、トレースバックをフォーマットしてサニタイズする
     - record.exc_text（トレースバック）が存在すればサニタイズする
     - すべてのレコードを通過させる（ドロップしない）
@@ -56,6 +56,10 @@ class InfraSanitizingFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         """ログレコードをサニタイズして通過させる。
 
+        msg と args を先にフォーマット展開し、完全なメッセージをサニタイズする。
+        これにより args に含まれる秘密もマスク対象になり、args クリア後も
+        プレースホルダが未展開で残らない。フォーマット失敗時は生 msg を扱う。
+
         Args:
             record: フィルタ対象のログレコード。
 
@@ -63,7 +67,11 @@ class InfraSanitizingFilter(logging.Filter):
             常に True（レコードをドロップしない）。
         """
         if isinstance(record.msg, str):
-            record.msg = sanitize_infra_message(record.msg)
+            try:
+                message = record.getMessage()
+            except (TypeError, ValueError):
+                message = record.msg
+            record.msg = sanitize_infra_message(message)
 
         record.args = None
 

--- a/egograph/backend/tests/unit/database/test_parquet_paths.py
+++ b/egograph/backend/tests/unit/database/test_parquet_paths.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 
+from dataset_catalog import datasets
 from pydantic import SecretStr
 
 from backend.config import R2Config
@@ -46,8 +47,7 @@ class TestBuildPartitionPaths:
 
         paths = build_partition_paths(
             config,
-            data_domain="events",
-            dataset_path="spotify/plays",
+            datasets.SPOTIFY_PLAYS,
             utc_start=datetime(2024, 1, 1),
             utc_end=datetime(2024, 2, 1),
         )
@@ -60,8 +60,7 @@ class TestBuildPartitionPaths:
 
         paths = build_partition_paths(
             config,
-            data_domain="events",
-            dataset_path="spotify/plays",
+            datasets.SPOTIFY_PLAYS,
             utc_start=datetime(2024, 1, 1),
             utc_end=datetime(2024, 2, 1),
         )
@@ -92,8 +91,7 @@ class TestBuildDatasetGlob:
 
         path = build_dataset_glob(
             config,
-            data_domain="master",
-            dataset_path="spotify/tracks",
+            datasets.SPOTIFY_TRACKS,
         )
 
         assert path == str(
@@ -111,8 +109,7 @@ class TestBuildDatasetGlob:
 
         path = build_dataset_glob(
             config,
-            data_domain="master",
-            dataset_path="spotify/tracks",
+            datasets.SPOTIFY_TRACKS,
         )
 
         assert path == "s3://test-bucket/compacted/master/spotify/tracks/**/*.parquet"

--- a/egograph/backend/tests/unit/logging/test_sanitizers.py
+++ b/egograph/backend/tests/unit/logging/test_sanitizers.py
@@ -187,6 +187,30 @@ class TestInfraSanitizingFilter:
         # Assert
         assert record.args is None
 
+    def test_infra_sanitizing_filter_interpolates_then_masks_args(self):
+        """args を先に展開してサニタイズする（%s 未展開・秘密漏洩を防ぐ）。"""
+        # Arrange
+        filt = InfraSanitizingFilter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Connecting to %s",
+            args=("s3://secret-bucket/path",),
+            exc_info=None,
+        )
+
+        # Act
+        filt.filter(record)
+
+        # Assert: %s は展開済みで、args 内の秘密はマスクされる
+        message = record.getMessage()
+        assert "%s" not in message
+        assert "secret-bucket" not in message
+        assert "s3://" not in message
+        assert "***" in message
+
 
 class TestFilterRegistration:
     """アプリケーション起動時のフィルター登録テスト。"""

--- a/egograph/backend/tests/unit/repositories/test_youtube_queries.py
+++ b/egograph/backend/tests/unit/repositories/test_youtube_queries.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
+from dataset_catalog import datasets
 
 from backend.config import R2Config
 from backend.infrastructure.database.parquet_paths import build_partition_paths
@@ -113,7 +114,10 @@ class TestBuildPartitionPaths:
         end = datetime(2024, 2, 1)
 
         paths = build_partition_paths(
-            mock_r2_config, "events", "youtube/watch_events", start, end
+            mock_r2_config,
+            datasets.YOUTUBE_WATCH_EVENTS,
+            start,
+            end,
         )
 
         assert len(paths) == 2  # Jan + Feb
@@ -125,7 +129,10 @@ class TestBuildPartitionPaths:
         end = datetime(2025, 2, 1)
 
         paths = build_partition_paths(
-            mock_r2_config, "events", "youtube/watch_events", start, end
+            mock_r2_config,
+            datasets.YOUTUBE_WATCH_EVENTS,
+            start,
+            end,
         )
 
         assert len(paths) == 4
@@ -136,7 +143,10 @@ class TestBuildPartitionPaths:
         end = datetime(2024, 2, 1)
 
         paths = build_partition_paths(
-            mock_r2_config, "events", "youtube/watch_events", start, end
+            mock_r2_config,
+            datasets.YOUTUBE_WATCH_EVENTS,
+            start,
+            end,
         )
 
         assert len(paths) == 3
@@ -167,8 +177,7 @@ class TestResolveWatchEventPaths:
         assert paths == expected
         mock_func.assert_called_once_with(
             mock_r2_config,
-            data_domain="events",
-            dataset_path="youtube/watch_events",
+            datasets.YOUTUBE_WATCH_EVENTS,
             utc_start=params.utc_start,
             utc_end=params.utc_end,
         )

--- a/egograph/backend/tests/unit/test_dataset_catalog.py
+++ b/egograph/backend/tests/unit/test_dataset_catalog.py
@@ -2,6 +2,7 @@
 
 import pytest
 from dataset_catalog import (
+    ALL_DATASETS,
     CompactionStrategy,
     DataDomain,
     DatasetDefinition,
@@ -24,11 +25,11 @@ def test_catalog_resolves_dataset_by_id():
     assert dataset.compaction_strategy is CompactionStrategy.APPEND_DEDUPE
     assert dataset.dedupe_key == "play_id"
     assert dataset.sort_key == "played_at_utc"
-    assert dataset.event_time_column == "played_at_utc"
+    assert dataset.time_column == "played_at_utc"
 
 
-def test_monthly_compaction_datasets_are_explicitly_ordered():
-    """monthly compaction 対象が provider ごとに明示順で取得できる。"""
+def test_monthly_compaction_datasets_covers_only_append_dedupe_providers():
+    """monthly compaction 対象が append_dedupe provider 全てを定義順で返す。"""
     assert monthly_compaction_datasets("spotify") == (
         datasets.SPOTIFY_PLAYS,
         datasets.SPOTIFY_TRACKS,
@@ -38,6 +39,60 @@ def test_monthly_compaction_datasets_are_explicitly_ordered():
         datasets.GITHUB_COMMITS,
         datasets.GITHUB_PULL_REQUESTS,
     )
+    assert monthly_compaction_datasets("browser_history") == (
+        datasets.BROWSER_HISTORY_PAGE_VIEWS,
+    )
+    assert monthly_compaction_datasets("youtube") == (
+        datasets.YOUTUBE_WATCH_EVENTS,
+    )
+
+
+def test_monthly_compaction_datasets_excludes_non_append_dedupe_provider():
+    """range_replace の provider (google_health) は対象外で KeyError。"""
+    with pytest.raises(KeyError, match="unknown_provider: google_health"):
+        monthly_compaction_datasets("google_health")
+
+
+def test_monthly_compaction_datasets_derived_in_definition_order():
+    """導出結果が ALL_DATASETS の定義順に一致する（drift 検出の regression guard）。"""
+    expected_spotify = tuple(
+        d
+        for d in ALL_DATASETS
+        if d.provider == "spotify"
+        and d.partition_policy is PartitionPolicy.MONTHLY
+        and d.compaction_strategy is CompactionStrategy.APPEND_DEDUPE
+    )
+    assert monthly_compaction_datasets("spotify") == expected_spotify
+
+
+def test_browser_history_sort_key_uses_ingestion_time():
+    """browser_history の sort_key は ingested_at_utc（run をまたいだ決定的勝者）。"""
+    assert datasets.BROWSER_HISTORY_PAGE_VIEWS.sort_key == "ingested_at_utc"
+
+
+def test_source_root_selects_by_domain():
+    """source_root は domain に応じて events / master の root を選ぶ。"""
+    events = "events/"
+    master = "master/"
+
+    assert datasets.SPOTIFY_PLAYS.source_root(events, master) == events
+    assert datasets.SPOTIFY_TRACKS.source_root(events, master) == master
+
+
+def test_required_dedupe_key_returns_key_or_raises():
+    """required_dedupe_key は設定済みなら返し、未設定ならエラー。"""
+    assert datasets.SPOTIFY_PLAYS.required_dedupe_key() == "play_id"
+
+    no_dedupe = DatasetDefinition(
+        dataset_id="test.none",
+        provider="test",
+        domain=DataDomain.EVENTS,
+        path="test/none",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.NONE,
+    )
+    with pytest.raises(ValueError, match="dedupe_key_required: test.none"):
+        no_dedupe.required_dedupe_key()
 
 
 def test_dataset_builds_storage_paths():

--- a/egograph/backend/tests/unit/test_dataset_catalog.py
+++ b/egograph/backend/tests/unit/test_dataset_catalog.py
@@ -1,0 +1,85 @@
+"""Dataset catalog tests."""
+
+import pytest
+from dataset_catalog import (
+    CompactionStrategy,
+    DataDomain,
+    DatasetDefinition,
+    PartitionPolicy,
+    datasets,
+    get_dataset,
+    monthly_compaction_datasets,
+)
+from dataset_catalog.catalog import _build_datasets_by_id
+
+
+def test_catalog_resolves_dataset_by_id():
+    """dataset id から定義を取得できる。"""
+    dataset = get_dataset("spotify.plays")
+
+    assert dataset is datasets.SPOTIFY_PLAYS
+    assert dataset.domain is DataDomain.EVENTS
+    assert dataset.path == "spotify/plays"
+    assert dataset.partition_policy is PartitionPolicy.MONTHLY
+    assert dataset.compaction_strategy is CompactionStrategy.APPEND_DEDUPE
+    assert dataset.dedupe_key == "play_id"
+    assert dataset.sort_key == "played_at_utc"
+    assert dataset.event_time_column == "played_at_utc"
+
+
+def test_monthly_compaction_datasets_are_explicitly_ordered():
+    """monthly compaction 対象が provider ごとに明示順で取得できる。"""
+    assert monthly_compaction_datasets("spotify") == (
+        datasets.SPOTIFY_PLAYS,
+        datasets.SPOTIFY_TRACKS,
+        datasets.SPOTIFY_ARTISTS,
+    )
+    assert monthly_compaction_datasets("github") == (
+        datasets.GITHUB_COMMITS,
+        datasets.GITHUB_PULL_REQUESTS,
+    )
+
+
+def test_dataset_builds_storage_paths():
+    """dataset 定義から source / compacted path を生成できる。"""
+    dataset = datasets.BROWSER_HISTORY_PAGE_VIEWS
+
+    assert dataset.source_partition_prefix("events/", year=2026, month=4) == (
+        "events/browser_history/page_views/year=2026/month=04/"
+    )
+    assert dataset.compacted_partition_key("compacted/", year=2026, month=4) == (
+        "compacted/events/browser_history/page_views/year=2026/month=04/data.parquet"
+    )
+    assert datasets.GITHUB_REPOSITORIES.source_glob("master/") == (
+        "master/github/repositories/**/*.parquet"
+    )
+
+
+def test_snapshot_dataset_builds_fixed_source_key():
+    """snapshot dataset は固定 source key を生成できる。"""
+    assert datasets.YOUTUBE_VIDEOS.source_snapshot_key("master/") == (
+        "master/youtube/videos/data.parquet"
+    )
+
+
+def test_duplicate_dataset_id_fails_fast():
+    """dataset id の重複は catalog 構築時に検知する。"""
+    duplicate_a = DatasetDefinition(
+        dataset_id="duplicate.dataset",
+        provider="test",
+        domain=DataDomain.EVENTS,
+        path="test/a",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.NONE,
+    )
+    duplicate_b = DatasetDefinition(
+        dataset_id="duplicate.dataset",
+        provider="test",
+        domain=DataDomain.EVENTS,
+        path="test/b",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.NONE,
+    )
+
+    with pytest.raises(ValueError, match="duplicate_dataset_id: duplicate.dataset"):
+        _build_datasets_by_id((duplicate_a, duplicate_b))

--- a/egograph/dataset_catalog/__init__.py
+++ b/egograph/dataset_catalog/__init__.py
@@ -1,0 +1,28 @@
+"""共有 Dataset Catalog。
+
+Pipelines の保存契約と Backend の読み取り契約を同じ定義から参照する。
+"""
+
+from dataset_catalog.catalog import (
+    ALL_DATASETS,
+    DATASETS_BY_ID,
+    CompactionStrategy,
+    DataDomain,
+    DatasetDefinition,
+    PartitionPolicy,
+    datasets,
+    get_dataset,
+    monthly_compaction_datasets,
+)
+
+__all__ = [
+    "ALL_DATASETS",
+    "DATASETS_BY_ID",
+    "CompactionStrategy",
+    "DataDomain",
+    "DatasetDefinition",
+    "PartitionPolicy",
+    "datasets",
+    "get_dataset",
+    "monthly_compaction_datasets",
+]

--- a/egograph/dataset_catalog/catalog.py
+++ b/egograph/dataset_catalog/catalog.py
@@ -1,0 +1,304 @@
+"""Parquet dataset catalog definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class DataDomain(StrEnum):
+    """R2 上のデータ分類。"""
+
+    EVENTS = "events"
+    MASTER = "master"
+
+
+class PartitionPolicy(StrEnum):
+    """Dataset の物理配置方針。"""
+
+    MONTHLY = "monthly"
+    SNAPSHOT = "snapshot"
+    RECURSIVE = "recursive"
+
+
+class CompactionStrategy(StrEnum):
+    """Compacted dataset の生成戦略。"""
+
+    APPEND_DEDUPE = "append_dedupe"
+    RANGE_REPLACE = "range_replace"
+    SNAPSHOT_UPSERT = "snapshot_upsert"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class DatasetDefinition:
+    """Parquet dataset の境界契約。"""
+
+    dataset_id: str
+    provider: str
+    domain: DataDomain
+    path: str
+    partition_policy: PartitionPolicy
+    compaction_strategy: CompactionStrategy
+    event_time_column: str | None = None
+    dedupe_key: str | None = None
+    sort_key: str | None = None
+    snapshot_file_name: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.path.startswith("/") or self.path.endswith("/"):
+            raise ValueError(f"invalid_dataset_path: {self.path}")
+        if self.partition_policy is PartitionPolicy.SNAPSHOT and not (
+            self.snapshot_file_name
+        ):
+            raise ValueError(f"snapshot_file_name_required: {self.dataset_id}")
+        if (
+            self.compaction_strategy is CompactionStrategy.APPEND_DEDUPE
+            and not self.dedupe_key
+        ):
+            raise ValueError(f"dedupe_key_required: {self.dataset_id}")
+
+    def source_prefix(self, root_path: str) -> str:
+        """events/master root から dataset prefix を組み立てる。"""
+        return f"{_normalize_path(root_path)}{self.path}/"
+
+    def source_partition_prefix(self, root_path: str, *, year: int, month: int) -> str:
+        """月次 partition の source prefix を組み立てる。"""
+        return f"{self.source_prefix(root_path)}year={year}/month={month:02d}/"
+
+    def source_glob(self, root_path: str) -> str:
+        """source dataset 全体の再帰 glob を組み立てる。"""
+        return f"{self.source_prefix(root_path)}**/*.parquet"
+
+    def source_snapshot_key(self, root_path: str) -> str:
+        """snapshot dataset の固定 source key を組み立てる。"""
+        if not self.snapshot_file_name:
+            raise ValueError(f"snapshot_file_name_required: {self.dataset_id}")
+        return f"{self.source_prefix(root_path)}{self.snapshot_file_name}"
+
+    def compacted_prefix(self, compacted_root: str) -> str:
+        """compacted root から dataset prefix を組み立てる。"""
+        return f"{_normalize_path(compacted_root)}{self.domain.value}/{self.path}/"
+
+    def compacted_partition_key(
+        self,
+        compacted_root: str,
+        *,
+        year: int,
+        month: int,
+    ) -> str:
+        """月次 compacted parquet key を組み立てる。"""
+        return (
+            f"{self.compacted_prefix(compacted_root)}"
+            f"year={year}/month={month:02d}/data.parquet"
+        )
+
+
+def _normalize_path(path: str) -> str:
+    return path.rstrip("/") + "/"
+
+
+class datasets:
+    """Dataset 定義の名前空間。"""
+
+    SPOTIFY_PLAYS = DatasetDefinition(
+        dataset_id="spotify.plays",
+        provider="spotify",
+        domain=DataDomain.EVENTS,
+        path="spotify/plays",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
+        event_time_column="played_at_utc",
+        dedupe_key="play_id",
+        sort_key="played_at_utc",
+    )
+    SPOTIFY_TRACKS = DatasetDefinition(
+        dataset_id="spotify.tracks",
+        provider="spotify",
+        domain=DataDomain.MASTER,
+        path="spotify/tracks",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
+        event_time_column="updated_at",
+        dedupe_key="track_id",
+        sort_key="updated_at",
+    )
+    SPOTIFY_ARTISTS = DatasetDefinition(
+        dataset_id="spotify.artists",
+        provider="spotify",
+        domain=DataDomain.MASTER,
+        path="spotify/artists",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
+        event_time_column="updated_at",
+        dedupe_key="artist_id",
+        sort_key="updated_at",
+    )
+    GITHUB_COMMITS = DatasetDefinition(
+        dataset_id="github.commits",
+        provider="github",
+        domain=DataDomain.EVENTS,
+        path="github/commits",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
+        event_time_column="committed_at_utc",
+        dedupe_key="commit_event_id",
+        sort_key="committed_at_utc",
+    )
+    GITHUB_PULL_REQUESTS = DatasetDefinition(
+        dataset_id="github.pull_requests",
+        provider="github",
+        domain=DataDomain.EVENTS,
+        path="github/pull_requests",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
+        event_time_column="updated_at_utc",
+        dedupe_key="pr_event_id",
+        sort_key="updated_at_utc",
+    )
+    GITHUB_REPOSITORIES = DatasetDefinition(
+        dataset_id="github.repositories",
+        provider="github",
+        domain=DataDomain.MASTER,
+        path="github/repositories",
+        partition_policy=PartitionPolicy.RECURSIVE,
+        compaction_strategy=CompactionStrategy.NONE,
+        event_time_column="updated_at_utc",
+    )
+    BROWSER_HISTORY_PAGE_VIEWS = DatasetDefinition(
+        dataset_id="browser_history.page_views",
+        provider="browser_history",
+        domain=DataDomain.EVENTS,
+        path="browser_history/page_views",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
+        event_time_column="started_at_utc",
+        dedupe_key="page_view_id",
+        sort_key="started_at_utc",
+    )
+    YOUTUBE_WATCH_EVENTS = DatasetDefinition(
+        dataset_id="youtube.watch_events",
+        provider="youtube",
+        domain=DataDomain.EVENTS,
+        path="youtube/watch_events",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
+        event_time_column="watched_at_utc",
+        dedupe_key="watch_event_id",
+        sort_key="watched_at_utc",
+    )
+    YOUTUBE_VIDEOS = DatasetDefinition(
+        dataset_id="youtube.videos",
+        provider="youtube",
+        domain=DataDomain.MASTER,
+        path="youtube/videos",
+        partition_policy=PartitionPolicy.SNAPSHOT,
+        compaction_strategy=CompactionStrategy.SNAPSHOT_UPSERT,
+        snapshot_file_name="data.parquet",
+    )
+    YOUTUBE_CHANNELS = DatasetDefinition(
+        dataset_id="youtube.channels",
+        provider="youtube",
+        domain=DataDomain.MASTER,
+        path="youtube/channels",
+        partition_policy=PartitionPolicy.SNAPSHOT,
+        compaction_strategy=CompactionStrategy.SNAPSHOT_UPSERT,
+        snapshot_file_name="data.parquet",
+    )
+    GOOGLE_HEALTH_DAILY_METRICS = DatasetDefinition(
+        dataset_id="google_health.daily_metrics",
+        provider="google_health",
+        domain=DataDomain.EVENTS,
+        path="google_health/daily_metrics",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.RANGE_REPLACE,
+        event_time_column="date",
+    )
+    GOOGLE_HEALTH_SAMPLES = DatasetDefinition(
+        dataset_id="google_health.samples",
+        provider="google_health",
+        domain=DataDomain.EVENTS,
+        path="google_health/samples",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.RANGE_REPLACE,
+        event_time_column="measured_at_utc",
+    )
+    GOOGLE_HEALTH_INTERVALS = DatasetDefinition(
+        dataset_id="google_health.intervals",
+        provider="google_health",
+        domain=DataDomain.EVENTS,
+        path="google_health/intervals",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.RANGE_REPLACE,
+        event_time_column="started_at_utc",
+    )
+    GOOGLE_HEALTH_SESSIONS = DatasetDefinition(
+        dataset_id="google_health.sessions",
+        provider="google_health",
+        domain=DataDomain.EVENTS,
+        path="google_health/sessions",
+        partition_policy=PartitionPolicy.MONTHLY,
+        compaction_strategy=CompactionStrategy.RANGE_REPLACE,
+        event_time_column="started_at_utc",
+    )
+
+
+ALL_DATASETS = (
+    datasets.SPOTIFY_PLAYS,
+    datasets.SPOTIFY_TRACKS,
+    datasets.SPOTIFY_ARTISTS,
+    datasets.GITHUB_COMMITS,
+    datasets.GITHUB_PULL_REQUESTS,
+    datasets.GITHUB_REPOSITORIES,
+    datasets.BROWSER_HISTORY_PAGE_VIEWS,
+    datasets.YOUTUBE_WATCH_EVENTS,
+    datasets.YOUTUBE_VIDEOS,
+    datasets.YOUTUBE_CHANNELS,
+    datasets.GOOGLE_HEALTH_DAILY_METRICS,
+    datasets.GOOGLE_HEALTH_SAMPLES,
+    datasets.GOOGLE_HEALTH_INTERVALS,
+    datasets.GOOGLE_HEALTH_SESSIONS,
+)
+
+def _build_datasets_by_id(
+    dataset_definitions: tuple[DatasetDefinition, ...],
+) -> dict[str, DatasetDefinition]:
+    datasets_by_id: dict[str, DatasetDefinition] = {}
+    for dataset in dataset_definitions:
+        if dataset.dataset_id in datasets_by_id:
+            raise ValueError(f"duplicate_dataset_id: {dataset.dataset_id}")
+        datasets_by_id[dataset.dataset_id] = dataset
+    return datasets_by_id
+
+
+DATASETS_BY_ID = _build_datasets_by_id(ALL_DATASETS)
+
+_MONTHLY_COMPACTION_BY_PROVIDER = {
+    "spotify": (
+        datasets.SPOTIFY_PLAYS,
+        datasets.SPOTIFY_TRACKS,
+        datasets.SPOTIFY_ARTISTS,
+    ),
+    "github": (
+        datasets.GITHUB_COMMITS,
+        datasets.GITHUB_PULL_REQUESTS,
+    ),
+    "browser_history": (datasets.BROWSER_HISTORY_PAGE_VIEWS,),
+    "youtube": (datasets.YOUTUBE_WATCH_EVENTS,),
+}
+
+
+def get_dataset(dataset_id: str) -> DatasetDefinition:
+    """dataset id から定義を返す。"""
+    try:
+        return DATASETS_BY_ID[dataset_id]
+    except KeyError as exc:
+        raise KeyError(f"unknown_dataset: {dataset_id}") from exc
+
+
+def monthly_compaction_datasets(provider: str) -> tuple[DatasetDefinition, ...]:
+    """provider の月次 compaction 対象を返す。"""
+    try:
+        return _MONTHLY_COMPACTION_BY_PROVIDER[provider]
+    except KeyError as exc:
+        raise KeyError(f"unknown_provider: {provider}") from exc

--- a/egograph/dataset_catalog/catalog.py
+++ b/egograph/dataset_catalog/catalog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+from types import SimpleNamespace
 
 
 class DataDomain(StrEnum):
@@ -40,7 +41,7 @@ class DatasetDefinition:
     path: str
     partition_policy: PartitionPolicy
     compaction_strategy: CompactionStrategy
-    event_time_column: str | None = None
+    time_column: str | None = None
     dedupe_key: str | None = None
     sort_key: str | None = None
     snapshot_file_name: str | None = None
@@ -58,8 +59,21 @@ class DatasetDefinition:
         ):
             raise ValueError(f"dedupe_key_required: {self.dataset_id}")
 
+    def source_root(self, events_path: str, master_path: str) -> str:
+        """domain に応じた source root を返す。
+
+        source 側は events / master で root が分かれているため、domain ごとに
+        対応する root を選択する。compacted 側は単一 root 配下に domain 階層を
+        持つため本メソッドの対象外（``compacted_prefix`` を使用）。
+        """
+        return events_path if self.domain is DataDomain.EVENTS else master_path
+
     def source_prefix(self, root_path: str) -> str:
-        """events/master root から dataset prefix を組み立てる。"""
+        """events/master root から dataset prefix を組み立てる。
+
+        source 側の root は domain 判別済み（events_path / master_path）のため、
+        戻り値に domain は含まない。compacted 側は ``compacted_prefix`` を使用。
+        """
         return f"{_normalize_path(root_path)}{self.path}/"
 
     def source_partition_prefix(self, root_path: str, *, year: int, month: int) -> str:
@@ -76,8 +90,19 @@ class DatasetDefinition:
             raise ValueError(f"snapshot_file_name_required: {self.dataset_id}")
         return f"{self.source_prefix(root_path)}{self.snapshot_file_name}"
 
+    def required_dedupe_key(self) -> str:
+        """dedupe_key を返す。未設定の場合はエラー。"""
+        if self.dedupe_key is None:
+            raise ValueError(f"dedupe_key_required: {self.dataset_id}")
+        return self.dedupe_key
+
     def compacted_prefix(self, compacted_root: str) -> str:
-        """compacted root から dataset prefix を組み立てる。"""
+        """compacted root から dataset prefix を組み立てる。
+
+        compacted 側は単一 root 配下に domain ごとの階層を持つため、戻り値に
+        domain を含む。source 側は domain 判別済み root を使うため
+        ``source_prefix`` では domain を含まない（これが両者の非対称性）。
+        """
         return f"{_normalize_path(compacted_root)}{self.domain.value}/{self.path}/"
 
     def compacted_partition_key(
@@ -98,96 +123,99 @@ def _normalize_path(path: str) -> str:
     return path.rstrip("/") + "/"
 
 
-class datasets:
-    """Dataset 定義の名前空間。"""
-
-    SPOTIFY_PLAYS = DatasetDefinition(
+# DatasetDefinition の名前付きレジストリ。class ではなく SimpleNamespace で
+# 「インスタンス（値）」であることを明示する（PEP 8: 型名ではないので小文字）。
+datasets = SimpleNamespace(
+    SPOTIFY_PLAYS=DatasetDefinition(
         dataset_id="spotify.plays",
         provider="spotify",
         domain=DataDomain.EVENTS,
         path="spotify/plays",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
-        event_time_column="played_at_utc",
+        time_column="played_at_utc",
         dedupe_key="play_id",
         sort_key="played_at_utc",
-    )
-    SPOTIFY_TRACKS = DatasetDefinition(
+    ),
+    SPOTIFY_TRACKS=DatasetDefinition(
         dataset_id="spotify.tracks",
         provider="spotify",
         domain=DataDomain.MASTER,
         path="spotify/tracks",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
-        event_time_column="updated_at",
+        time_column="updated_at",
         dedupe_key="track_id",
         sort_key="updated_at",
-    )
-    SPOTIFY_ARTISTS = DatasetDefinition(
+    ),
+    SPOTIFY_ARTISTS=DatasetDefinition(
         dataset_id="spotify.artists",
         provider="spotify",
         domain=DataDomain.MASTER,
         path="spotify/artists",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
-        event_time_column="updated_at",
+        time_column="updated_at",
         dedupe_key="artist_id",
         sort_key="updated_at",
-    )
-    GITHUB_COMMITS = DatasetDefinition(
+    ),
+    GITHUB_COMMITS=DatasetDefinition(
         dataset_id="github.commits",
         provider="github",
         domain=DataDomain.EVENTS,
         path="github/commits",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
-        event_time_column="committed_at_utc",
+        time_column="committed_at_utc",
         dedupe_key="commit_event_id",
         sort_key="committed_at_utc",
-    )
-    GITHUB_PULL_REQUESTS = DatasetDefinition(
+    ),
+    GITHUB_PULL_REQUESTS=DatasetDefinition(
         dataset_id="github.pull_requests",
         provider="github",
         domain=DataDomain.EVENTS,
         path="github/pull_requests",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
-        event_time_column="updated_at_utc",
+        time_column="updated_at_utc",
         dedupe_key="pr_event_id",
         sort_key="updated_at_utc",
-    )
-    GITHUB_REPOSITORIES = DatasetDefinition(
+    ),
+    GITHUB_REPOSITORIES=DatasetDefinition(
         dataset_id="github.repositories",
         provider="github",
         domain=DataDomain.MASTER,
         path="github/repositories",
         partition_policy=PartitionPolicy.RECURSIVE,
         compaction_strategy=CompactionStrategy.NONE,
-        event_time_column="updated_at_utc",
-    )
-    BROWSER_HISTORY_PAGE_VIEWS = DatasetDefinition(
+        time_column="updated_at_utc",
+    ),
+    BROWSER_HISTORY_PAGE_VIEWS=DatasetDefinition(
         dataset_id="browser_history.page_views",
         provider="browser_history",
         domain=DataDomain.EVENTS,
         path="browser_history/page_views",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
-        event_time_column="started_at_utc",
+        time_column="started_at_utc",
         dedupe_key="page_view_id",
-        sort_key="started_at_utc",
-    )
-    YOUTUBE_WATCH_EVENTS = DatasetDefinition(
+        # page_view_id は started_at_utc から生成されるため sort_key として
+        # started_at_utc を使うと重複行間で同値になり決定性が失われる。
+        # ingested_at_utc で「最新 run のレコード」を確定勝者とする。
+        sort_key="ingested_at_utc",
+    ),
+    YOUTUBE_WATCH_EVENTS=DatasetDefinition(
         dataset_id="youtube.watch_events",
         provider="youtube",
         domain=DataDomain.EVENTS,
         path="youtube/watch_events",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.APPEND_DEDUPE,
-        event_time_column="watched_at_utc",
+        time_column="watched_at_utc",
         dedupe_key="watch_event_id",
         sort_key="watched_at_utc",
-    )
-    YOUTUBE_VIDEOS = DatasetDefinition(
+    ),
+    YOUTUBE_VIDEOS=DatasetDefinition(
         dataset_id="youtube.videos",
         provider="youtube",
         domain=DataDomain.MASTER,
@@ -195,8 +223,8 @@ class datasets:
         partition_policy=PartitionPolicy.SNAPSHOT,
         compaction_strategy=CompactionStrategy.SNAPSHOT_UPSERT,
         snapshot_file_name="data.parquet",
-    )
-    YOUTUBE_CHANNELS = DatasetDefinition(
+    ),
+    YOUTUBE_CHANNELS=DatasetDefinition(
         dataset_id="youtube.channels",
         provider="youtube",
         domain=DataDomain.MASTER,
@@ -204,43 +232,44 @@ class datasets:
         partition_policy=PartitionPolicy.SNAPSHOT,
         compaction_strategy=CompactionStrategy.SNAPSHOT_UPSERT,
         snapshot_file_name="data.parquet",
-    )
-    GOOGLE_HEALTH_DAILY_METRICS = DatasetDefinition(
+    ),
+    GOOGLE_HEALTH_DAILY_METRICS=DatasetDefinition(
         dataset_id="google_health.daily_metrics",
         provider="google_health",
         domain=DataDomain.EVENTS,
         path="google_health/daily_metrics",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.RANGE_REPLACE,
-        event_time_column="date",
-    )
-    GOOGLE_HEALTH_SAMPLES = DatasetDefinition(
+        time_column="date",
+    ),
+    GOOGLE_HEALTH_SAMPLES=DatasetDefinition(
         dataset_id="google_health.samples",
         provider="google_health",
         domain=DataDomain.EVENTS,
         path="google_health/samples",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.RANGE_REPLACE,
-        event_time_column="measured_at_utc",
-    )
-    GOOGLE_HEALTH_INTERVALS = DatasetDefinition(
+        time_column="measured_at_utc",
+    ),
+    GOOGLE_HEALTH_INTERVALS=DatasetDefinition(
         dataset_id="google_health.intervals",
         provider="google_health",
         domain=DataDomain.EVENTS,
         path="google_health/intervals",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.RANGE_REPLACE,
-        event_time_column="started_at_utc",
-    )
-    GOOGLE_HEALTH_SESSIONS = DatasetDefinition(
+        time_column="started_at_utc",
+    ),
+    GOOGLE_HEALTH_SESSIONS=DatasetDefinition(
         dataset_id="google_health.sessions",
         provider="google_health",
         domain=DataDomain.EVENTS,
         path="google_health/sessions",
         partition_policy=PartitionPolicy.MONTHLY,
         compaction_strategy=CompactionStrategy.RANGE_REPLACE,
-        event_time_column="started_at_utc",
-    )
+        time_column="started_at_utc",
+    ),
+)
 
 
 ALL_DATASETS = (
@@ -260,6 +289,7 @@ ALL_DATASETS = (
     datasets.GOOGLE_HEALTH_SESSIONS,
 )
 
+
 def _build_datasets_by_id(
     dataset_definitions: tuple[DatasetDefinition, ...],
 ) -> dict[str, DatasetDefinition]:
@@ -273,20 +303,6 @@ def _build_datasets_by_id(
 
 DATASETS_BY_ID = _build_datasets_by_id(ALL_DATASETS)
 
-_MONTHLY_COMPACTION_BY_PROVIDER = {
-    "spotify": (
-        datasets.SPOTIFY_PLAYS,
-        datasets.SPOTIFY_TRACKS,
-        datasets.SPOTIFY_ARTISTS,
-    ),
-    "github": (
-        datasets.GITHUB_COMMITS,
-        datasets.GITHUB_PULL_REQUESTS,
-    ),
-    "browser_history": (datasets.BROWSER_HISTORY_PAGE_VIEWS,),
-    "youtube": (datasets.YOUTUBE_WATCH_EVENTS,),
-}
-
 
 def get_dataset(dataset_id: str) -> DatasetDefinition:
     """dataset id から定義を返す。"""
@@ -297,8 +313,20 @@ def get_dataset(dataset_id: str) -> DatasetDefinition:
 
 
 def monthly_compaction_datasets(provider: str) -> tuple[DatasetDefinition, ...]:
-    """provider の月次 compaction 対象を返す。"""
-    try:
-        return _MONTHLY_COMPACTION_BY_PROVIDER[provider]
-    except KeyError as exc:
-        raise KeyError(f"unknown_provider: {provider}") from exc
+    """provider の月次 append-dedupe compaction 対象を ``ALL_DATASETS`` から導出する。
+
+    ``ALL_DATASETS`` の定義順を維持し、``partition_policy=MONTHLY`` かつ
+    ``compaction_strategy=APPEND_DEDUPE`` の dataset のみを返す。新規 dataset 追加時に
+    別リストをメンテする必要がなく、リストと定義の drift を構造的に排除する。
+    range_replace / snapshot の dataset は自動的に除外される。
+    """
+    result = tuple(
+        dataset
+        for dataset in ALL_DATASETS
+        if dataset.provider == provider
+        and dataset.partition_policy is PartitionPolicy.MONTHLY
+        and dataset.compaction_strategy is CompactionStrategy.APPEND_DEDUPE
+    )
+    if not result:
+        raise KeyError(f"unknown_provider: {provider}")
+    return result

--- a/egograph/dataset_catalog/pyproject.toml
+++ b/egograph/dataset_catalog/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "egograph-dataset-catalog"
+version = "0.1.0"
+description = "Shared Parquet dataset catalog for EgoGraph"
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.hatch.build.targets.wheel]
+packages = ["dataset_catalog"]

--- a/egograph/pipelines/sources/browser_history/storage.py
+++ b/egograph/pipelines/sources/browser_history/storage.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 import boto3
 import pandas as pd
 from botocore.exceptions import ClientError
+from dataset_catalog import datasets
 
 from pipelines.sources.common.compaction import (
     COMPACTED_ROOT,
@@ -99,7 +100,7 @@ class BrowserHistoryStorage:
         *,
         year: int,
         month: int,
-        prefix: str = "browser_history/page_views",
+        prefix: str = datasets.BROWSER_HISTORY_PAGE_VIEWS.path,
     ) -> str | None:
         """events parquet を保存する。"""
         if not rows:
@@ -166,13 +167,13 @@ class BrowserHistoryStorage:
         *,
         year: int,
         month: int,
-        dataset_path: str = "browser_history/page_views",
-        dedupe_key: str = "page_view_id",
-        sort_by: str | None = "ingested_at_utc",
     ) -> str | None:
         """指定月の browser history events を compact する。"""
-        source_prefix = (
-            f"{self.events_path}{dataset_path}/year={year}/month={month:02d}/"
+        dataset = datasets.BROWSER_HISTORY_PAGE_VIEWS
+        source_prefix = dataset.source_partition_prefix(
+            self.events_path,
+            year=year,
+            month=month,
         )
         records = read_parquet_records_from_prefix(
             self.s3,
@@ -185,13 +186,12 @@ class BrowserHistoryStorage:
 
         compacted_df = compact_records(
             records,
-            dedupe_key=dedupe_key,
-            sort_by=sort_by,
+            dedupe_key=dataset.dedupe_key or "",
+            sort_by=dataset.sort_key,
         )
         key = build_compacted_key(
             self.compacted_path,
-            data_domain="events",
-            dataset_path=dataset_path,
+            dataset,
             year=year,
             month=month,
         )
@@ -206,7 +206,7 @@ class BrowserHistoryStorage:
             logger.exception(
                 "Failed to save compacted browser history parquet: "
                 "dataset=%s year=%d month=%02d key=%s",
-                dataset_path,
+                dataset.path,
                 year,
                 month,
                 key,

--- a/egograph/pipelines/sources/browser_history/storage.py
+++ b/egograph/pipelines/sources/browser_history/storage.py
@@ -186,7 +186,7 @@ class BrowserHistoryStorage:
 
         compacted_df = compact_records(
             records,
-            dedupe_key=dataset.dedupe_key or "",
+            dedupe_key=dataset.required_dedupe_key(),
             sort_by=dataset.sort_key,
         )
         key = build_compacted_key(

--- a/egograph/pipelines/sources/common/bootstrap_compact.py
+++ b/egograph/pipelines/sources/common/bootstrap_compact.py
@@ -62,7 +62,7 @@ def _compact_spotify(
     failures: list[str] = []
 
     for dataset in monthly_compaction_datasets("spotify"):
-        root_prefix = events_path if dataset.domain.value == "events" else master_path
+        root_prefix = dataset.source_root(events_path, master_path)
         months = _discover_dataset_months(
             s3_client,
             bucket_name,

--- a/egograph/pipelines/sources/common/bootstrap_compact.py
+++ b/egograph/pipelines/sources/common/bootstrap_compact.py
@@ -2,10 +2,10 @@
 
 import argparse
 import logging
-from dataclasses import dataclass
 from typing import Any
 
 import boto3
+from dataset_catalog import DatasetDefinition, datasets, monthly_compaction_datasets
 
 from pipelines.sources.browser_history.storage import BrowserHistoryStorage
 from pipelines.sources.common.compaction import discover_available_months
@@ -15,16 +15,6 @@ from pipelines.sources.spotify.storage import SpotifyStorage
 from pipelines.sources.youtube.storage import YouTubeStorage
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class DatasetSpec:
-    """Dataset compaction settings."""
-
-    data_domain: str
-    dataset_path: str
-    dedupe_key: str
-    sort_by: str | None = None
 
 
 def _parse_args() -> argparse.Namespace:
@@ -56,9 +46,9 @@ def _discover_dataset_months(
     s3_client: Any,
     bucket_name: str,
     root_prefix: str,
-    dataset: DatasetSpec,
+    dataset: DatasetDefinition,
 ) -> list[tuple[int, int]]:
-    source_prefix = f"{root_prefix}{dataset.dataset_path}/"
+    source_prefix = dataset.source_prefix(root_prefix)
     return discover_available_months(s3_client, bucket_name, source_prefix)
 
 
@@ -70,14 +60,9 @@ def _compact_spotify(
     storage: SpotifyStorage,
 ) -> list[str]:
     failures: list[str] = []
-    datasets = (
-        DatasetSpec("events", "spotify/plays", "play_id", "played_at_utc"),
-        DatasetSpec("master", "spotify/tracks", "track_id", "updated_at"),
-        DatasetSpec("master", "spotify/artists", "artist_id", "updated_at"),
-    )
 
-    for dataset in datasets:
-        root_prefix = events_path if dataset.data_domain == "events" else master_path
+    for dataset in monthly_compaction_datasets("spotify"):
+        root_prefix = events_path if dataset.domain.value == "events" else master_path
         months = _discover_dataset_months(
             s3_client,
             bucket_name,
@@ -87,29 +72,26 @@ def _compact_spotify(
         logger.info(
             "Bootstrap compact target months discovered: "
             "provider=spotify dataset=%s months=%s",
-            dataset.dataset_path,
+            dataset.path,
             months,
         )
         for year, month in months:
             try:
                 storage.compact_month(
-                    data_domain=dataset.data_domain,
-                    dataset_path=dataset.dataset_path,
+                    dataset=dataset,
                     year=year,
                     month=month,
-                    dedupe_key=dataset.dedupe_key,
-                    sort_by=dataset.sort_by,
                 )
             except Exception as exc:
                 logger.exception(
                     "Bootstrap Spotify compaction failed: "
                     "dataset=%s year=%d month=%02d error=%s",
-                    dataset.dataset_path,
+                    dataset.path,
                     year,
                     month,
                     exc,
                 )
-                failures.append(f"spotify:{dataset.dataset_path}:{year}-{month:02d}")
+                failures.append(f"spotify:{dataset.path}:{year}-{month:02d}")
 
     return failures
 
@@ -121,12 +103,8 @@ def _compact_github(
     storage: GitHubWorklogStorage,
 ) -> list[str]:
     failures: list[str] = []
-    datasets = (
-        DatasetSpec("events", "github/commits", "commit_event_id", "committed_at_utc"),
-        DatasetSpec("events", "github/pull_requests", "pr_event_id", "updated_at_utc"),
-    )
 
-    for dataset in datasets:
+    for dataset in monthly_compaction_datasets("github"):
         months = _discover_dataset_months(
             s3_client,
             bucket_name,
@@ -136,28 +114,26 @@ def _compact_github(
         logger.info(
             "Bootstrap compact target months discovered: "
             "provider=github dataset=%s months=%s",
-            dataset.dataset_path,
+            dataset.path,
             months,
         )
         for year, month in months:
             try:
                 storage.compact_month(
-                    dataset_path=dataset.dataset_path,
+                    dataset=dataset,
                     year=year,
                     month=month,
-                    dedupe_key=dataset.dedupe_key,
-                    sort_by=dataset.sort_by,
                 )
             except Exception as exc:
                 logger.exception(
                     "Bootstrap GitHub compaction failed: "
                     "dataset=%s year=%d month=%02d error=%s",
-                    dataset.dataset_path,
+                    dataset.path,
                     year,
                     month,
                     exc,
                 )
-                failures.append(f"github:{dataset.dataset_path}:{year}-{month:02d}")
+                failures.append(f"github:{dataset.path}:{year}-{month:02d}")
 
     return failures
 
@@ -169,12 +145,7 @@ def _compact_browser_history(
     storage: BrowserHistoryStorage,
 ) -> list[str]:
     failures: list[str] = []
-    dataset = DatasetSpec(
-        "events",
-        "browser_history/page_views",
-        "page_view_id",
-        "ingested_at_utc",
-    )
+    dataset = datasets.BROWSER_HISTORY_PAGE_VIEWS
 
     months = _discover_dataset_months(
         s3_client,
@@ -185,30 +156,25 @@ def _compact_browser_history(
     logger.info(
         "Bootstrap compact target months discovered: "
         "provider=browser_history dataset=%s months=%s",
-        dataset.dataset_path,
+        dataset.path,
         months,
     )
     for year, month in months:
         try:
             storage.compact_month(
-                dataset_path=dataset.dataset_path,
                 year=year,
                 month=month,
-                dedupe_key=dataset.dedupe_key,
-                sort_by=dataset.sort_by,
             )
         except Exception as exc:
             logger.exception(
                 "Bootstrap browser_history compaction failed: "
                 "dataset=%s year=%d month=%02d error=%s",
-                dataset.dataset_path,
+                dataset.path,
                 year,
                 month,
                 exc,
             )
-            failures.append(
-                f"browser_history:{dataset.dataset_path}:{year}-{month:02d}"
-            )
+            failures.append(f"browser_history:{dataset.path}:{year}-{month:02d}")
 
     return failures
 
@@ -220,12 +186,7 @@ def _compact_youtube(
     storage: YouTubeStorage,
 ) -> list[str]:
     failures: list[str] = []
-    dataset = DatasetSpec(
-        "events",
-        "youtube/watch_events",
-        "watch_event_id",
-        "watched_at_utc",
-    )
+    dataset = datasets.YOUTUBE_WATCH_EVENTS
 
     months = _discover_dataset_months(
         s3_client,
@@ -236,7 +197,7 @@ def _compact_youtube(
     logger.info(
         "Bootstrap compact target months discovered: "
         "provider=youtube dataset=%s months=%s",
-        dataset.dataset_path,
+        dataset.path,
         months,
     )
     for year, month in months:
@@ -253,12 +214,12 @@ def _compact_youtube(
             logger.exception(
                 "Bootstrap YouTube compaction failed: "
                 "dataset=%s year=%d month=%02d error=%s",
-                dataset.dataset_path,
+                dataset.path,
                 year,
                 month,
                 exc,
             )
-            failures.append(f"youtube:{dataset.dataset_path}:{year}-{month:02d}")
+            failures.append(f"youtube:{dataset.path}:{year}-{month:02d}")
 
     return failures
 

--- a/egograph/pipelines/sources/common/compaction.py
+++ b/egograph/pipelines/sources/common/compaction.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from typing import Any
 
 import pandas as pd
+from dataset_catalog import DatasetDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -39,17 +40,12 @@ def _unify_datetime_columns(df: pd.DataFrame) -> pd.DataFrame:
 
 def build_compacted_key(
     compacted_path: str,
-    data_domain: str,
-    dataset_path: str,
+    dataset: DatasetDefinition,
     year: int,
     month: int,
 ) -> str:
     """月次 compacted parquet の key を組み立てる。"""
-    compacted_path = _normalize_path(compacted_path)
-    return (
-        f"{compacted_path}{data_domain}/{dataset_path}/"
-        f"year={year}/month={month:02d}/data.parquet"
-    )
+    return dataset.compacted_partition_key(compacted_path, year=year, month=month)
 
 
 def compact_records(

--- a/egograph/pipelines/sources/github/pipeline.py
+++ b/egograph/pipelines/sources/github/pipeline.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from dataset_catalog import monthly_compaction_datasets
+
 from pipelines.sources.common.compaction import resolve_target_months
 from pipelines.sources.common.config import Config
 from pipelines.sources.common.settings import PipelinesSettings
@@ -47,31 +49,24 @@ def run_github_compact(
     skipped_targets: list[str] = []
     failures: list[str] = []
     for target_year, target_month in target_months:
-        for dataset_path, dedupe_key, sort_by in (
-            ("github/commits", "commit_event_id", "committed_at_utc"),
-            ("github/pull_requests", "pr_event_id", "updated_at_utc"),
-        ):
+        for dataset in monthly_compaction_datasets("github"):
             try:
                 key = storage.compact_month(
-                    dataset_path=dataset_path,
+                    dataset=dataset,
                     year=target_year,
                     month=target_month,
-                    dedupe_key=dedupe_key,
-                    sort_by=sort_by,
                 )
             except Exception:
                 logger.exception(
                     "GitHub compaction failed: dataset=%s year=%d month=%02d",
-                    dataset_path,
+                    dataset.path,
                     target_year,
                     target_month,
                 )
-                failures.append(f"{dataset_path}:{target_year}-{target_month:02d}")
+                failures.append(f"{dataset.path}:{target_year}-{target_month:02d}")
                 continue
             if key is None:
-                skipped_targets.append(
-                    f"{dataset_path}:{target_year}-{target_month:02d}"
-                )
+                skipped_targets.append(f"{dataset.path}:{target_year}-{target_month:02d}")
             else:
                 compacted_keys.append(key)
 

--- a/egograph/pipelines/sources/github/storage.py
+++ b/egograph/pipelines/sources/github/storage.py
@@ -505,11 +505,9 @@ class GitHubWorklogStorage:
             logger.info("No parquet records found for compaction: %s", source_prefix)
             return None
 
-        if dataset.dedupe_key is None:
-            raise ValueError(f"dedupe_key_required: {dataset.dataset_id}")
         compacted_df = compact_records(
             records,
-            dedupe_key=dataset.dedupe_key,
+            dedupe_key=dataset.required_dedupe_key(),
             sort_by=dataset.sort_key,
         )
         key = build_compacted_key(

--- a/egograph/pipelines/sources/github/storage.py
+++ b/egograph/pipelines/sources/github/storage.py
@@ -10,6 +10,7 @@ from typing import Any
 import boto3
 import pandas as pd
 from botocore.exceptions import ClientError
+from dataset_catalog import DatasetDefinition
 
 from pipelines.sources.common.compaction import (
     COMPACTED_ROOT,
@@ -487,15 +488,15 @@ class GitHubWorklogStorage:
 
     def compact_month(
         self,
-        dataset_path: str,
+        dataset: DatasetDefinition,
         year: int,
         month: int,
-        dedupe_key: str,
-        sort_by: str | None = None,
     ) -> str | None:
         """指定月のGitHubイベントParquetをcompact版として保存する。"""
-        source_prefix = (
-            f"{self.events_path}{dataset_path}/year={year}/month={month:02d}/"
+        source_prefix = dataset.source_partition_prefix(
+            self.events_path,
+            year=year,
+            month=month,
         )
         records = read_parquet_records_from_prefix(
             self.s3, self.bucket_name, source_prefix
@@ -504,11 +505,16 @@ class GitHubWorklogStorage:
             logger.info("No parquet records found for compaction: %s", source_prefix)
             return None
 
-        compacted_df = compact_records(records, dedupe_key=dedupe_key, sort_by=sort_by)
+        if dataset.dedupe_key is None:
+            raise ValueError(f"dedupe_key_required: {dataset.dataset_id}")
+        compacted_df = compact_records(
+            records,
+            dedupe_key=dataset.dedupe_key,
+            sort_by=dataset.sort_key,
+        )
         key = build_compacted_key(
             self.compacted_path,
-            data_domain="events",
-            dataset_path=dataset_path,
+            dataset,
             year=year,
             month=month,
         )

--- a/egograph/pipelines/sources/google_health/writer.py
+++ b/egograph/pipelines/sources/google_health/writer.py
@@ -28,17 +28,6 @@ GOOGLE_HEALTH_DATASETS = (
     datasets.GOOGLE_HEALTH_INTERVALS,
     datasets.GOOGLE_HEALTH_SESSIONS,
 )
-GOOGLE_HEALTH_RECORD_KEYS = {
-    datasets.GOOGLE_HEALTH_DAILY_METRICS: "daily_metrics",
-    datasets.GOOGLE_HEALTH_SAMPLES: "samples",
-    datasets.GOOGLE_HEALTH_INTERVALS: "intervals",
-    datasets.GOOGLE_HEALTH_SESSIONS: "sessions",
-}
-DATASET_DATE_COLUMNS = {
-    GOOGLE_HEALTH_RECORD_KEYS[dataset]: dataset.event_time_column
-    for dataset in GOOGLE_HEALTH_DATASETS
-    if dataset.event_time_column is not None
-}
 
 
 class GoogleHealthWriter:
@@ -259,16 +248,13 @@ def _retain_outside_target(
 
 
 def _dataset_name(dataset: DatasetDefinition) -> str:
-    try:
-        return GOOGLE_HEALTH_RECORD_KEYS[dataset]
-    except KeyError as exc:
-        raise KeyError(f"unknown_google_health_dataset: {dataset.dataset_id}") from exc
+    return dataset.dataset_id.split(".", 1)[1]
 
 
 def _date_column(dataset: DatasetDefinition) -> str:
-    if dataset.event_time_column is None:
-        raise ValueError(f"event_time_column_required: {dataset.dataset_id}")
-    return dataset.event_time_column
+    if dataset.time_column is None:
+        raise ValueError(f"time_column_required: {dataset.dataset_id}")
+    return dataset.time_column
 
 
 def _row_month(row: dict[str, Any], date_column: str) -> tuple[int, int]:

--- a/egograph/pipelines/sources/google_health/writer.py
+++ b/egograph/pipelines/sources/google_health/writer.py
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo
 import boto3
 import pandas as pd
 from botocore.exceptions import ClientError
+from dataset_catalog import DatasetDefinition, datasets
 
 from pipelines.sources.common.compaction import (
     COMPACTED_ROOT,
@@ -21,11 +22,22 @@ from pipelines.sources.google_health.timezone import (
     local_date_start_utc,
 )
 
+GOOGLE_HEALTH_DATASETS = (
+    datasets.GOOGLE_HEALTH_DAILY_METRICS,
+    datasets.GOOGLE_HEALTH_SAMPLES,
+    datasets.GOOGLE_HEALTH_INTERVALS,
+    datasets.GOOGLE_HEALTH_SESSIONS,
+)
+GOOGLE_HEALTH_RECORD_KEYS = {
+    datasets.GOOGLE_HEALTH_DAILY_METRICS: "daily_metrics",
+    datasets.GOOGLE_HEALTH_SAMPLES: "samples",
+    datasets.GOOGLE_HEALTH_INTERVALS: "intervals",
+    datasets.GOOGLE_HEALTH_SESSIONS: "sessions",
+}
 DATASET_DATE_COLUMNS = {
-    "daily_metrics": "date",
-    "samples": "measured_at_utc",
-    "intervals": "started_at_utc",
-    "sessions": "started_at_utc",
+    GOOGLE_HEALTH_RECORD_KEYS[dataset]: dataset.event_time_column
+    for dataset in GOOGLE_HEALTH_DATASETS
+    if dataset.event_time_column is not None
 }
 
 
@@ -94,16 +106,20 @@ class GoogleHealthWriter:
     ) -> list[str]:
         """今回runの正規化行をUUID名のevents Parquetへ保存する。"""
         saved_keys: list[str] = []
-        for dataset, date_column in DATASET_DATE_COLUMNS.items():
+        for dataset in GOOGLE_HEALTH_DATASETS:
+            dataset_name = _dataset_name(dataset)
+            date_column = _date_column(dataset)
             rows_by_month: dict[tuple[int, int], list[dict[str, Any]]] = {}
-            for row in records.get(dataset, []):
+            for row in records.get(dataset_name, []):
                 month = _row_month(row, date_column)
                 rows_by_month.setdefault(month, []).append(row)
             for (year, month), rows in sorted(rows_by_month.items()):
-                key = (
-                    f"{self.events_path}google_health/{dataset}/"
-                    f"year={year}/month={month:02d}/{run_id}.parquet"
+                prefix = dataset.source_partition_prefix(
+                    self.events_path,
+                    year=year,
+                    month=month,
                 )
+                key = f"{prefix}{run_id}.parquet"
                 self.s3.put_object(
                     Bucket=self.bucket_name,
                     Key=key,
@@ -124,16 +140,21 @@ class GoogleHealthWriter:
     ) -> list[str]:
         """既存compactedの対象範囲を今回runのeventsで置換する。"""
         compacted_keys: list[str] = []
-        for dataset, date_column in DATASET_DATE_COLUMNS.items():
+        for dataset in GOOGLE_HEALTH_DATASETS:
+            dataset_name = _dataset_name(dataset)
+            date_column = _date_column(dataset)
             months = set(
                 _target_months(
-                    dataset,
+                    dataset_name,
                     date_from=date_from,
                     date_to=date_to,
                     timezone=self.timezone,
                 )
             )
-            if dataset == "sessions" and "sleep" in selected_data_types:
+            if (
+                dataset is datasets.GOOGLE_HEALTH_SESSIONS
+                and "sleep" in selected_data_types
+            ):
                 sleep_start = local_date_start_utc(
                     date_from - timedelta(days=1),
                     self.timezone,
@@ -168,20 +189,23 @@ class GoogleHealthWriter:
 
     def _event_key(
         self,
-        dataset: str,
+        dataset: DatasetDefinition,
         year: int,
         month: int,
         run_id: str,
     ) -> str:
-        return (
-            f"{self.events_path}google_health/{dataset}/"
-            f"year={year}/month={month:02d}/{run_id}.parquet"
+        prefix = dataset.source_partition_prefix(
+            self.events_path,
+            year=year,
+            month=month,
         )
+        return f"{prefix}{run_id}.parquet"
 
-    def _compacted_key(self, dataset: str, year: int, month: int) -> str:
-        return (
-            f"{self.compacted_path}events/google_health/{dataset}/"
-            f"year={year}/month={month:02d}/data.parquet"
+    def _compacted_key(self, dataset: DatasetDefinition, year: int, month: int) -> str:
+        return dataset.compacted_partition_key(
+            self.compacted_path,
+            year=year,
+            month=month,
         )
 
     def _load_parquet(self, key: str) -> list[dict[str, Any]]:
@@ -232,6 +256,19 @@ def _retain_outside_target(
         if not is_target:
             retained.append(row)
     return retained
+
+
+def _dataset_name(dataset: DatasetDefinition) -> str:
+    try:
+        return GOOGLE_HEALTH_RECORD_KEYS[dataset]
+    except KeyError as exc:
+        raise KeyError(f"unknown_google_health_dataset: {dataset.dataset_id}") from exc
+
+
+def _date_column(dataset: DatasetDefinition) -> str:
+    if dataset.event_time_column is None:
+        raise ValueError(f"event_time_column_required: {dataset.dataset_id}")
+    return dataset.event_time_column
 
 
 def _row_month(row: dict[str, Any], date_column: str) -> tuple[int, int]:

--- a/egograph/pipelines/sources/spotify/pipeline.py
+++ b/egograph/pipelines/sources/spotify/pipeline.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from dataset_catalog import monthly_compaction_datasets
+
 from pipelines.sources.common.compaction import resolve_target_months
 from pipelines.sources.common.config import Config
 from pipelines.sources.common.settings import PipelinesSettings
@@ -47,33 +49,24 @@ def run_spotify_compact(
     skipped_targets: list[str] = []
     failures: list[str] = []
     for target_year, target_month in target_months:
-        for data_domain, dataset_path, dedupe_key, sort_by in (
-            ("events", "spotify/plays", "play_id", "played_at_utc"),
-            ("master", "spotify/tracks", "track_id", "updated_at"),
-            ("master", "spotify/artists", "artist_id", "updated_at"),
-        ):
+        for dataset in monthly_compaction_datasets("spotify"):
             try:
                 key = storage.compact_month(
-                    data_domain=data_domain,
-                    dataset_path=dataset_path,
+                    dataset=dataset,
                     year=target_year,
                     month=target_month,
-                    dedupe_key=dedupe_key,
-                    sort_by=sort_by,
                 )
             except Exception:
                 logger.exception(
                     "Spotify compaction failed: dataset=%s year=%d month=%02d",
-                    dataset_path,
+                    dataset.path,
                     target_year,
                     target_month,
                 )
-                failures.append(f"{dataset_path}:{target_year}-{target_month:02d}")
+                failures.append(f"{dataset.path}:{target_year}-{target_month:02d}")
                 continue
             if key is None:
-                skipped_targets.append(
-                    f"{dataset_path}:{target_year}-{target_month:02d}"
-                )
+                skipped_targets.append(f"{dataset.path}:{target_year}-{target_month:02d}")
             else:
                 compacted_keys.append(key)
 

--- a/egograph/pipelines/sources/spotify/storage.py
+++ b/egograph/pipelines/sources/spotify/storage.py
@@ -255,11 +255,8 @@ class SpotifyStorage:
         month: int,
     ) -> str | None:
         """指定月のParquetをcompact版として保存する。"""
-        source_root = (
-            self.events_path if dataset.domain.value == "events" else self.master_path
-        )
         source_prefix = dataset.source_partition_prefix(
-            source_root,
+            dataset.source_root(self.events_path, self.master_path),
             year=year,
             month=month,
         )
@@ -270,11 +267,9 @@ class SpotifyStorage:
             logger.info("No parquet records found for compaction: %s", source_prefix)
             return None
 
-        if dataset.dedupe_key is None:
-            raise ValueError(f"dedupe_key_required: {dataset.dataset_id}")
         compacted_df = compact_records(
             records,
-            dedupe_key=dataset.dedupe_key,
+            dedupe_key=dataset.required_dedupe_key(),
             sort_by=dataset.sort_key,
         )
         key = build_compacted_key(

--- a/egograph/pipelines/sources/spotify/storage.py
+++ b/egograph/pipelines/sources/spotify/storage.py
@@ -10,6 +10,7 @@ from typing import Any
 import boto3
 import pandas as pd
 from botocore.exceptions import ClientError
+from dataset_catalog import DatasetDefinition
 
 from pipelines.sources.common.compaction import (
     COMPACTED_ROOT,
@@ -249,16 +250,19 @@ class SpotifyStorage:
 
     def compact_month(
         self,
-        data_domain: str,
-        dataset_path: str,
+        dataset: DatasetDefinition,
         year: int,
         month: int,
-        dedupe_key: str,
-        sort_by: str | None = None,
     ) -> str | None:
         """指定月のParquetをcompact版として保存する。"""
-        source_root = self.events_path if data_domain == "events" else self.master_path
-        source_prefix = f"{source_root}{dataset_path}/year={year}/month={month:02d}/"
+        source_root = (
+            self.events_path if dataset.domain.value == "events" else self.master_path
+        )
+        source_prefix = dataset.source_partition_prefix(
+            source_root,
+            year=year,
+            month=month,
+        )
         records = read_parquet_records_from_prefix(
             self.s3, self.bucket_name, source_prefix
         )
@@ -266,11 +270,16 @@ class SpotifyStorage:
             logger.info("No parquet records found for compaction: %s", source_prefix)
             return None
 
-        compacted_df = compact_records(records, dedupe_key=dedupe_key, sort_by=sort_by)
+        if dataset.dedupe_key is None:
+            raise ValueError(f"dedupe_key_required: {dataset.dataset_id}")
+        compacted_df = compact_records(
+            records,
+            dedupe_key=dataset.dedupe_key,
+            sort_by=dataset.sort_key,
+        )
         key = build_compacted_key(
             self.compacted_path,
-            data_domain=data_domain,
-            dataset_path=dataset_path,
+            dataset,
             year=year,
             month=month,
         )

--- a/egograph/pipelines/sources/youtube/storage.py
+++ b/egograph/pipelines/sources/youtube/storage.py
@@ -12,6 +12,7 @@ import boto3
 import pandas as pd
 import pyarrow.parquet as pq
 from botocore.exceptions import ClientError
+from dataset_catalog import datasets
 
 from pipelines.sources.common.compaction import (
     COMPACTED_ROOT,
@@ -60,8 +61,11 @@ class YouTubeStorage:
 
     def compact_month(self, year: int, month: int) -> str | None:
         """指定月のYouTube watch events Parquetをcompact版として保存する。"""
-        source_prefix = (
-            f"{self.events_path}youtube/watch_events/year={year}/month={month:02d}/"
+        dataset = datasets.YOUTUBE_WATCH_EVENTS
+        source_prefix = dataset.source_partition_prefix(
+            self.events_path,
+            year=year,
+            month=month,
         )
         records = read_parquet_records_from_prefix(
             self.s3, self.bucket_name, source_prefix
@@ -71,12 +75,13 @@ class YouTubeStorage:
             return None
 
         compacted_df = compact_records(
-            records, dedupe_key="watch_event_id", sort_by="watched_at_utc"
+            records,
+            dedupe_key=dataset.dedupe_key or "",
+            sort_by=dataset.sort_key,
         )
         key = build_compacted_key(
             self.compacted_path,
-            data_domain="events",
-            dataset_path="youtube/watch_events",
+            dataset,
             year=year,
             month=month,
         )
@@ -159,8 +164,11 @@ class YouTubeStorage:
         rows: list[dict[str, Any]] = []
         for year, month in target_months:
             key = (
-                f"compacted/events/browser_history/page_views/"
-                f"year={year}/month={month:02d}/data.parquet"
+                datasets.BROWSER_HISTORY_PAGE_VIEWS.compacted_partition_key(
+                    self.compacted_path,
+                    year=year,
+                    month=month,
+                )
             )
             try:
                 response = self.s3.get_object(Bucket=self.bucket_name, Key=key)
@@ -191,19 +199,21 @@ class YouTubeStorage:
         """watch events parquet を sync_id 単位の安定キーで保存する。"""
         if not rows:
             return None
-        key = (
-            f"{self.events_path}youtube/watch_events/year={year}/month={month:02d}/"
-            f"sync_id={sync_id}.parquet"
+        prefix = datasets.YOUTUBE_WATCH_EVENTS.source_partition_prefix(
+            self.events_path,
+            year=year,
+            month=month,
         )
+        key = f"{prefix}sync_id={sync_id}.parquet"
         return self._save_dataframe_key(rows, key)
 
     def build_video_master_key(self) -> str:
         """video master の固定保存キーを返す。"""
-        return f"{self.master_path}youtube/videos/data.parquet"
+        return datasets.YOUTUBE_VIDEOS.source_snapshot_key(self.master_path)
 
     def build_channel_master_key(self) -> str:
         """channel master の固定保存キーを返す。"""
-        return f"{self.master_path}youtube/channels/data.parquet"
+        return datasets.YOUTUBE_CHANNELS.source_snapshot_key(self.master_path)
 
     def load_video_master(self) -> list[dict[str, Any]]:
         """既存 video master snapshot を読み込む。"""

--- a/egograph/pipelines/sources/youtube/storage.py
+++ b/egograph/pipelines/sources/youtube/storage.py
@@ -76,7 +76,7 @@ class YouTubeStorage:
 
         compacted_df = compact_records(
             records,
-            dedupe_key=dataset.dedupe_key or "",
+            dedupe_key=dataset.required_dedupe_key(),
             sort_by=dataset.sort_key,
         )
         key = build_compacted_key(

--- a/egograph/pipelines/tests/unit/github/test_storage.py
+++ b/egograph/pipelines/tests/unit/github/test_storage.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 from botocore.exceptions import ClientError
+from dataset_catalog import datasets
 from pipelines.sources.github.storage import (
     GitHubWorklogStorage,
     StorageConsistencyError,
@@ -535,10 +536,9 @@ class TestGitHubWorklogStorage(unittest.TestCase):
                 return_value=b"x",
             ):
                 key = self.storage.compact_month(
-                    dataset_path="github/commits",
+                    dataset=datasets.GITHUB_COMMITS,
                     year=2024,
                     month=1,
-                    dedupe_key="commit_event_id",
                 )
 
         call_args = self.mock_s3.put_object.call_args[1]

--- a/egograph/pipelines/tests/unit/spotify/test_storage.py
+++ b/egograph/pipelines/tests/unit/spotify/test_storage.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from botocore.exceptions import ClientError
+from dataset_catalog import datasets
 from pipelines.sources.spotify.storage import SpotifyStorage, StorageConsistencyError
 
 
@@ -153,11 +154,9 @@ class TestSpotifyStorage(unittest.TestCase):
                 return_value=b"x",
             ):
                 key = self.storage.compact_month(
-                    data_domain="events",
-                    dataset_path="spotify/plays",
+                    dataset=datasets.SPOTIFY_PLAYS,
                     year=2024,
                     month=1,
-                    dedupe_key="play_id",
                 )
 
         call_args = self.mock_s3.put_object.call_args[1]

--- a/egograph/pipelines/tests/unit/test_bootstrap_compact.py
+++ b/egograph/pipelines/tests/unit/test_bootstrap_compact.py
@@ -48,7 +48,7 @@ class TestCompactSpotify:
             assert s3 is s3_client
             assert bucket_name == "egograph"
             return discovered_months[
-                (root_prefix, dataset.data_domain, dataset.dataset_path)
+                (root_prefix, dataset.domain.value, dataset.path)
             ]
 
         monkeypatch.setattr(
@@ -85,7 +85,7 @@ class TestCompactGitHub:
             assert s3 is s3_client
             assert bucket_name == "egograph"
             return discovered_months[
-                (root_prefix, dataset.data_domain, dataset.dataset_path)
+                (root_prefix, dataset.domain.value, dataset.path)
             ]
 
         monkeypatch.setattr(
@@ -120,7 +120,7 @@ class TestCompactBrowserHistory:
             assert s3 is s3_client
             assert bucket_name == "egograph"
             return discovered_months[
-                (root_prefix, dataset.data_domain, dataset.dataset_path)
+                (root_prefix, dataset.domain.value, dataset.path)
             ]
 
         monkeypatch.setattr(

--- a/egograph/pipelines/tests/unit/test_compaction.py
+++ b/egograph/pipelines/tests/unit/test_compaction.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 
 import pandas as pd
+from dataset_catalog import datasets
 from pipelines.sources.common.compaction import (
     _unify_datetime_columns,
     build_compacted_key,
@@ -18,8 +19,7 @@ class TestBuildCompactedKey:
     def test_builds_events_key(self):
         key = build_compacted_key(
             compacted_path="compacted/",
-            data_domain="events",
-            dataset_path="spotify/plays",
+            dataset=datasets.SPOTIFY_PLAYS,
             year=2024,
             month=1,
         )
@@ -29,8 +29,7 @@ class TestBuildCompactedKey:
     def test_builds_master_key(self):
         key = build_compacted_key(
             compacted_path="compacted/",
-            data_domain="master",
-            dataset_path="spotify/tracks",
+            dataset=datasets.SPOTIFY_TRACKS,
             year=2024,
             month=2,
         )

--- a/egograph/pipelines/tests/unit/test_provider_entrypoints.py
+++ b/egograph/pipelines/tests/unit/test_provider_entrypoints.py
@@ -115,9 +115,10 @@ def test_run_spotify_compact_returns_compacted_and_skipped_targets(monkeypatch):
 
         def compact_month(self, **kwargs):
             calls.append(kwargs)
-            if kwargs["dataset_path"] == "spotify/artists":
+            dataset_path = kwargs["dataset"].path
+            if dataset_path == "spotify/artists":
                 return None
-            return f"compacted/{kwargs['dataset_path']}/data.parquet"
+            return f"compacted/{dataset_path}/data.parquet"
 
     monkeypatch.setattr(
         "pipelines.sources.spotify.pipeline.SpotifyStorage",
@@ -147,7 +148,7 @@ def test_run_github_compact_raises_after_collecting_failures(monkeypatch):
             pass
 
         def compact_month(self, **kwargs):
-            if kwargs["dataset_path"] == "github/pull_requests":
+            if kwargs["dataset"].path == "github/pull_requests":
                 raise RuntimeError("boom")
             return "compacted/events/github/commits/year=2026/month=04/data.parquet"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [tool.uv.workspace]
-members = ["egograph/backend", "egograph/pipelines"]
+members = [
+    "egograph/backend",
+    "egograph/dataset_catalog",
+    "egograph/pipelines",
+]
 
 [tool.ruff]
 line-length = 88

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 [manifest]
 members = [
     "egograph-backend",
+    "egograph-dataset-catalog",
     "egograph-pipelines",
 ]
 
@@ -460,6 +461,11 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.12.0" },
     { name = "rich", specifier = ">=13.7.0" },
 ]
+
+[[package]]
+name = "egograph-dataset-catalog"
+version = "0.1.0"
+source = { editable = "egograph/dataset_catalog" }
 
 [[package]]
 name = "egograph-pipelines"


### PR DESCRIPTION
## 概要

Pipelines の Parquet 保存契約と Backend の読み取り契約を共有する `dataset_catalog` を追加しました。

- dataset の path / domain / partition policy / compaction strategy / dedupe key / sort key / event time column を `DatasetDefinition` に集約
- Backend の Parquet path resolver と各 query 実装を catalog 参照へ変更
- Pipelines の compaction / bootstrap / provider storage を catalog 参照へ変更
- Dockerfile / CI / deploy workflow / architecture docs を更新
- 計画とレビュー結果を `docs/plan/plan-dataset-catalog.md` に保存

## 背景

これまでは Pipelines 側の書き込み path と Backend 側の読み取り path が個別に文字列定義されており、データソース追加や配置変更時に片方だけ更新されるリスクがありました。

今回の変更で、dataset の物理契約を catalog に寄せ、保存・compaction・読み取りが同じ定義を参照する形にしました。

## 検証

- `uv run ruff check egograph/dataset_catalog egograph/backend/api/health.py egograph/backend/infrastructure/database egograph/backend/tests/unit/database/test_parquet_paths.py egograph/backend/tests/unit/repositories/test_youtube_queries.py egograph/backend/tests/unit/test_dataset_catalog.py egograph/pipelines/sources/common/compaction.py egograph/pipelines/sources/common/bootstrap_compact.py egograph/pipelines/sources/spotify/pipeline.py egograph/pipelines/sources/spotify/storage.py egograph/pipelines/sources/github/pipeline.py egograph/pipelines/sources/github/storage.py egograph/pipelines/sources/browser_history/storage.py egograph/pipelines/sources/youtube/storage.py egograph/pipelines/sources/google_health/writer.py egograph/pipelines/tests/unit/test_compaction.py egograph/pipelines/tests/unit/test_bootstrap_compact.py egograph/pipelines/tests/unit/spotify/test_storage.py egograph/pipelines/tests/unit/github/test_storage.py egograph/pipelines/tests/unit/test_provider_entrypoints.py`
- `R2_ENDPOINT_URL=https://test.r2.cloudflarestorage.com R2_ACCESS_KEY_ID=test R2_SECRET_ACCESS_KEY=test R2_BUCKET_NAME=test-bucket uv run pytest egograph/backend/tests --tb=short -q`（292 passed）
- `R2_ENDPOINT_URL=https://test.r2.cloudflarestorage.com R2_ACCESS_KEY_ID=test R2_SECRET_ACCESS_KEY=test R2_BUCKET_NAME=test-bucket uv run pytest egograph/pipelines/tests/unit --tb=short -q`（458 passed, 1 warning）
- `R2_ENDPOINT_URL=https://test.r2.cloudflarestorage.com R2_ACCESS_KEY_ID=test R2_SECRET_ACCESS_KEY=test R2_BUCKET_NAME=test-bucket uv run pytest egograph/pipelines/tests/integration --tb=short -q`（36 passed）
- `R2_ENDPOINT_URL=https://test.r2.cloudflarestorage.com R2_ACCESS_KEY_ID=test R2_SECRET_ACCESS_KEY=test R2_BUCKET_NAME=test-bucket uv run pytest egograph/pipelines/tests/e2e --tb=short -q`（1 passed）
- `git diff --cached --check`

補足: `uv run ruff check .` はこの変更外の既存 lint（`.claude/skills/agent-tool-test/run_tool_matrix.py`, `egograph/backend/api/github.py`, `egograph/backend/config.py`, `egograph/pipelines/sources/google_activity/transform.py`, `scripts/convert_takeout_html.py` など）で失敗するため、変更対象に絞って ruff を実行しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * データカタログを導入し、Spotify・GitHub・YouTube・Browser History・Google Health のデータ定義を共通化しました。
  * パーティション解決やコンパクションが、データ定義ベースで統一されました。
* **Bug Fixes**
  * 一部データ更新時に、関連するCIや自動デプロイが実行されるようになりました。
  * コンテナイメージに必要なデータ定義を含めるようになりました。
* **Documentation**
  * データカタログと自動デプロイ条件の説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->