### PR TITLE
feat(backend): Daily Timeline read model (REST + MCP)

### DIFF
--- a/egograph/backend/api/schemas/__init__.py
+++ b/egograph/backend/api/schemas/__init__.py
@@ -21,6 +21,7 @@ from backend.api.schemas.github import (
     RepoSummaryStatsResponse,
 )
 from backend.api.schemas.google_health import GoogleHealthDailySummaryResponse
+from backend.api.schemas.timeline import DailyTimelineResponse, TimelineRange
 
 __all__ = [
     # Data API スキーマ
@@ -39,4 +40,7 @@ __all__ = [
     "ActivityStatsResponse",
     "RepoSummaryStatsResponse",
     "GoogleHealthDailySummaryResponse",
+    # Timeline API スキーマ
+    "DailyTimelineResponse",
+    "TimelineRange",
 ]

--- a/egograph/backend/api/schemas/timeline.py
+++ b/egograph/backend/api/schemas/timeline.py
@@ -1,0 +1,43 @@
+"""Daily Timeline API レスポンススキーマ。
+
+REST と MCP で同じ response shape を使うため、本スキーマは MCP 応答の
+契約とも一致する。Pydantic モデルは REST の OpenAPI / 直列化検証に使う。
+"""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class TimelineRange(BaseModel):
+    """1日の対象範囲（local / UTC）。"""
+
+    start_local: datetime
+    end_local: datetime
+    start_utc: datetime
+    end_utc: datetime
+
+
+class TimelineMeta(BaseModel):
+    """タイムライン応答のメタ情報。"""
+
+    item_count: int
+    truncated: bool
+    generated_at: str
+
+
+class DailyTimelineResponse(BaseModel):
+    """``GET /v1/data/timeline/daily`` のレスポンス。"""
+
+    date: str
+    timezone: str
+    range: TimelineRange
+    items: list[dict[str, Any]]
+    correlations: list[dict[str, Any]]
+    gaps: list[dict[str, Any]]
+    daily_summaries: dict[str, Any] = Field(default_factory=dict)
+    coverage: dict[str, Any]
+    meta: TimelineMeta
+
+    model_config = {"extra": "allow"}

--- a/egograph/backend/api/timeline.py
+++ b/egograph/backend/api/timeline.py
@@ -1,0 +1,54 @@
+"""Daily Timeline REST API エンドポイント。
+
+REST も MCP も同じ ``GetDailyTimelineTool`` を呼び、同じ validation /
+response shape を共有する。本エンドポイントは query parameter の受け取りと
+HTTP レスポンス生成のみを担う。
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from backend.api.schemas.timeline import DailyTimelineResponse
+from backend.constants import (
+    DEFAULT_GAP_MINUTES,
+    DEFAULT_TIMELINE_LIMIT,
+)
+from backend.dependencies import get_daily_timeline_tool, verify_api_key_docs
+from backend.domain.tools.timeline.daily import GetDailyTimelineTool
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/data/timeline", tags=["data", "timeline"])
+
+
+@router.get("/daily", response_model=DailyTimelineResponse)
+async def get_daily_timeline_endpoint(
+    date: str = Query(..., description="ローカル日付（YYYY-MM-DD）"),
+    timezone: str | None = Query(None, description="IANA timezone"),
+    sources: list[str] | None = Query(
+        None, description="含めるデータソース（複数指定可）"
+    ),
+    gap_minutes: str | None = Query(
+        str(DEFAULT_GAP_MINUTES),
+        description="この分数以上の観測欠落を gaps に返す。0/null は検出なし",
+    ),
+    include_correlations: str = Query("true", description="関連候補を返すか"),
+    include_raw_refs: str = Query("false", description="raw_ref を返すか"),
+    limit: str = Query(str(DEFAULT_TIMELINE_LIMIT), description="items の最大件数"),
+    tool: GetDailyTimelineTool = Depends(get_daily_timeline_tool),
+    _api_key: None = Depends(verify_api_key_docs),
+):
+    """複数データソースを統合した1日分のタイムラインを取得する。"""
+    try:
+        return tool.execute(
+            date=date,
+            timezone=timezone,
+            sources=sources,
+            gap_minutes=gap_minutes,
+            include_correlations=include_correlations,
+            include_raw_refs=include_raw_refs,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/egograph/backend/config.py
+++ b/egograph/backend/config.py
@@ -5,6 +5,7 @@ import os
 from zoneinfo import ZoneInfo
 
 from egograph_paths import PARQUET_DATA_DIR
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel, Field, SecretStr, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -63,6 +64,11 @@ class BackendConfig(BaseSettings):
     # サブ設定
     r2: R2Config | None = None
 
+    @property
+    def timezone_configured(self) -> bool:
+        """TIMEZONE が明示設定されているかを返す。"""
+        return "timezone" in self.model_fields_set or "TIMEZONE" in os.environ
+
     # MCP transport security: テスト環境向けにHost許可リストを設定可能
     mcp_allowed_hosts: list[str] = Field([], alias="MCP_ALLOWED_HOSTS")
 
@@ -116,8 +122,6 @@ class BackendConfig(BaseSettings):
         本番環境ではDNS rebinding保護を無効化する（Tailscaleネットワーク内で
         WireGuard暗号化・認証済みのため、追加の保護は不要）。
         """
-        from mcp.server.transport_security import TransportSecuritySettings
-
         if self.mcp_allowed_hosts:
             return TransportSecuritySettings(
                 enable_dns_rebinding_protection=True,

--- a/egograph/backend/constants.py
+++ b/egograph/backend/constants.py
@@ -25,3 +25,32 @@ MS_TO_MINUTES_FACTOR = 60000.0
 
 # Tool Execution
 MAX_TOOL_ITERATIONS = 5
+
+# Daily Timeline
+DEFAULT_TIMELINE_LIMIT = 500
+MAX_TIMELINE_LIMIT = 2000
+DEFAULT_GAP_MINUTES = 120
+MAX_GAP_MINUTES = 1440  # 24時間分
+
+# Daily Timeline が扱う source 一覧。items に混ぜる source と、
+# daily_summaries / coverage にのみ現れる source を含む。
+TIMELINE_SOURCES = (
+    "spotify",
+    "youtube",
+    "browser_history",
+    "github",
+    "google_health",
+)
+
+# 同一時刻の item 整列で使う source 優先度（小さいほど先）。
+# Browser History → YouTube → Spotify → GitHub の順で、ページ遷移から
+# 視聴イベントが続く流れを読みやすくする。
+TIMELINE_SOURCE_PRIORITY = {
+    "browser_history": 0,
+    "youtube": 1,
+    "spotify": 2,
+    "github": 3,
+}
+
+# Browser History と YouTube 視聴イベントの関連候補判定窓（秒）。
+CORRELATION_YOUTUBE_WINDOW_SECONDS = 120

--- a/egograph/backend/dependencies.py
+++ b/egograph/backend/dependencies.py
@@ -152,7 +152,14 @@ def get_google_health_daily_summary_use_case(
 def get_timeline_repository(
     config: BackendConfig = Depends(get_config),
 ) -> TimelineRepository:
-    return TimelineRepository(_require_r2(config))
+    try:
+        r2 = _require_r2(config)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"invalid_r2_config: {exc}",
+        ) from exc
+    return TimelineRepository(r2)
 
 
 def get_daily_timeline_tool(

--- a/egograph/backend/dependencies.py
+++ b/egograph/backend/dependencies.py
@@ -11,6 +11,10 @@ from fastapi import Depends, HTTPException, Security
 from fastapi.security import APIKeyHeader
 
 from backend.config import BackendConfig, R2Config
+from backend.domain.tools.timeline.daily import (
+    GetDailyTimelineTool,
+    resolve_default_timezone,
+)
 from backend.infrastructure.database import DuckDBConnection
 from backend.infrastructure.repositories.browser_history_repository import (
     BrowserHistoryRepository,
@@ -20,6 +24,9 @@ from backend.infrastructure.repositories.google_health_repository import (
     GoogleHealthRepository,
 )
 from backend.infrastructure.repositories.spotify_repository import SpotifyRepository
+from backend.infrastructure.repositories.timeline_repository import (
+    TimelineRepository,
+)
 from backend.infrastructure.repositories.youtube_repository import YouTubeRepository
 from backend.usecases.google_health import GetGoogleHealthDailySummaryUseCase
 
@@ -140,3 +147,23 @@ def get_google_health_daily_summary_use_case(
 ) -> GetGoogleHealthDailySummaryUseCase:
     """Google Health日次サマリ取得UseCaseを構築する。"""
     return GetGoogleHealthDailySummaryUseCase(repository)
+
+
+def get_timeline_repository(
+    config: BackendConfig = Depends(get_config),
+) -> TimelineRepository:
+    return TimelineRepository(_require_r2(config))
+
+
+def get_daily_timeline_tool(
+    config: BackendConfig = Depends(get_config),
+    repository: TimelineRepository = Depends(get_timeline_repository),
+) -> GetDailyTimelineTool:
+    """Daily Timeline MCP ツールを構築する。"""
+    return GetDailyTimelineTool(
+        repository,
+        default_timezone=resolve_default_timezone(
+            config.timezone,
+            timezone_configured=config.timezone_configured,
+        ),
+    )

--- a/egograph/backend/domain/tools/timeline/__init__.py
+++ b/egograph/backend/domain/tools/timeline/__init__.py
@@ -1,0 +1,1 @@
+"""Daily Timeline ツールパッケージ。"""

--- a/egograph/backend/domain/tools/timeline/daily.py
+++ b/egograph/backend/domain/tools/timeline/daily.py
@@ -1,0 +1,241 @@
+"""``get_daily_timeline`` MCP ツール。
+
+REST API と MCP Tool は同じ入力制約、同じ response shape、同じ validation を使う。
+本ツールの ``execute`` が唯一の validation + repository 呼び出しポイントであり、
+REST 側も本ツールを経由して同じロジックを実行する。
+"""
+
+import logging
+import re
+from datetime import date
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from backend.constants import (
+    DEFAULT_GAP_MINUTES,
+    DEFAULT_TIMELINE_LIMIT,
+    MAX_GAP_MINUTES,
+    MAX_TIMELINE_LIMIT,
+    TIMELINE_SOURCES,
+)
+from backend.domain.models.tool import ToolBase
+from backend.infrastructure.repositories.timeline_repository import (
+    TimelineRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+# timezone 未指定時の既定。設計仕様「未設定時は Asia/Tokyo」に従う。
+# BackendConfig.timezone は未設定だと UTC になるが、本ツールの契約としては
+# 日本ベースの個人データ前提で Asia/Tokyo を既定とする。
+DEFAULT_TIMELINE_TIMEZONE = ZoneInfo("Asia/Tokyo")
+
+
+def resolve_default_timezone(
+    config_tz: ZoneInfo | None,
+    *,
+    timezone_configured: bool = False,
+) -> ZoneInfo:
+    """Backend の TIMEZONE から Daily Timeline の既定 timezone を解決する。
+
+    設計仕様「Backend の TIMEZONE。未設定時は Asia/Tokyo」に従い、
+    TIMEZONE が明示設定されている場合は UTC も含めてその値を採用する。
+    REST・MCP の両構築経路で本関数を使い、解釈を一本化する。
+    """
+    if config_tz is not None and timezone_configured:
+        return config_tz
+    return DEFAULT_TIMELINE_TIMEZONE
+
+
+class GetDailyTimelineTool(ToolBase):
+    """1日分の統合タイムラインを取得するツール。"""
+
+    def __init__(
+        self,
+        repository: TimelineRepository,
+        default_timezone: ZoneInfo | None = None,
+    ) -> None:
+        self.repository = repository
+        self.default_timezone = default_timezone or DEFAULT_TIMELINE_TIMEZONE
+
+    @property
+    def name(self) -> str:
+        return "get_daily_timeline"
+
+    @property
+    def description(self) -> str:
+        return (
+            "複数データソース（Spotify, YouTube, Browser History, GitHub, "
+            "Google Health）の観測イベントを1日単位で時刻順に統合した"
+            "タイムラインを取得します。Google Health は items には入らず"
+            "daily_summaries に添付されます。"
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "timezone 上のローカル日付（YYYY-MM-DD）",
+                },
+                "timezone": {
+                    "type": "string",
+                    "description": (
+                        "IANA timezone。既定は Backend の TIMEZONE"
+                        "（未設定時は Asia/Tokyo）"
+                    ),
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "含めるデータソース一覧。省略時は全 source",
+                },
+                "gap_minutes": {
+                    "type": ["integer", "null"],
+                    "description": (
+                        "この分数以上の観測欠落を gaps に返す。"
+                        "0 または null は gap 検出なし（既定 120）"
+                    ),
+                },
+                "include_correlations": {
+                    "type": "boolean",
+                    "description": "関連候補を correlations に返すか（既定 true）",
+                },
+                "include_raw_refs": {
+                    "type": "boolean",
+                    "description": (
+                        "元 dataset と record id を raw_ref に返すか（既定 false）"
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "items の最大件数（1..2000、既定 500）",
+                },
+            },
+            "required": ["date"],
+        }
+
+    def execute(
+        self,
+        date: str,
+        timezone: str | None = None,
+        sources: list[str] | None = None,
+        gap_minutes: Any = DEFAULT_GAP_MINUTES,
+        include_correlations: Any = True,
+        include_raw_refs: Any = False,
+        limit: Any = DEFAULT_TIMELINE_LIMIT,
+    ) -> dict[str, Any]:
+        """1日分のタイムラインを取得する。
+
+        Raises:
+            ValueError: 入力制約を満たさない場合。
+        """
+        validated_date = _validate_date(date)
+        validated_tz = _resolve_timezone(timezone, self.default_timezone)
+        validated_sources = _validate_sources(sources)
+        validated_gap = _validate_gap_minutes(gap_minutes)
+        validated_limit = _validate_limit(limit)
+        validated_include_correlations = _validate_bool(
+            include_correlations,
+            field_name="include_correlations",
+        )
+        validated_include_raw_refs = _validate_bool(
+            include_raw_refs,
+            field_name="include_raw_refs",
+        )
+
+        logger.info(
+            "Executing get_daily_timeline: date=%s, tz=%s, sources=%s, "
+            "gap_minutes=%s, limit=%s",
+            validated_date,
+            validated_tz,
+            validated_sources,
+            validated_gap,
+            validated_limit,
+        )
+
+        return self.repository.build_daily_timeline(
+            date_local=validated_date,
+            timezone=validated_tz,
+            sources=validated_sources,
+            gap_minutes=validated_gap,
+            include_correlations=validated_include_correlations,
+            include_raw_refs=validated_include_raw_refs,
+            limit=validated_limit,
+        )
+
+
+def _validate_date(value: str) -> date:
+    """``YYYY-MM-DD`` 形式のローカル日付を検証する。"""
+    if not isinstance(value, str) or not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+        raise ValueError("invalid_date: expected YYYY-MM-DD")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("invalid_date: expected YYYY-MM-DD") from exc
+
+
+def _resolve_timezone(value: str | None, default: ZoneInfo) -> ZoneInfo:
+    """IANA timezone を解決する。``None`` のときは default を使う。"""
+    if value is None:
+        return default
+    try:
+        return ZoneInfo(value)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError("invalid_timezone: unknown timezone") from exc
+
+
+def _validate_sources(sources: list[str] | None) -> set[str]:
+    """``sources`` の許可値を検証し、集合として返す。``None`` は全 source。"""
+    if sources is None:
+        return set()
+    unknown = [source for source in sources if source not in TIMELINE_SOURCES]
+    if unknown:
+        raise ValueError("invalid_sources: unknown source")
+    return set(sources)
+
+
+def _validate_gap_minutes(value: int | None) -> int | None:
+    """``gap_minutes`` の範囲を検証する。``None`` は gap なし。"""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        if not value:
+            return None
+        if not re.fullmatch(r"\d+", value):
+            raise ValueError("invalid_gap_minutes: expected 0..1440")
+        value = int(value)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError("invalid_gap_minutes: expected 0..1440")
+    if value < 0 or value > MAX_GAP_MINUTES:
+        raise ValueError("invalid_gap_minutes: expected 0..1440")
+    return value
+
+
+def _validate_limit(value: Any) -> int:
+    """``limit`` の範囲を検証する。"""
+    if isinstance(value, str):
+        if not re.fullmatch(r"\d+", value):
+            raise ValueError("invalid_limit: expected 1..2000")
+        value = int(value)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError("invalid_limit: expected 1..2000")
+    if value < 1 or value > MAX_TIMELINE_LIMIT:
+        raise ValueError("invalid_limit: expected 1..2000")
+    return value
+
+
+def _validate_bool(value: Any, *, field_name: str) -> bool:
+    """REST query / MCP args の bool 入力を同じ規則で検証する。"""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    raise ValueError(f"invalid_{field_name}: expected boolean")

--- a/egograph/backend/domain/tools/timeline/daily.py
+++ b/egograph/backend/domain/tools/timeline/daily.py
@@ -184,7 +184,7 @@ def _resolve_timezone(value: str | None, default: ZoneInfo) -> ZoneInfo:
         return default
     try:
         return ZoneInfo(value)
-    except ZoneInfoNotFoundError as exc:
+    except (ZoneInfoNotFoundError, ValueError) as exc:
         raise ValueError("invalid_timezone: unknown timezone") from exc
 
 

--- a/egograph/backend/infrastructure/database/timeline_queries.py
+++ b/egograph/backend/infrastructure/database/timeline_queries.py
@@ -1,0 +1,254 @@
+"""Daily Timeline 用の DuckDB クエリ。
+
+各 source の compacted Parquet から指定期間（UTC range）の raw event を取得する。
+正規化、ソート、correlation、gap 生成は Repository 層で行うため、
+本モジュールは「UTC の raw 行」を最小限の列で返すことのみを責務とする。
+
+時刻列は TIMESTAMP / TIMESTAMPTZ の混在に耐えるため
+``make_timestamp(epoch_us(col))`` で UTC の naive TIMESTAMP に正規化して返す。
+``epoch_us`` は絶対 UTC エポックを返すためセッションタイムゾーンに依存しない。
+"""
+
+from pathlib import Path
+from typing import Any
+
+from dataset_catalog import datasets
+
+from backend.infrastructure.database.parquet_paths import (
+    COMPACTED_ROOT,
+    build_dataset_glob,
+    build_partition_paths,
+)
+from backend.infrastructure.database.query_params import QueryParams, execute_query
+
+# TIMESTAMP / TIMESTAMPTZ を UTC naive に正規化する式。
+_TS = "make_timestamp(epoch_us({col}))"
+
+
+def dataset_has_parquet(params: QueryParams, dataset) -> bool:
+    """dataset の compacted Parquet が1件でも存在するか。
+
+    ``local_parquet_root`` 設定時はローカルミラーを優先して判定し、
+    ローカルに無い場合は R2 の glob へ fallback する。
+    coverage の ``not_available`` 判定のために使う。
+    """
+    if params.r2_config.local_parquet_root:
+        local_root = Path(
+            params.r2_config.local_parquet_root
+        ) / dataset.compacted_prefix(COMPACTED_ROOT)
+        if any(local_root.rglob("*.parquet")):
+            return True
+    pattern = build_dataset_glob(params.r2_config, dataset)
+    rows = params.conn.execute("SELECT COUNT(*) FROM glob(?)", (pattern,)).fetchone()
+    return bool(rows and rows[0] > 0)
+
+
+def fetch_spotify_plays(params: QueryParams) -> list[dict[str, Any]]:
+    """Spotify 再生イベントを再生時刻 UTC 昇順で取得する。"""
+    paths = build_partition_paths(
+        params.r2_config,
+        datasets.SPOTIFY_PLAYS,
+        params.utc_start,
+        params.utc_end,
+    )
+    sql = f"""
+        SELECT
+            play_id,
+            {_TS.format(col="played_at_utc")} AS played_at_utc,
+            track_id,
+            track_name,
+            artist_names,
+            album_name,
+            ms_played
+        FROM read_parquet(?)
+        WHERE {_TS.format(col="played_at_utc")} >= ?
+          AND {_TS.format(col="played_at_utc")} < ?
+        ORDER BY played_at_utc ASC
+    """
+    return execute_query(params.conn, sql, [paths, params.utc_start, params.utc_end])
+
+
+def fetch_browser_page_views(params: QueryParams) -> list[dict[str, Any]]:
+    """Browser History page view を開始時刻 UTC 昇順で取得する。"""
+    paths = build_partition_paths(
+        params.r2_config,
+        datasets.BROWSER_HISTORY_PAGE_VIEWS,
+        params.utc_start,
+        params.utc_end,
+    )
+    sql = f"""
+        SELECT
+            page_view_id,
+            {_TS.format(col="started_at_utc")} AS started_at_utc,
+            {_TS.format(col="ended_at_utc")} AS ended_at_utc,
+            url,
+            title,
+            browser,
+            profile,
+            transition,
+            visit_span_count
+        FROM read_parquet(?)
+        WHERE {_TS.format(col="started_at_utc")} >= ?
+          AND {_TS.format(col="started_at_utc")} < ?
+        ORDER BY started_at_utc ASC
+    """
+    return execute_query(params.conn, sql, [paths, params.utc_start, params.utc_end])
+
+
+def fetch_youtube_watch_events(params: QueryParams) -> list[dict[str, Any]]:
+    """YouTube 視聴イベントを視聴時刻 UTC 昇順で取得する。
+
+    timeline の正規化に必要なのは視聴イベント行そのもの（title/channel は
+    watch_events に埋め込まれている）ため、master の結合は行わない。
+    """
+    paths = build_partition_paths(
+        params.r2_config,
+        datasets.YOUTUBE_WATCH_EVENTS,
+        params.utc_start,
+        params.utc_end,
+    )
+    sql = f"""
+        SELECT
+            watch_event_id,
+            {_TS.format(col="watched_at_utc")} AS watched_at_utc,
+            video_id,
+            video_url,
+            video_title,
+            channel_id,
+            channel_name,
+            content_type,
+            source,
+            source_device
+        FROM read_parquet(?)
+        WHERE {_TS.format(col="watched_at_utc")} >= ?
+          AND {_TS.format(col="watched_at_utc")} < ?
+        ORDER BY watched_at_utc ASC
+    """
+    return execute_query(params.conn, sql, [paths, params.utc_start, params.utc_end])
+
+
+def fetch_github_commits(params: QueryParams) -> list[dict[str, Any]]:
+    """GitHub commit を commit 時刻 UTC 昇順で取得する。"""
+    paths = build_partition_paths(
+        params.r2_config,
+        datasets.GITHUB_COMMITS,
+        params.utc_start,
+        params.utc_end,
+    )
+    sql = f"""
+        SELECT
+            commit_event_id,
+            owner,
+            repo,
+            repo_full_name,
+            sha,
+            message,
+            {_TS.format(col="committed_at_utc")} AS committed_at_utc,
+            changed_files_count,
+            additions,
+            deletions
+        FROM read_parquet(?)
+        WHERE {_TS.format(col="committed_at_utc")} >= ?
+          AND {_TS.format(col="committed_at_utc")} < ?
+        ORDER BY committed_at_utc ASC
+    """
+    return execute_query(params.conn, sql, [paths, params.utc_start, params.utc_end])
+
+
+def fetch_github_pull_requests(params: QueryParams) -> list[dict[str, Any]]:
+    """GitHub Pull Request イベントを更新時刻 UTC 昇順で取得する。"""
+    paths = build_partition_paths(
+        params.r2_config,
+        datasets.GITHUB_PULL_REQUESTS,
+        params.utc_start,
+        params.utc_end,
+    )
+    sql = f"""
+        SELECT
+            pr_event_id,
+            owner,
+            repo,
+            repo_full_name,
+            pr_number,
+            action,
+            state,
+            is_merged,
+            title,
+            labels,
+            {_TS.format(col="updated_at_utc")} AS updated_at_utc,
+            additions,
+            deletions,
+            changed_files_count
+        FROM read_parquet(?)
+        WHERE {_TS.format(col="updated_at_utc")} >= ?
+          AND {_TS.format(col="updated_at_utc")} < ?
+        ORDER BY updated_at_utc ASC
+    """
+    return execute_query(params.conn, sql, [paths, params.utc_start, params.utc_end])
+
+
+def fetch_google_health_daily_metrics(params: QueryParams) -> dict[str, Any]:
+    """対象 local date の Google Health 日次指標を取得する。
+
+    daily_metrics は long format（metric_name, value）なので、
+    timeline が必要な指標のみ pivot して1行にまとめる。
+    partition は local ``date`` の年月で決まるため、UTC range を使った
+    build_partition_paths が対象月を含むように日付範囲を渡す。
+    """
+    sql = """
+        WITH pivot_metrics AS (
+            SELECT
+                MAX(CASE WHEN metric_name = 'steps' THEN value END) AS steps,
+                MAX(CASE
+                    WHEN metric_name = 'active_energy_burned' THEN value
+                END) AS active_energy_burned,
+                MAX(CASE
+                    WHEN metric_name IN (
+                        'resting_heart_rate',
+                        'daily_resting_heart_rate'
+                    ) THEN value
+                END) AS resting_heart_rate,
+                MAX(CASE
+                    WHEN metric_name = 'sleep_duration' THEN value
+                END) AS sleep_duration_seconds
+            FROM read_parquet(?)
+            WHERE date = ?
+        )
+        SELECT * FROM pivot_metrics
+    """
+    paths = build_partition_paths(
+        params.r2_config,
+        datasets.GOOGLE_HEALTH_DAILY_METRICS,
+        params.utc_start,
+        params.utc_end,
+    )
+    rows = execute_query(params.conn, sql, [paths, params.start_date])
+    return rows[0] if rows else {}
+
+
+def fetch_google_health_sleep_sessions(params: QueryParams) -> list[dict[str, Any]]:
+    """対象 local date に帰属する睡眠セッションを取得する。
+
+    睡眠は「起床日の」指標として扱うため、``ended_at_utc`` を local date に
+    変換した結果が対象日と一致するセッションを取得する。睡眠は前夜に始まるため、
+    UTC range（対象 local date の UTC 窓）は前月 partition も自然に含む。
+    """
+    sql = f"""
+        SELECT
+            {_TS.format(col="started_at_utc")} AS started_at_utc,
+            {_TS.format(col="ended_at_utc")} AS ended_at_utc,
+            duration_seconds,
+            session_type
+        FROM read_parquet(?)
+        WHERE data_type = 'sleep'
+          AND (({_TS.format(col="ended_at_utc")} AT TIME ZONE 'UTC')
+                AT TIME ZONE '{params.tz_name}')::DATE = ?
+        ORDER BY started_at_utc ASC
+    """
+    paths = build_partition_paths(
+        params.r2_config,
+        datasets.GOOGLE_HEALTH_SESSIONS,
+        params.utc_start,
+        params.utc_end,
+    )
+    return execute_query(params.conn, sql, [paths, params.start_date])

--- a/egograph/backend/infrastructure/database/timeline_queries.py
+++ b/egograph/backend/infrastructure/database/timeline_queries.py
@@ -242,7 +242,7 @@ def fetch_google_health_sleep_sessions(params: QueryParams) -> list[dict[str, An
         FROM read_parquet(?)
         WHERE data_type = 'sleep'
           AND (({_TS.format(col="ended_at_utc")} AT TIME ZONE 'UTC')
-                AT TIME ZONE '{params.tz_name}')::DATE = ?
+                AT TIME ZONE ?)::DATE = ?
         ORDER BY started_at_utc ASC
     """
     paths = build_partition_paths(
@@ -251,4 +251,4 @@ def fetch_google_health_sleep_sessions(params: QueryParams) -> list[dict[str, An
         params.utc_start,
         params.utc_end,
     )
-    return execute_query(params.conn, sql, [paths, params.start_date])
+    return execute_query(params.conn, sql, [paths, params.tz_name, params.start_date])

--- a/egograph/backend/infrastructure/repositories/__init__.py
+++ b/egograph/backend/infrastructure/repositories/__init__.py
@@ -11,6 +11,9 @@ from backend.infrastructure.repositories.google_health_repository import (
     GoogleHealthRepository,
 )
 from backend.infrastructure.repositories.spotify_repository import SpotifyRepository
+from backend.infrastructure.repositories.timeline_repository import (
+    TimelineRepository,
+)
 from backend.infrastructure.repositories.youtube_repository import YouTubeRepository
 
 __all__ = [
@@ -18,5 +21,6 @@ __all__ = [
     "GitHubRepository",
     "GoogleHealthRepository",
     "SpotifyRepository",
+    "TimelineRepository",
     "YouTubeRepository",
 ]

--- a/egograph/backend/infrastructure/repositories/timeline_repository.py
+++ b/egograph/backend/infrastructure/repositories/timeline_repository.py
@@ -1,0 +1,862 @@
+"""Daily Timeline リポジトリ。
+
+複数 source の観測イベントを1日単位で時刻順に統合する read model を構築する。
+
+責務:
+    - source ごとの raw クエリ呼び出し
+    - 共通 shape への正規化
+    - ``started_at_utc`` + source priority による安定ソート
+    - Browser History / YouTube 関連候補（correlation）の生成
+    - 観測 gap の生成
+    - source ごとの coverage 生成
+    - Google Health 日次サマリの添付
+
+純粋論理（正規化・ソート・correlation・gap）はモジュール直下の関数として切り出し、
+DuckDB に依存せず単体テスト可能にしている。これは「UTC range を入力にした builder」
+として将来の別契約でも再利用できるようにするため。
+"""
+
+import logging
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+from zoneinfo import ZoneInfo
+
+from dataset_catalog import datasets
+
+from backend.config import R2Config
+from backend.constants import (
+    CORRELATION_YOUTUBE_WINDOW_SECONDS,
+    TIMELINE_SOURCE_PRIORITY,
+    TIMELINE_SOURCES,
+)
+from backend.infrastructure.database import timeline_queries as queries
+from backend.infrastructure.database.connection import DuckDBConnection
+from backend.infrastructure.database.query_params import QueryParams
+from backend.validators import to_utc_range
+
+logger = logging.getLogger(__name__)
+
+# event_id の中央要素（dataset に安定した短名を与える）。
+_EVENT_TYPE_SUFFIX = {
+    "spotify:music_play": "play",
+    "browser_history:page_view": "page_view",
+    "youtube:youtube_watch": "watch_event",
+    "github:github_commit": "commit",
+    "github:github_pull_request": "pull_request",
+}
+
+# source ごとの代表 dataset（存在確認用）と、items 系 source の取得計画。
+_ITEM_SOURCE_DATASETS = {
+    "spotify": datasets.SPOTIFY_PLAYS,
+    "youtube": datasets.YOUTUBE_WATCH_EVENTS,
+    "browser_history": datasets.BROWSER_HISTORY_PAGE_VIEWS,
+    "github:commits": datasets.GITHUB_COMMITS,
+    "github:pull_requests": datasets.GITHUB_PULL_REQUESTS,
+}
+
+
+class TimelineRepository:
+    """Daily Timeline の統合ビューを構築するリポジトリ。"""
+
+    def __init__(self, r2_config: R2Config) -> None:
+        self.r2_config = r2_config
+
+    def build_daily_timeline(
+        self,
+        *,
+        date_local: date,
+        timezone: ZoneInfo,
+        sources: set[str],
+        gap_minutes: int | None,
+        include_correlations: bool,
+        include_raw_refs: bool,
+        limit: int,
+    ) -> dict[str, Any]:
+        """1日分のタイムライン応答を構築する。
+
+        Args:
+            date_local: ``timezone`` 上のローカル日付。
+            timezone: 日付範囲と表示用 local 時刻の生成に使うタイムゾーン。
+            sources: 含める source の集合。空なら全 source。
+            gap_minutes: この分数以上の観測欠落を gap とする。``None`` または
+                ``0`` のときは gap 検出を行わない。
+            include_correlations: ``True`` なら関連候補を生成する。
+            include_raw_refs: ``True`` なら ``raw_ref`` を各 item に付与する。
+            limit: ``items`` の最大件数。
+        """
+        effective_sources = set(sources) if sources else set(TIMELINE_SOURCES)
+        utc_start, utc_end = to_utc_range(date_local, date_local, timezone)
+
+        with DuckDBConnection(self.r2_config) as conn:
+            params = QueryParams(
+                conn=conn,
+                r2_config=self.r2_config,
+                start_date=date_local,
+                end_date=date_local,
+                utc_start=utc_start,
+                utc_end=utc_end,
+                tz_name=str(timezone),
+            )
+            items, coverage = self._collect_items(params, effective_sources)
+            google_health_summary, gh_dataset_exists = (
+                self._build_google_health_summary(
+                    params, date_local, timezone, effective_sources
+                )
+            )
+
+        coverage = self._finalize_coverage(
+            coverage,
+            effective_sources=effective_sources,
+            google_health_dataset_exists=gh_dataset_exists,
+            google_health_summary_available=google_health_summary is not None,
+        )
+
+        items = sort_items(items)
+        truncated = len(items) > limit
+        items = items[:limit]
+        apply_raw_refs(items, include_raw_refs)
+
+        correlations = build_correlations(items) if include_correlations else []
+        gaps = build_gaps(items, gap_minutes=gap_minutes, timezone=timezone)
+
+        # gap / correlation の計算が終わったあとに UTC / local を ISO 文字列へ直列化する
+        finalize_item_times(items, timezone)
+
+        daily_summaries: dict[str, Any] = {}
+        if google_health_summary is not None:
+            daily_summaries["google_health"] = google_health_summary
+
+        logger.info(
+            "Built daily timeline: date=%s, tz=%s, items=%s, correlations=%s, "
+            "gaps=%s, truncated=%s",
+            date_local,
+            timezone,
+            len(items),
+            len(correlations),
+            len(gaps),
+            truncated,
+        )
+        return {
+            "date": date_local.isoformat(),
+            "timezone": str(timezone),
+            "range": _build_range(date_local, timezone, utc_start, utc_end),
+            "items": items,
+            "correlations": correlations,
+            "gaps": gaps,
+            "daily_summaries": daily_summaries,
+            "coverage": coverage,
+            "meta": {
+                "item_count": len(items),
+                "truncated": truncated,
+                "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # items 収集
+    # ------------------------------------------------------------------
+
+    def _collect_items(
+        self,
+        params: QueryParams,
+        effective_sources: set[str],
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        """各 source の raw クエリを呼び出し、正規化 item と coverage を返す。"""
+        items: list[dict[str, Any]] = []
+        coverage: dict[str, Any] = {}
+
+        single_source_plan = (
+            ("spotify", queries.fetch_spotify_plays, normalize_spotify_play),
+            (
+                "browser_history",
+                queries.fetch_browser_page_views,
+                normalize_browser_page_view,
+            ),
+            ("youtube", queries.fetch_youtube_watch_events, normalize_youtube_watch),
+        )
+        for source, fetcher, normalizer in single_source_plan:
+            coverage[source] = self._collect_single_source(
+                params,
+                source=source,
+                dataset=_ITEM_SOURCE_DATASETS[source],
+                fetcher=fetcher,
+                normalizer=normalizer,
+                included=source in effective_sources,
+                items=items,
+            )
+
+        coverage["github"] = self._collect_github(params, effective_sources, items)
+        return items, coverage
+
+    def _collect_single_source(
+        self,
+        params: QueryParams,
+        *,
+        source: str,
+        dataset,
+        fetcher,
+        normalizer,
+        included: bool,
+        items: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        if not included:
+            return _coverage_excluded()
+        if not queries.dataset_has_parquet(params, dataset):
+            return _coverage_not_available()
+        raw_rows = fetcher(params)
+        items.extend(normalizer(row) for row in raw_rows)
+        return _coverage_ok(len(raw_rows))
+
+    def _collect_github(
+        self,
+        params: QueryParams,
+        effective_sources: set[str],
+        items: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        if "github" not in effective_sources:
+            return _coverage_excluded()
+
+        plan = (
+            (
+                _ITEM_SOURCE_DATASETS["github:commits"],
+                queries.fetch_github_commits,
+                normalize_github_commit,
+            ),
+            (
+                _ITEM_SOURCE_DATASETS["github:pull_requests"],
+                queries.fetch_github_pull_requests,
+                normalize_github_pull_request,
+            ),
+        )
+        any_exists = False
+        count = 0
+        for dataset, fetcher, normalizer in plan:
+            if not queries.dataset_has_parquet(params, dataset):
+                continue
+            any_exists = True
+            raw_rows = fetcher(params)
+            items.extend(normalizer(row) for row in raw_rows)
+            count += len(raw_rows)
+        return _coverage_ok(count) if any_exists else _coverage_not_available()
+
+    # ------------------------------------------------------------------
+    # Google Health 日次サマリ
+    # ------------------------------------------------------------------
+
+    def _build_google_health_summary(
+        self,
+        params: QueryParams,
+        date_local: date,
+        tz: ZoneInfo,
+        effective_sources: set[str],
+    ) -> tuple[dict[str, Any] | None, bool]:
+        """Google Health 日次サマリと、daily_metrics dataset の存在可否を返す。"""
+        dataset = datasets.GOOGLE_HEALTH_DAILY_METRICS
+        if "google_health" not in effective_sources:
+            return None, False
+        dataset_exists = queries.dataset_has_parquet(params, dataset)
+        if not dataset_exists:
+            return None, False
+
+        metrics = queries.fetch_google_health_daily_metrics(params)
+        sleep_sessions = queries.fetch_google_health_sleep_sessions(params)
+        summary = _compose_google_health_summary(
+            metrics, sleep_sessions, date_local, tz
+        )
+        return summary, True
+
+    def _finalize_coverage(
+        self,
+        coverage: dict[str, Any],
+        *,
+        effective_sources: set[str],
+        google_health_dataset_exists: bool,
+        google_health_summary_available: bool,
+    ) -> dict[str, Any]:
+        """google_health の coverage を決定し、順序を安定させる。"""
+        ordered: dict[str, Any] = {}
+        for source in TIMELINE_SOURCES:
+            if source in coverage:
+                ordered[source] = coverage[source]
+            elif source == "google_health":
+                if "google_health" not in effective_sources:
+                    ordered["google_health"] = _coverage_excluded()
+                elif not google_health_dataset_exists:
+                    ordered["google_health"] = _coverage_not_available()
+                else:
+                    ordered["google_health"] = {
+                        "included": True,
+                        "event_count": 0,
+                        "status": "ok",
+                        "summary_available": google_health_summary_available,
+                    }
+        return ordered
+
+
+# ============================================================
+# 正規化関数: raw 行 → 共通 shape の timeline item
+# ============================================================
+
+
+def normalize_spotify_play(row: dict[str, Any]) -> dict[str, Any]:
+    """Spotify 再生行を timeline item に正規化する。"""
+    record_id = str(row["play_id"])
+    artists = row.get("artist_names") or []
+    primary_artist = artists[0] if len(artists) >= 1 else None
+    track_name = row.get("track_name")
+    title = (
+        f"{primary_artist} - {track_name}"
+        if primary_artist and track_name
+        else (track_name or primary_artist or "Spotify play")
+    )
+    ms_played = _as_float(row.get("ms_played"))
+    duration_seconds = int(ms_played / 1000) if ms_played and ms_played > 0 else None
+
+    return {
+        "event_id": _event_id("spotify", "music_play", record_id),
+        "source": "spotify",
+        "kind": "music_play",
+        "started_at_utc": _to_utc(row.get("played_at_utc")),
+        "started_at_local": None,
+        "ended_at_utc": None,
+        "ended_at_local": None,
+        "duration_seconds": duration_seconds,
+        "title": title,
+        "subtitle": "Spotify play",
+        "url": None,
+        "raw_ref": _raw_ref("spotify.plays", record_id, "played_at_utc"),
+        "metadata": {
+            "play_id": record_id,
+            "track_id": row.get("track_id"),
+            "track_name": track_name,
+            "artist_names": list(artists),
+            "album_name": row.get("album_name"),
+            "ms_played": ms_played,
+        },
+    }
+
+
+def normalize_browser_page_view(row: dict[str, Any]) -> dict[str, Any]:
+    """Browser History page view 行を timeline item に正規化する。"""
+    record_id = str(row["page_view_id"])
+    started = _to_utc(row.get("started_at_utc"))
+    ended = _to_utc(row.get("ended_at_utc"))
+    url = row.get("url")
+
+    return {
+        "event_id": _event_id("browser_history", "page_view", record_id),
+        "source": "browser_history",
+        "kind": "page_view",
+        "started_at_utc": started,
+        "started_at_local": None,
+        "ended_at_utc": ended,
+        "ended_at_local": None,
+        "duration_seconds": _duration_seconds(started, ended),
+        "title": row.get("title") or url or "Untitled page",
+        "subtitle": _domain_of(url),
+        "url": url,
+        "raw_ref": _raw_ref("browser_history.page_views", record_id, "started_at_utc"),
+        "metadata": {
+            "page_view_id": record_id,
+            "browser": row.get("browser"),
+            "profile": row.get("profile"),
+            "transition": row.get("transition"),
+            "visit_span_count": row.get("visit_span_count"),
+        },
+    }
+
+
+def normalize_youtube_watch(row: dict[str, Any]) -> dict[str, Any]:
+    """YouTube 視聴イベント行を timeline item に正規化する。"""
+    record_id = str(row["watch_event_id"])
+    return {
+        "event_id": _event_id("youtube", "youtube_watch", record_id),
+        "source": "youtube",
+        "kind": "youtube_watch",
+        "started_at_utc": _to_utc(row.get("watched_at_utc")),
+        "started_at_local": None,
+        "ended_at_utc": None,
+        "ended_at_local": None,
+        "duration_seconds": None,
+        "title": row.get("video_title") or "YouTube watch",
+        "subtitle": row.get("channel_name"),
+        "url": row.get("video_url"),
+        "raw_ref": _raw_ref("youtube.watch_events", record_id, "watched_at_utc"),
+        "metadata": {
+            "watch_event_id": record_id,
+            "video_id": row.get("video_id"),
+            "channel_id": row.get("channel_id"),
+            "channel_name": row.get("channel_name"),
+            "content_type": row.get("content_type"),
+            "source": row.get("source"),
+            "source_device": row.get("source_device"),
+        },
+    }
+
+
+def normalize_github_commit(row: dict[str, Any]) -> dict[str, Any]:
+    """GitHub commit 行を timeline item に正規化する。"""
+    record_id = str(row["commit_event_id"])
+    return {
+        "event_id": _event_id("github", "github_commit", record_id),
+        "source": "github",
+        "kind": "github_commit",
+        "started_at_utc": _to_utc(row.get("committed_at_utc")),
+        "started_at_local": None,
+        "ended_at_utc": None,
+        "ended_at_local": None,
+        "duration_seconds": None,
+        "title": _commit_title(row.get("message")),
+        "subtitle": row.get("repo_full_name"),
+        "url": None,
+        "raw_ref": _raw_ref("github.commits", record_id, "committed_at_utc"),
+        "metadata": {
+            "commit_event_id": record_id,
+            "sha": row.get("sha"),
+            "owner": row.get("owner"),
+            "repo": row.get("repo"),
+            "additions": row.get("additions"),
+            "deletions": row.get("deletions"),
+            "changed_files_count": row.get("changed_files_count"),
+        },
+    }
+
+
+def normalize_github_pull_request(row: dict[str, Any]) -> dict[str, Any]:
+    """GitHub Pull Request 行を timeline item に正規化する。"""
+    record_id = str(row["pr_event_id"])
+    return {
+        "event_id": _event_id("github", "github_pull_request", record_id),
+        "source": "github",
+        "kind": "github_pull_request",
+        "started_at_utc": _to_utc(row.get("updated_at_utc")),
+        "started_at_local": None,
+        "ended_at_utc": None,
+        "ended_at_local": None,
+        "duration_seconds": None,
+        "title": row.get("title") or "Pull Request",
+        "subtitle": row.get("repo_full_name"),
+        "url": None,
+        "raw_ref": _raw_ref("github.pull_requests", record_id, "updated_at_utc"),
+        "metadata": {
+            "pr_event_id": record_id,
+            "pr_number": row.get("pr_number"),
+            "action": row.get("action"),
+            "state": row.get("state"),
+            "is_merged": row.get("is_merged"),
+            "owner": row.get("owner"),
+            "repo": row.get("repo"),
+            "labels": list(row.get("labels") or []),
+            "additions": row.get("additions"),
+            "deletions": row.get("deletions"),
+            "changed_files_count": row.get("changed_files_count"),
+        },
+    }
+
+
+# ============================================================
+# ソート
+# ============================================================
+
+
+def sort_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """``started_at_utc`` 昇順、source priority、event_id で安定ソートする。"""
+    return sorted(
+        items,
+        key=lambda item: (
+            item["started_at_utc"] or datetime.max.replace(tzinfo=UTC),
+            TIMELINE_SOURCE_PRIORITY.get(item["source"], 99),
+            item["event_id"],
+        ),
+    )
+
+
+# ============================================================
+# Correlation
+# ============================================================
+
+
+def build_correlations(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Browser History と YouTube の関連候補を生成する。
+
+    ``items`` の削除や統合は行わず、注釈のみを返す。
+    """
+    page_views = [item for item in items if item["source"] == "browser_history"]
+    watches = [item for item in items if item["source"] == "youtube"]
+    if not page_views or not watches:
+        return []
+
+    correlations: list[dict[str, Any]] = []
+    for page_view in page_views:
+        pv_started = page_view["started_at_utc"]
+        if pv_started is None:
+            continue
+        pv_url = page_view.get("url")
+        pv_video_id = _extract_youtube_video_id(pv_url)
+        pv_is_youtube = _is_youtube_url(pv_url)
+        for watch in watches:
+            watch_started = watch["started_at_utc"]
+            if watch_started is None:
+                continue
+            delta = abs((pv_started - watch_started).total_seconds())
+            if delta > CORRELATION_YOUTUBE_WINDOW_SECONDS:
+                continue
+
+            watch_video_id = _extract_youtube_video_id(watch.get("url"))
+            if pv_video_id and watch_video_id and pv_video_id == watch_video_id:
+                correlations.append(
+                    _correlation(
+                        [page_view["event_id"], watch["event_id"]],
+                        reason="same_youtube_video_url_within_120_seconds",
+                        confidence=0.95,
+                    )
+                )
+            elif pv_is_youtube and not pv_video_id:
+                correlations.append(
+                    _correlation(
+                        [page_view["event_id"], watch["event_id"]],
+                        reason="youtube_url_near_watch_event",
+                        confidence=0.75,
+                    )
+                )
+    return _with_sequential_ids(correlations)
+
+
+def _correlation(
+    event_ids: list[str],
+    *,
+    reason: str,
+    confidence: float,
+) -> dict[str, Any]:
+    return {
+        "correlation_id": "",
+        "kind": "same_activity_candidate",
+        "event_ids": event_ids,
+        "confidence": confidence,
+        "reason": reason,
+    }
+
+
+def _with_sequential_ids(
+    correlations: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """source pair ごとに ``corr_<tag>_<seq>`` の決定的 ID を振る。"""
+    counters: dict[str, int] = {}
+    for correlation in correlations:
+        sources = sorted({eid.split(":", 1)[0] for eid in correlation["event_ids"]})
+        tag = "_".join(sources)
+        counters[tag] = counters.get(tag, 0) + 1
+        correlation["correlation_id"] = f"corr_{tag}_{counters[tag]:03d}"
+    return correlations
+
+
+# ============================================================
+# Gap
+# ============================================================
+
+
+def build_gaps(
+    items: list[dict[str, Any]],
+    *,
+    gap_minutes: int | None,
+    timezone: ZoneInfo,
+) -> list[dict[str, Any]]:
+    """隣接する観測イベント間で ``gap_minutes`` 以上の空きを gap として生成する。
+
+    gap 判定は ``started_at_utc`` のみを使い、``ended_at_utc`` は使わない。
+    「観測イベントがない」ことだけを意味し、長時間占有していたと断定しない。
+    日の先頭・末尾の範囲外区間は gap にしない（前後両方に観測イベントが必要）。
+    """
+    if not gap_minutes or gap_minutes <= 0:
+        return []
+
+    ordered = [item for item in sort_items(items) if item["started_at_utc"]]
+    if len(ordered) < 2:
+        return []
+
+    threshold = timedelta(minutes=gap_minutes)
+    gaps: list[dict[str, Any]] = []
+    for previous, following in zip(ordered, ordered[1:]):
+        start = previous["started_at_utc"]
+        end = following["started_at_utc"]
+        if end - start < threshold:
+            continue
+        gaps.append(
+            _gap(
+                start,
+                end,
+                preceded_by=previous["event_id"],
+                followed_by=following["event_id"],
+                tz=timezone,
+            )
+        )
+    return gaps
+
+
+def _gap(
+    start_utc: datetime,
+    end_utc: datetime,
+    *,
+    preceded_by: str,
+    followed_by: str,
+    tz: ZoneInfo,
+) -> dict[str, Any]:
+    duration_minutes = int((end_utc - start_utc).total_seconds() // 60)
+    return {
+        "gap_id": (
+            f"gap_{start_utc.astimezone(tz):%Y%m%d_%H%M}_{end_utc.astimezone(tz):%H%M}"
+        ),
+        "kind": "no_observed_events_gap",
+        "start_utc": _iso_utc(start_utc),
+        "end_utc": _iso_utc(end_utc),
+        "start_local": _iso_local(start_utc, tz),
+        "end_local": _iso_local(end_utc, tz),
+        "duration_minutes": duration_minutes,
+        "preceded_by_event_id": preceded_by,
+        "followed_by_event_id": followed_by,
+    }
+
+
+# ============================================================
+# raw_ref 制御 / local 時刻付与
+# ============================================================
+
+
+def apply_raw_refs(items: list[dict[str, Any]], include: bool) -> None:
+    """``include=False`` のとき ``raw_ref`` を各 item から取り除く。"""
+    if include:
+        return
+    for item in items:
+        item.pop("raw_ref", None)
+
+
+def finalize_item_times(items: list[dict[str, Any]], tz: ZoneInfo) -> None:
+    """各 item の ``*_utc`` / ``*_local`` を ISO 文字列へ直列化する。
+
+    gap / correlation の計算は datetime のまま行う必要があるため、
+    それらが終わったあとの最終段階で呼ぶ。
+    """
+    for item in items:
+        started = item.get("started_at_utc")
+        ended = item.get("ended_at_utc")
+        item["started_at_utc"] = _iso_utc(started)
+        item["started_at_local"] = _iso_local(started, tz)
+        item["ended_at_utc"] = _iso_utc(ended)
+        item["ended_at_local"] = _iso_local(ended, tz)
+
+
+# ============================================================
+# Google Health 日次サマリ構築
+# ============================================================
+
+
+def _compose_google_health_summary(
+    metrics: dict[str, Any],
+    sleep_sessions: list[dict[str, Any]],
+    date_local: date,
+    tz: ZoneInfo,
+) -> dict[str, Any] | None:
+    """日次指標と睡眠セッションから Google Health 日次サマリを構築する。"""
+    steps = _as_float(metrics.get("steps"))
+    active_energy = _as_float(metrics.get("active_energy_burned"))
+    resting_hr = _as_float(metrics.get("resting_heart_rate"))
+    sleep_duration_seconds = _as_float(metrics.get("sleep_duration_seconds"))
+    sleep = _build_sleep(sleep_sessions, sleep_duration_seconds, tz)
+
+    has_any = (
+        any(
+            value is not None
+            for value in (steps, active_energy, resting_hr, sleep_duration_seconds)
+        )
+        or sleep is not None
+    )
+    if not has_any:
+        return None
+
+    return {
+        "date": date_local.isoformat(),
+        "timezone": str(tz),
+        "resting_heart_rate_bpm": _to_int(resting_hr),
+        "sleep": sleep,
+        "steps": _to_int(steps),
+        "active_energy_kcal": _to_int(active_energy),
+    }
+
+
+def _build_sleep(
+    sessions: list[dict[str, Any]],
+    sleep_duration_seconds: float | None,
+    tz: ZoneInfo,
+) -> dict[str, Any] | None:
+    """睡眠セッションと日次睡眠時間から sleep オブジェクトを構築する。"""
+    valid = [
+        s
+        for s in sessions
+        if _to_utc(s.get("started_at_utc")) and _to_utc(s.get("ended_at_utc"))
+    ]
+    if not valid and sleep_duration_seconds is None:
+        return None
+
+    asleep_minutes = (
+        round(sleep_duration_seconds / 60)
+        if sleep_duration_seconds is not None
+        else None
+    )
+    if valid:
+        starts = [_to_utc(s["started_at_utc"]) for s in valid]
+        ends = [_to_utc(s["ended_at_utc"]) for s in valid]
+        min_start = min(starts)
+        max_end = max(ends)
+        in_bed_minutes = round((max_end - min_start).total_seconds() / 60)
+        return {
+            "asleep_minutes": (
+                asleep_minutes if asleep_minutes is not None else in_bed_minutes
+            ),
+            "in_bed_minutes": in_bed_minutes,
+            "started_at_local": _iso_local(min_start, tz),
+            "ended_at_local": _iso_local(max_end, tz),
+        }
+    return {"asleep_minutes": asleep_minutes}
+
+
+# ============================================================
+# 内部ヘルパ
+# ============================================================
+
+
+def _build_range(
+    date_local: date,
+    tz: ZoneInfo,
+    utc_start: datetime,
+    utc_end: datetime,
+) -> dict[str, Any]:
+    """top level の range オブジェクトを構築する。"""
+    start_local = datetime(date_local.year, date_local.month, date_local.day, tzinfo=tz)
+    end_local = start_local + timedelta(days=1)
+    return {
+        "start_local": start_local.isoformat(),
+        "end_local": end_local.isoformat(),
+        "start_utc": _iso_utc(utc_start.replace(tzinfo=UTC)),
+        "end_utc": _iso_utc(utc_end.replace(tzinfo=UTC)),
+    }
+
+
+def _event_id(source: str, kind: str, record_id: str) -> str:
+    suffix = _EVENT_TYPE_SUFFIX[f"{source}:{kind}"]
+    return f"{source}:{suffix}:{record_id}"
+
+
+def _raw_ref(dataset_id: str, record_id: str, timestamp_column: str) -> dict[str, str]:
+    return {
+        "dataset_id": dataset_id,
+        "record_id": record_id,
+        "timestamp_column": timestamp_column,
+    }
+
+
+def _coverage_ok(event_count: int) -> dict[str, Any]:
+    return {"included": True, "event_count": event_count, "status": "ok"}
+
+
+def _coverage_excluded() -> dict[str, Any]:
+    return {"included": False, "event_count": 0, "status": "excluded"}
+
+
+def _coverage_not_available() -> dict[str, Any]:
+    return {"included": True, "event_count": 0, "status": "not_available"}
+
+
+def _to_utc(value: Any) -> datetime | None:
+    """raw 行の時刻値を UTC aware datetime に正規化する。"""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        dt = datetime.fromisoformat(str(value))
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _iso_utc(dt: datetime | None) -> str | None:
+    if dt is None:
+        return None
+    aware = dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+    return aware.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _iso_local(dt: datetime | None, tz: ZoneInfo) -> str | None:
+    if dt is None:
+        return None
+    aware = dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+    return aware.astimezone(tz).isoformat()
+
+
+def _duration_seconds(started: datetime | None, ended: datetime | None) -> int | None:
+    if started is None or ended is None:
+        return None
+    delta = (ended - started).total_seconds()
+    if delta <= 0:
+        return None
+    return int(delta)
+
+
+def _domain_of(url: str | None) -> str | None:
+    if not url:
+        return None
+    return urlparse(url).netloc or None
+
+
+_YOUTUBE_HOSTS = frozenset(
+    {"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be", "music.youtube.com"}
+)
+
+
+def _is_youtube_url(url: str | None) -> bool:
+    if not url:
+        return False
+    return (urlparse(url).netloc or "").lower() in _YOUTUBE_HOSTS
+
+
+def _extract_youtube_video_id(url: str | None) -> str | None:
+    """YouTube 動画 URL から video id を抽出する。抽出できない場合は None。"""
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if (parsed.netloc or "").lower() not in _YOUTUBE_HOSTS:
+        return None
+    if parsed.netloc.lower() == "youtu.be":
+        return parsed.path.strip("/") or None
+    query = parse_qs(parsed.query)
+    values = query.get("v")
+    if values and values[0]:
+        return values[0]
+    return None
+
+
+def _commit_title(message: str | None) -> str:
+    """commit message の1行目を title とする。"""
+    if not message:
+        return "Commit"
+    first_line = message.splitlines()[0].strip()
+    return first_line or "Commit"
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    if result != result:  # NaN
+        return None
+    return result
+
+
+def _to_int(value: float | None) -> int | None:
+    if value is None:
+        return None
+    return int(round(value))

--- a/egograph/backend/main.py
+++ b/egograph/backend/main.py
@@ -20,6 +20,7 @@ from backend.api import (
     github,
     google_health,
     health,
+    timeline,
     youtube,
 )
 from backend.config import BackendConfig
@@ -157,6 +158,7 @@ def create_app(config: BackendConfig | None = None) -> FastAPI:
     app.include_router(github.router)
     app.include_router(youtube.router)
     app.include_router(google_health.router)
+    app.include_router(timeline.router)
 
     # MCPサブアプリをマウント
     app.mount("/mcp", mcp_asgi)

--- a/egograph/backend/mcp_server.py
+++ b/egograph/backend/mcp_server.py
@@ -35,7 +35,11 @@ def create_mcp_server(config: BackendConfig) -> FastMCP:
         transport_security=config.mcp_transport_security,
     )
 
-    registry = build_tool_registry(config.r2, tz=config.timezone)
+    registry = build_tool_registry(
+        config.r2,
+        tz=config.timezone,
+        timezone_configured=config.timezone_configured,
+    )
 
     server = mcp._mcp_server
 

--- a/egograph/backend/tests/integration/test_timeline_api.py
+++ b/egograph/backend/tests/integration/test_timeline_api.py
@@ -1,0 +1,562 @@
+"""Daily Timeline の統合テスト。
+
+ローカル compacted Parquet を使って Repository → REST API → MCP Tool の
+一連の流れと、Dataset Catalog との契約を検証する。
+"""
+
+import asyncio
+import json
+from datetime import date, datetime
+from pathlib import Path
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+from dataset_catalog import DATASETS_BY_ID, datasets
+from mcp.types import (
+    CallToolRequest,
+    CallToolRequestParams,
+    ListToolsRequest,
+)
+from pydantic import SecretStr
+
+from backend.config import R2Config
+from backend.dependencies import get_daily_timeline_tool
+from backend.domain.tools.timeline.daily import GetDailyTimelineTool
+from backend.infrastructure.repositories.timeline_repository import (
+    TimelineRepository,
+)
+from backend.mcp_server import create_mcp_server
+
+JST = ZoneInfo("Asia/Tokyo")
+
+# テスト対象日: 2026-06-28 (JST) = UTC [2026-06-27T15:00, 2026-06-28T15:00)
+TARGET_DATE = date(2026, 6, 28)
+
+
+def _utc(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _local_root(tmp_path: Path) -> Path:
+    return tmp_path / "mirror"
+
+
+def _compacted_dir(local_root: Path, domain: str, dataset_path: str) -> Path:
+    return local_root / "compacted" / domain / dataset_path / "year=2026" / "month=06"
+
+
+def _write_all_sources(tmp_path: Path) -> Path:
+    """全 source の compacted Parquet を 2026-06 月に書き出す。"""
+    local_root = _local_root(tmp_path)
+
+    # spotify.plays
+    spotify_dir = _compacted_dir(local_root, "events", "spotify/plays")
+    spotify_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "play_id": "play_1",
+                "played_at_utc": _utc("2026-06-28T00:12:03"),
+                "track_id": "t1",
+                "track_name": "だから僕は僕を辞めた",
+                "artist_names": ["ヨルシカ"],
+                "album_name": "盗作",
+                "ms_played": 222000,
+            }
+        ]
+    ).to_parquet(spotify_dir / "data.parquet")
+
+    # browser_history.page_views（YouTube 視聴ページ）
+    browser_dir = _compacted_dir(local_root, "events", "browser_history/page_views")
+    browser_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "page_view_id": "pv_1",
+                "started_at_utc": _utc("2026-06-28T03:00:00"),
+                "ended_at_utc": _utc("2026-06-28T03:00:30"),
+                "url": "https://www.youtube.com/watch?v=abc",
+                "title": "YouTube Video",
+                "browser": "edge",
+                "profile": "Default",
+                "transition": "link",
+                "visit_span_count": 1,
+            }
+        ]
+    ).to_parquet(browser_dir / "data.parquet")
+
+    # youtube.watch_events（同一 video id → correlation 対象）
+    youtube_dir = _compacted_dir(local_root, "events", "youtube/watch_events")
+    youtube_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "watch_event_id": "we_1",
+                "watched_at_utc": _utc("2026-06-28T03:00:30"),
+                "video_id": "abc",
+                "video_url": "https://www.youtube.com/watch?v=abc",
+                "video_title": "YouTube Video",
+                "channel_id": "c1",
+                "channel_name": "Channel",
+                "content_type": "video",
+                "source": "browser_history",
+                "source_device": "home-pc",
+            }
+        ]
+    ).to_parquet(youtube_dir / "data.parquet")
+
+    # github.commits
+    commit_dir = _compacted_dir(local_root, "events", "github/commits")
+    commit_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "commit_event_id": "commit_1",
+                "owner": "endo-ly",
+                "repo": "egograph",
+                "repo_full_name": "endo-ly/egograph",
+                "sha": "abc123",
+                "message": "Add timeline feature\n\nDetail",
+                "committed_at_utc": _utc("2026-06-28T05:00:00"),
+                "changed_files_count": 3,
+                "additions": 100,
+                "deletions": 10,
+            }
+        ]
+    ).to_parquet(commit_dir / "data.parquet")
+
+    # github.pull_requests
+    pr_dir = _compacted_dir(local_root, "events", "github/pull_requests")
+    pr_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "pr_event_id": "pr_1",
+                "owner": "endo-ly",
+                "repo": "egograph",
+                "repo_full_name": "endo-ly/egograph",
+                "pr_number": 79,
+                "action": "opened",
+                "state": "open",
+                "is_merged": False,
+                "title": "Daily Timeline",
+                "labels": ["feature"],
+                "updated_at_utc": _utc("2026-06-28T06:00:00"),
+                "additions": 500,
+                "deletions": 50,
+                "changed_files_count": 8,
+            }
+        ]
+    ).to_parquet(pr_dir / "data.parquet")
+
+    # google_health.daily_metrics
+    gh_dir = _compacted_dir(local_root, "events", "google_health/daily_metrics")
+    gh_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "data_type": "steps",
+                "date": TARGET_DATE,
+                "metric_name": "steps",
+                "value": 8120.0,
+                "unit": "count",
+            },
+            {
+                "data_type": "active-energy-burned",
+                "date": TARGET_DATE,
+                "metric_name": "active_energy_burned",
+                "value": 420.0,
+                "unit": "kcal",
+            },
+            {
+                "data_type": "daily-resting-heart-rate",
+                "date": TARGET_DATE,
+                "metric_name": "resting_heart_rate",
+                "value": 53.0,
+                "unit": "bpm",
+            },
+            {
+                "data_type": "sleep",
+                "date": TARGET_DATE,
+                "metric_name": "sleep_duration",
+                "value": 21120.0,
+                "unit": "second",
+            },
+        ]
+    ).to_parquet(gh_dir / "data.parquet")
+
+    # google_health.sessions（睡眠: 前夜に開始し 6/28 朝に起床）
+    sessions_dir = _compacted_dir(local_root, "events", "google_health/sessions")
+    sessions_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "data_type": "sleep",
+                "started_at_utc": _utc("2026-06-27T14:48:00"),
+                "ended_at_utc": _utc("2026-06-27T22:03:00"),
+                "duration_seconds": 26100,
+                "session_type": "sleep",
+            }
+        ]
+    ).to_parquet(sessions_dir / "data.parquet")
+
+    return local_root
+
+
+def _build_r2_config(local_root: Path) -> R2Config:
+    return R2Config.model_construct(
+        endpoint_url="https://test.r2.cloudflarestorage.com",
+        access_key_id="test_key",
+        secret_access_key=SecretStr("test_secret"),
+        bucket_name="test-bucket",
+        raw_path="raw/",
+        events_path="events/",
+        master_path="master/",
+        local_parquet_root=str(local_root),
+    )
+
+
+def _build_tool(local_root: Path) -> GetDailyTimelineTool:
+    repository = TimelineRepository(_build_r2_config(local_root))
+    return GetDailyTimelineTool(repository, default_timezone=JST)
+
+
+# ============================================================
+# Repository 統合: 全 source 統合ビュー
+# ============================================================
+
+
+class TestBuildDailyTimelineIntegration:
+    """Repository が全 source を統合したビューを正しく構築するか。"""
+
+    def test_builds_full_timeline(self, tmp_path):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        response = tool.execute(date="2026-06-28", timezone="Asia/Tokyo")
+
+        assert response["date"] == "2026-06-28"
+        assert response["timezone"] == "Asia/Tokyo"
+        assert response["range"]["start_utc"] == "2026-06-27T15:00:00Z"
+        assert response["range"]["end_utc"] == "2026-06-28T15:00:00Z"
+
+        # google_health は items に入らない。残り5件（commit + pr を含む）。
+        sources_in_items = {item["source"] for item in response["items"]}
+        assert "google_health" not in sources_in_items
+        assert sources_in_items == {"spotify", "browser_history", "youtube", "github"}
+        assert len(response["items"]) == 5
+
+        # ソート順: spotify → browser_history → youtube → commit → pr
+        ordered_sources = [item["source"] for item in response["items"]]
+        assert ordered_sources == [
+            "spotify",
+            "browser_history",
+            "youtube",
+            "github",
+            "github",
+        ]
+
+    def test_correlations_link_browser_and_youtube(self, tmp_path):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        with patch(
+            "backend.infrastructure.database.timeline_queries.dataset_has_parquet",
+            side_effect=lambda _params, dataset: (
+                dataset is not datasets.GOOGLE_HEALTH_DAILY_METRICS
+            ),
+        ):
+            response = tool.execute(date="2026-06-28", timezone="Asia/Tokyo")
+
+        assert len(response["correlations"]) == 1
+        correlation = response["correlations"][0]
+        assert correlation["reason"] == "same_youtube_video_url_within_120_seconds"
+        assert set(correlation["event_ids"]) == {
+            "browser_history:page_view:pv_1",
+            "youtube:watch_event:we_1",
+        }
+
+    def test_gaps_respect_threshold(self, tmp_path):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        response = tool.execute(
+            date="2026-06-28", timezone="Asia/Tokyo", gap_minutes=120
+        )
+        # spotify(00:12) → browser(03:00) のみ 120 分超
+        assert len(response["gaps"]) == 1
+        gap = response["gaps"][0]
+        assert gap["duration_minutes"] >= 120
+        assert gap["preceded_by_event_id"] == "spotify:play:play_1"
+        assert gap["followed_by_event_id"] == "browser_history:page_view:pv_1"
+
+    def test_google_health_daily_summary_attached(self, tmp_path):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        response = tool.execute(date="2026-06-28", timezone="Asia/Tokyo")
+
+        summary = response["daily_summaries"]["google_health"]
+        assert summary["date"] == "2026-06-28"
+        assert summary["steps"] == 8120
+        assert summary["active_energy_kcal"] == 420
+        assert summary["resting_heart_rate_bpm"] == 53
+        assert summary["sleep"]["asleep_minutes"] == 352
+        assert summary["sleep"]["in_bed_minutes"] == 435
+        assert summary["sleep"]["started_at_local"] == "2026-06-27T23:48:00+09:00"
+        assert summary["sleep"]["ended_at_local"] == "2026-06-28T07:03:00+09:00"
+
+    def test_coverage_reports_all_sources(self, tmp_path):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        response = tool.execute(date="2026-06-28", timezone="Asia/Tokyo")
+
+        coverage = response["coverage"]
+        assert coverage["spotify"] == {
+            "included": True,
+            "event_count": 1,
+            "status": "ok",
+        }
+        assert coverage["github"] == {
+            "included": True,
+            "event_count": 2,
+            "status": "ok",
+        }
+        assert coverage["google_health"]["included"] is True
+        assert coverage["google_health"]["status"] == "ok"
+        assert coverage["google_health"]["summary_available"] is True
+
+    def test_not_available_when_dataset_missing(self, tmp_path):
+        # 全 source を書いたあと youtube の parquet だけ削除
+        local_root = _write_all_sources(tmp_path)
+        youtube_parquet = (
+            local_root
+            / "compacted"
+            / "events"
+            / "youtube"
+            / "watch_events"
+            / "year=2026"
+            / "month=06"
+            / "data.parquet"
+        )
+        youtube_parquet.unlink()
+
+        tool = _build_tool(local_root)
+        with patch(
+            "backend.infrastructure.database.timeline_queries.dataset_has_parquet",
+            side_effect=lambda _params, dataset: (
+                dataset is not datasets.YOUTUBE_WATCH_EVENTS
+            ),
+        ):
+            response = tool.execute(date="2026-06-28", timezone="Asia/Tokyo")
+        assert response["coverage"]["youtube"]["status"] == "not_available"
+        # 他 source は正常取得できる
+        assert response["coverage"]["spotify"]["status"] == "ok"
+
+    def test_google_health_not_available_when_dataset_missing(self, tmp_path):
+        local_root = _write_all_sources(tmp_path)
+        # daily_metrics を削除
+        gh_parquet = (
+            local_root
+            / "compacted"
+            / "events"
+            / "google_health"
+            / "daily_metrics"
+            / "year=2026"
+            / "month=06"
+            / "data.parquet"
+        )
+        gh_parquet.unlink()
+
+        tool = _build_tool(local_root)
+        with patch(
+            "backend.infrastructure.database.timeline_queries.dataset_has_parquet",
+            side_effect=lambda _params, dataset: (
+                dataset is not datasets.GOOGLE_HEALTH_DAILY_METRICS
+            ),
+        ):
+            response = tool.execute(date="2026-06-28", timezone="Asia/Tokyo")
+        assert response["coverage"]["google_health"]["status"] == "not_available"
+        assert "google_health" not in response["daily_summaries"]
+
+    def test_excluded_sources_marked(self, tmp_path):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        response = tool.execute(
+            date="2026-06-28",
+            timezone="Asia/Tokyo",
+            sources=["spotify"],
+        )
+        coverage = response["coverage"]
+        assert coverage["spotify"]["status"] == "ok"
+        assert coverage["youtube"]["status"] == "excluded"
+        assert coverage["google_health"]["status"] == "excluded"
+        # spotify のみ items に現れる
+        assert {item["source"] for item in response["items"]} == {"spotify"}
+        # 除外時は daily_summaries に google_health はない
+        assert response["daily_summaries"] == {}
+
+    def test_truncation_respects_limit(self, tmp_path):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        response = tool.execute(date="2026-06-28", timezone="Asia/Tokyo", limit=2)
+        assert response["meta"]["truncated"] is True
+        assert len(response["items"]) == 2
+        assert response["meta"]["item_count"] == 2
+
+    def test_raw_ref_hidden_by_default(self, tmp_path):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        response = tool.execute(date="2026-06-28", timezone="Asia/Tokyo")
+        for item in response["items"]:
+            assert "raw_ref" not in item
+
+    def test_raw_ref_present_when_requested(self, tmp_path):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        response = tool.execute(
+            date="2026-06-28", timezone="Asia/Tokyo", include_raw_refs=True
+        )
+        for item in response["items"]:
+            assert item["raw_ref"]["dataset_id"] in DATASETS_BY_ID
+
+
+# ============================================================
+# REST API と MCP Tool の契約一致
+# ============================================================
+
+
+class TestRestAndMcpContract:
+    """REST API と MCP Tool が同じ response shape を返す。"""
+
+    def test_rest_and_tool_return_same_shape(self, tmp_path, test_client):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        test_client.app.dependency_overrides[get_daily_timeline_tool] = lambda: tool
+
+        params = {
+            "date": "2026-06-28",
+            "timezone": "Asia/Tokyo",
+            "gap_minutes": 120,
+            "include_correlations": "true",
+            "include_raw_refs": "true",
+            "limit": 500,
+        }
+        response = test_client.get(
+            "/v1/data/timeline/daily",
+            params=params,
+            headers={"X-API-Key": "test-backend-key"},
+        )
+        assert response.status_code == 200
+        rest_body = response.json()
+
+        tool_body = tool.execute(
+            date="2026-06-28",
+            timezone="Asia/Tokyo",
+            gap_minutes=120,
+            include_correlations=True,
+            include_raw_refs=True,
+            limit=500,
+        )
+        # generated_at は呼び出しごとに変わるため除外して比較
+        rest_body["meta"].pop("generated_at", None)
+        tool_body["meta"].pop("generated_at", None)
+        assert rest_body == tool_body
+
+    def test_rest_returns_400_on_invalid_date(self, tmp_path, test_client):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        test_client.app.dependency_overrides[get_daily_timeline_tool] = lambda: tool
+
+        response = test_client.get(
+            "/v1/data/timeline/daily?date=not-a-date",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == "invalid_date: expected YYYY-MM-DD"
+
+    def test_rest_returns_400_on_invalid_gap(self, tmp_path, test_client):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        test_client.app.dependency_overrides[get_daily_timeline_tool] = lambda: tool
+
+        response = test_client.get(
+            "/v1/data/timeline/daily?date=2026-06-28&gap_minutes=9999",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+        assert response.status_code == 400
+        assert "invalid_gap_minutes" in response.json()["detail"]
+
+    def test_rest_returns_400_on_invalid_gap_type(self, tmp_path, test_client):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        test_client.app.dependency_overrides[get_daily_timeline_tool] = lambda: tool
+
+        response = test_client.get(
+            "/v1/data/timeline/daily?date=2026-06-28&gap_minutes=abc",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+        assert response.status_code == 400
+        assert "invalid_gap_minutes" in response.json()["detail"]
+
+    def test_rest_returns_400_on_invalid_limit_type(self, tmp_path, test_client):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        test_client.app.dependency_overrides[get_daily_timeline_tool] = lambda: tool
+
+        response = test_client.get(
+            "/v1/data/timeline/daily?date=2026-06-28&limit=abc",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+        assert response.status_code == 400
+        assert "invalid_limit" in response.json()["detail"]
+
+    def test_rest_returns_400_on_invalid_boolean_type(self, tmp_path, test_client):
+        local_root = _write_all_sources(tmp_path)
+        tool = _build_tool(local_root)
+        test_client.app.dependency_overrides[get_daily_timeline_tool] = lambda: tool
+
+        response = test_client.get(
+            "/v1/data/timeline/daily"
+            "?date=2026-06-28&include_correlations=maybe",
+            headers={"X-API-Key": "test-backend-key"},
+        )
+        assert response.status_code == 400
+        assert "invalid_include_correlations" in response.json()["detail"]
+
+    def test_rest_requires_api_key(self, test_client):
+        response = test_client.get("/v1/data/timeline/daily?date=2026-06-28")
+        assert response.status_code == 401
+
+
+class TestMcpServerRegistration:
+    """MCP ToolRegistry に get_daily_timeline が登録される。"""
+
+    def test_registry_includes_timeline_tool(self, mock_backend_config):
+        server = create_mcp_server(mock_backend_config)
+        handler = server._mcp_server.request_handlers[ListToolsRequest]
+        result = asyncio.run(handler(ListToolsRequest(method="tools/list"))).root
+        tool_names = [tool.name for tool in result.tools]
+        assert "get_daily_timeline" in tool_names
+
+    def test_mcp_call_returns_json_payload(self, tmp_path, mock_backend_config):
+        local_root = _write_all_sources(tmp_path)
+        # mock_backend_config が指す local root をテストデータへ差し替え
+        mock_backend_config.r2.local_parquet_root = str(local_root)
+
+        server = create_mcp_server(mock_backend_config)
+        handler = server._mcp_server.request_handlers[CallToolRequest]
+        request = CallToolRequest(
+            method="tools/call",
+            params=CallToolRequestParams(
+                name="get_daily_timeline",
+                arguments={
+                    "date": "2026-06-28",
+                    "timezone": "Asia/Tokyo",
+                    "include_raw_refs": True,
+                },
+            ),
+        )
+        result = asyncio.run(handler(request)).root
+        assert result.isError is False
+        payload = json.loads(result.content[0].text)
+        assert payload["date"] == "2026-06-28"
+        assert len(payload["items"]) == 5
+        assert "google_health" in payload["daily_summaries"]

--- a/egograph/backend/tests/test_mcp_server.py
+++ b/egograph/backend/tests/test_mcp_server.py
@@ -259,7 +259,11 @@ def test_create_mcp_server_with_none_r2(mock_backend_config):
         result = _run_list_tools(server)
 
     # Assert: build_tool_registry が None で呼ばれ、ツール0件で返ることを検証
-    mock_build.assert_called_once_with(None, tz=mock_backend_config.timezone)
+    mock_build.assert_called_once_with(
+        None,
+        tz=mock_backend_config.timezone,
+        timezone_configured=mock_backend_config.timezone_configured,
+    )
     assert isinstance(server, FastMCP)
     assert result.tools == []
 

--- a/egograph/backend/tests/unit/repositories/test_timeline_repository.py
+++ b/egograph/backend/tests/unit/repositories/test_timeline_repository.py
@@ -1,0 +1,494 @@
+"""Daily Timeline リポジトリの純粋論理の単体テスト。
+
+正規化、ソート、correlation、gap、local 時刻付与、Google Health 日次サマリ構築など、
+DuckDB に依存しない関数を検証する。
+"""
+
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+from dataset_catalog import datasets
+from pydantic import SecretStr
+
+from backend.config import R2Config
+from backend.infrastructure.database.query_params import QueryParams
+from backend.infrastructure.database.timeline_queries import dataset_has_parquet
+from backend.infrastructure.repositories.timeline_repository import (
+    _build_range,
+    _compose_google_health_summary,
+    apply_raw_refs,
+    build_correlations,
+    build_gaps,
+    finalize_item_times,
+    normalize_browser_page_view,
+    normalize_github_commit,
+    normalize_github_pull_request,
+    normalize_spotify_play,
+    normalize_youtube_watch,
+    sort_items,
+)
+
+JST = ZoneInfo("Asia/Tokyo")
+UTC = timezone.utc
+
+
+def _dt(iso: str) -> datetime:
+    """ISO 文字列を UTC aware datetime にする。"""
+    return datetime.fromisoformat(iso).astimezone(UTC)
+
+
+# ============================================================
+# 正規化
+# ============================================================
+
+
+class TestNormalizeSpotifyPlay:
+    def test_builds_common_shape_with_duration(self):
+        row = {
+            "play_id": "abc123",
+            "played_at_utc": datetime(2026, 6, 28, 0, 12, 3),
+            "track_id": "t1",
+            "track_name": "だから僕は僕を辞めた",
+            "artist_names": ["ヨルシカ"],
+            "album_name": "盗作",
+            "ms_played": 222000,
+        }
+        item = normalize_spotify_play(row)
+
+        assert item["event_id"] == "spotify:play:abc123"
+        assert item["source"] == "spotify"
+        assert item["kind"] == "music_play"
+        assert item["started_at_utc"] == _dt("2026-06-28T00:12:03+00:00")
+        assert item["title"] == "ヨルシカ - だから僕は僕を辞めた"
+        assert item["subtitle"] == "Spotify play"
+        assert item["duration_seconds"] == 222
+        assert item["raw_ref"] == {
+            "dataset_id": "spotify.plays",
+            "record_id": "abc123",
+            "timestamp_column": "played_at_utc",
+        }
+        assert item["metadata"]["track_name"] == "だから僕は僕を辞めた"
+
+    def test_duration_omitted_when_ms_played_zero(self):
+        row = {
+            "play_id": "p1",
+            "played_at_utc": datetime(2026, 6, 28, 0, 12, 3),
+            "track_id": "t1",
+            "track_name": "Song",
+            "artist_names": [],
+            "album_name": None,
+            "ms_played": 0,
+        }
+        item = normalize_spotify_play(row)
+        assert item["duration_seconds"] is None
+        # artist がないときは track_name だけ
+        assert item["title"] == "Song"
+
+
+class TestNormalizeBrowserPageView:
+    def test_builds_item_with_domain_subtitle_and_duration(self):
+        row = {
+            "page_view_id": "pv_1",
+            "started_at_utc": datetime(2026, 6, 28, 1, 30, 0),
+            "ended_at_utc": datetime(2026, 6, 28, 1, 30, 45),
+            "url": "https://docs.example.com/page",
+            "title": "Example Page",
+            "browser": "edge",
+            "profile": "Default",
+            "transition": "link",
+            "visit_span_count": 2,
+        }
+        item = normalize_browser_page_view(row)
+
+        assert item["event_id"] == "browser_history:page_view:pv_1"
+        assert item["kind"] == "page_view"
+        assert item["subtitle"] == "docs.example.com"
+        assert item["url"] == "https://docs.example.com/page"
+        assert item["duration_seconds"] == 45
+        assert item["raw_ref"]["dataset_id"] == "browser_history.page_views"
+
+    def test_no_ended_at_yields_no_duration(self):
+        row = {
+            "page_view_id": "pv_2",
+            "started_at_utc": datetime(2026, 6, 28, 2, 0, 0),
+            "ended_at_utc": None,
+            "url": "https://x.com",
+            "title": "X",
+            "browser": "edge",
+            "profile": "Default",
+            "transition": "link",
+            "visit_span_count": 1,
+        }
+        item = normalize_browser_page_view(row)
+        assert item["duration_seconds"] is None
+        assert item["ended_at_utc"] is None
+
+
+class TestNormalizeYoutubeWatch:
+    def test_builds_item(self):
+        row = {
+            "watch_event_id": "we_1",
+            "watched_at_utc": datetime(2026, 6, 28, 3, 0, 0),
+            "video_id": "v1",
+            "video_url": "https://www.youtube.com/watch?v=v1",
+            "video_title": "Title",
+            "channel_id": "c1",
+            "channel_name": "Channel",
+            "content_type": "video",
+            "source": "browser_history",
+            "source_device": "home-pc",
+        }
+        item = normalize_youtube_watch(row)
+
+        assert item["event_id"] == "youtube:watch_event:we_1"
+        assert item["kind"] == "youtube_watch"
+        assert item["duration_seconds"] is None
+        assert item["url"] == "https://www.youtube.com/watch?v=v1"
+        assert item["subtitle"] == "Channel"
+
+
+class TestNormalizeGithub:
+    def test_commit_uses_first_message_line(self):
+        row = {
+            "commit_event_id": "c1",
+            "owner": "o",
+            "repo": "r",
+            "repo_full_name": "o/r",
+            "sha": "abc",
+            "message": "Add timeline feature\n\nDetailed body",
+            "committed_at_utc": datetime(2026, 6, 28, 4, 0, 0),
+            "changed_files_count": 3,
+            "additions": 10,
+            "deletions": 2,
+        }
+        item = normalize_github_commit(row)
+        assert item["event_id"] == "github:commit:c1"
+        assert item["kind"] == "github_commit"
+        assert item["title"] == "Add timeline feature"
+        assert item["subtitle"] == "o/r"
+        assert item["duration_seconds"] is None
+
+    def test_pull_request_uses_updated_at(self):
+        row = {
+            "pr_event_id": "pr1",
+            "owner": "o",
+            "repo": "r",
+            "repo_full_name": "o/r",
+            "pr_number": 12,
+            "action": "opened",
+            "state": "open",
+            "is_merged": False,
+            "title": "Fix bug",
+            "labels": ["bug"],
+            "updated_at_utc": datetime(2026, 6, 28, 5, 0, 0),
+            "additions": 1,
+            "deletions": 1,
+            "changed_files_count": 1,
+        }
+        item = normalize_github_pull_request(row)
+        assert item["event_id"] == "github:pull_request:pr1"
+        assert item["kind"] == "github_pull_request"
+        assert item["started_at_utc"] == _dt("2026-06-28T05:00:00+00:00")
+        assert item["title"] == "Fix bug"
+
+
+# ============================================================
+# ソート
+# ============================================================
+
+
+class TestSortItems:
+    def test_sorts_by_started_at_utc(self):
+        items = [
+            {
+                "event_id": "b",
+                "source": "spotify",
+                "started_at_utc": _dt("2026-06-28T02:00:00+00:00"),
+            },
+            {
+                "event_id": "a",
+                "source": "spotify",
+                "started_at_utc": _dt("2026-06-28T01:00:00+00:00"),
+            },
+        ]
+        ordered = sort_items(items)
+        assert [i["event_id"] for i in ordered] == ["a", "b"]
+
+    def test_same_time_uses_source_priority(self):
+        same_time = _dt("2026-06-28T01:00:00+00:00")
+        items = [
+            {"event_id": "z", "source": "spotify", "started_at_utc": same_time},
+            {"event_id": "y", "source": "youtube", "started_at_utc": same_time},
+            {"event_id": "x", "source": "browser_history", "started_at_utc": same_time},
+            {"event_id": "w", "source": "github", "started_at_utc": same_time},
+        ]
+        ordered = sort_items(items)
+        assert [i["source"] for i in ordered] == [
+            "browser_history",
+            "youtube",
+            "spotify",
+            "github",
+        ]
+
+    def test_same_time_same_source_uses_event_id(self):
+        same_time = _dt("2026-06-28T01:00:00+00:00")
+        items = [
+            {
+                "event_id": "spotify:play:b",
+                "source": "spotify",
+                "started_at_utc": same_time,
+            },
+            {
+                "event_id": "spotify:play:a",
+                "source": "spotify",
+                "started_at_utc": same_time,
+            },
+        ]
+        ordered = sort_items(items)
+        assert [i["event_id"] for i in ordered] == ["spotify:play:a", "spotify:play:b"]
+
+
+# ============================================================
+# Correlation
+# ============================================================
+
+
+class TestBuildCorrelations:
+    def test_same_video_url_within_window(self):
+        t = _dt("2026-06-28T01:00:00+00:00")
+        items = [
+            {
+                "event_id": "browser_history:page_view:pv_1",
+                "source": "browser_history",
+                "started_at_utc": t,
+                "url": "https://www.youtube.com/watch?v=abc",
+            },
+            {
+                "event_id": "youtube:watch_event:we_1",
+                "source": "youtube",
+                "started_at_utc": t,
+                "url": "https://youtube.com/watch?v=abc",
+            },
+        ]
+        correlations = build_correlations(items)
+        assert len(correlations) == 1
+        correlation = correlations[0]
+        assert correlation["reason"] == "same_youtube_video_url_within_120_seconds"
+        assert correlation["confidence"] == 0.95
+        assert correlation["correlation_id"].startswith("corr_")
+
+    def test_youtube_url_without_video_id_near_watch_event(self):
+        t = _dt("2026-06-28T01:00:00+00:00")
+        items = [
+            {
+                "event_id": "browser_history:page_view:pv_1",
+                "source": "browser_history",
+                "started_at_utc": t,
+                "url": "https://www.youtube.com/feed/subscriptions",
+            },
+            {
+                "event_id": "youtube:watch_event:we_1",
+                "source": "youtube",
+                "started_at_utc": t,
+                "url": "https://youtube.com/watch?v=xyz",
+            },
+        ]
+        correlations = build_correlations(items)
+        assert len(correlations) == 1
+        assert correlations[0]["reason"] == "youtube_url_near_watch_event"
+        assert correlations[0]["confidence"] == 0.75
+
+    def test_no_correlation_outside_window(self):
+        items = [
+            {
+                "event_id": "browser_history:page_view:pv_1",
+                "source": "browser_history",
+                "started_at_utc": _dt("2026-06-28T01:00:00+00:00"),
+                "url": "https://www.youtube.com/watch?v=abc",
+            },
+            {
+                "event_id": "youtube:watch_event:we_1",
+                "source": "youtube",
+                "started_at_utc": _dt("2026-06-28T01:05:00+00:00"),
+                "url": "https://youtube.com/watch?v=abc",
+            },
+        ]
+        assert build_correlations(items) == []
+
+    def test_does_not_remove_or_merge_items(self):
+        t = _dt("2026-06-28T01:00:00+00:00")
+        items = [
+            {
+                "event_id": "browser_history:page_view:pv_1",
+                "source": "browser_history",
+                "started_at_utc": t,
+                "url": "https://www.youtube.com/watch?v=abc",
+            },
+            {
+                "event_id": "youtube:watch_event:we_1",
+                "source": "youtube",
+                "started_at_utc": t,
+                "url": "https://youtube.com/watch?v=abc",
+            },
+        ]
+        build_correlations(items)
+        assert len(items) == 2  # correlation は注釈のみ
+
+
+# ============================================================
+# Gap
+# ============================================================
+
+
+class TestBuildGaps:
+    def _item(self, event_id: str, iso: str):
+        return {
+            "event_id": event_id,
+            "source": "spotify",
+            "started_at_utc": _dt(iso),
+        }
+
+    def test_emits_gap_when_above_threshold(self):
+        items = [
+            self._item("a", "2026-06-28T01:00:00+00:00"),
+            self._item("b", "2026-06-28T01:30:00+00:00"),
+            self._item("c", "2026-06-28T04:00:00+00:00"),
+        ]
+        gaps = build_gaps(items, gap_minutes=120, timezone=JST)
+        assert len(gaps) == 1
+        gap = gaps[0]
+        assert gap["kind"] == "no_observed_events_gap"
+        assert gap["duration_minutes"] == 150
+        assert gap["preceded_by_event_id"] == "b"
+        assert gap["followed_by_event_id"] == "c"
+        assert gap["gap_id"] == "gap_20260628_1030_1300"
+
+    def test_no_gap_when_disabled(self):
+        items = [
+            self._item("a", "2026-06-28T01:00:00+00:00"),
+            self._item("b", "2026-06-28T10:00:00+00:00"),
+        ]
+        assert build_gaps(items, gap_minutes=None, timezone=JST) == []
+        assert build_gaps(items, gap_minutes=0, timezone=JST) == []
+
+    def test_no_gap_with_single_item(self):
+        items = [self._item("a", "2026-06-28T01:00:00+00:00")]
+        assert build_gaps(items, gap_minutes=120, timezone=JST) == []
+
+
+# ============================================================
+# local 時刻付与 / raw_ref 制御
+# ============================================================
+
+
+class TestFinalizeItemTimesAndRawRefs:
+    def test_finalizes_utc_and_local_times(self):
+        items = [
+            {
+                "started_at_utc": _dt("2026-06-27T15:00:00+00:00"),
+                "started_at_local": None,
+                "ended_at_utc": None,
+                "ended_at_local": None,
+            }
+        ]
+        finalize_item_times(items, JST)
+        assert items[0]["started_at_utc"] == "2026-06-27T15:00:00Z"
+        assert items[0]["started_at_local"] == "2026-06-28T00:00:00+09:00"
+        assert items[0]["ended_at_utc"] is None
+        assert items[0]["ended_at_local"] is None
+
+    def test_apply_raw_refs_false_removes_raw_ref(self):
+        items = [{"event_id": "x", "raw_ref": {"dataset_id": "d", "record_id": "r"}}]
+        apply_raw_refs(items, include=False)
+        assert "raw_ref" not in items[0]
+
+    def test_apply_raw_refs_true_keeps_raw_ref(self):
+        items = [{"event_id": "x", "raw_ref": {"dataset_id": "d", "record_id": "r"}}]
+        apply_raw_refs(items, include=True)
+        assert items[0]["raw_ref"]["dataset_id"] == "d"
+
+
+# ============================================================
+# Range / Google Health 日次サマリ
+# ============================================================
+
+
+class TestBuildRange:
+    def test_builds_local_and_utc_range(self):
+        utc_start = datetime(2026, 6, 27, 15, 0, 0)
+        utc_end = datetime(2026, 6, 28, 15, 0, 0)
+        result = _build_range(date(2026, 6, 28), JST, utc_start, utc_end)
+        assert result["start_local"] == "2026-06-28T00:00:00+09:00"
+        assert result["end_local"] == "2026-06-29T00:00:00+09:00"
+        assert result["start_utc"] == "2026-06-27T15:00:00Z"
+        assert result["end_utc"] == "2026-06-28T15:00:00Z"
+
+
+class TestDatasetHasParquet:
+    def test_falls_back_to_r2_when_local_dataset_missing(self, tmp_path):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (1,)
+        config = R2Config.model_construct(
+            endpoint_url="https://test.r2.cloudflarestorage.com",
+            access_key_id="test_key",
+            secret_access_key=SecretStr("test_secret"),
+            bucket_name="test-bucket",
+            raw_path="raw/",
+            events_path="events/",
+            master_path="master/",
+            local_parquet_root=str(tmp_path),
+        )
+        params = QueryParams(
+            conn=conn,
+            r2_config=config,
+            start_date=date(2026, 6, 28),
+            end_date=date(2026, 6, 28),
+            utc_start=datetime(2026, 6, 27, 15, 0, 0),
+            utc_end=datetime(2026, 6, 28, 15, 0, 0),
+            tz_name="Asia/Tokyo",
+        )
+
+        assert dataset_has_parquet(params, datasets.SPOTIFY_PLAYS) is True
+        conn.execute.assert_called_once()
+
+
+class TestComposeGoogleHealthSummary:
+    def test_builds_summary_with_sleep_sessions(self):
+        metrics = {
+            "steps": 8120.0,
+            "active_energy_burned": 420.0,
+            "resting_heart_rate": 53.0,
+            "sleep_duration_seconds": 21120.0,  # 352 min
+        }
+        sessions = [
+            {
+                "started_at_utc": datetime(2026, 6, 27, 14, 48),
+                "ended_at_utc": datetime(2026, 6, 27, 22, 3),
+                "duration_seconds": 26100,
+                "session_type": "sleep",
+            }
+        ]
+        summary = _compose_google_health_summary(
+            metrics, sessions, date(2026, 6, 28), JST
+        )
+        assert summary is not None
+        assert summary["date"] == "2026-06-28"
+        assert summary["timezone"] == "Asia/Tokyo"
+        assert summary["steps"] == 8120
+        assert summary["active_energy_kcal"] == 420
+        assert summary["resting_heart_rate_bpm"] == 53
+        assert summary["sleep"]["asleep_minutes"] == 352
+        assert summary["sleep"]["in_bed_minutes"] == 435
+        assert summary["sleep"]["started_at_local"] == "2026-06-27T23:48:00+09:00"
+        assert summary["sleep"]["ended_at_local"] == "2026-06-28T07:03:00+09:00"
+
+    def test_returns_none_when_no_data(self):
+        summary = _compose_google_health_summary({}, [], date(2026, 6, 28), JST)
+        assert summary is None
+
+    def test_sleep_duration_only_without_sessions(self):
+        metrics = {"sleep_duration_seconds": 36000.0}
+        summary = _compose_google_health_summary(metrics, [], date(2026, 6, 28), JST)
+        assert summary is not None
+        assert summary["sleep"] == {"asleep_minutes": 600}

--- a/egograph/backend/tests/unit/tools/timeline/test_daily.py
+++ b/egograph/backend/tests/unit/tools/timeline/test_daily.py
@@ -59,12 +59,12 @@ class TestExecuteValidation:
 
 
 class TestDateValidation:
-    @pytest.mark.parametrize("value", ["2026-06-28", "2026-06-28"])
+    @pytest.mark.parametrize("value", ["2026-06-28", "2024-02-29"])
     def test_accepts_valid_date(self, value):
         tool = _tool()
         tool.execute(date=value)
         kwargs = tool.repository.build_daily_timeline.call_args.kwargs
-        assert kwargs["date_local"] == date(2026, 6, 28)
+        assert kwargs["date_local"] == date.fromisoformat(value)
 
     @pytest.mark.parametrize("value", ["2026/06/28", "not-a-date", "2026-13-01"])
     def test_rejects_invalid_date(self, value):
@@ -188,10 +188,13 @@ class TestBooleanValidation:
 
 class TestDefaultTimezoneResolution:
     def test_unconfigured_timezone_defaults_to_jst(self):
-        assert resolve_default_timezone(
-            ZoneInfo("UTC"),
-            timezone_configured=False,
-        ) == JST
+        assert (
+            resolve_default_timezone(
+                ZoneInfo("UTC"),
+                timezone_configured=False,
+            )
+            == JST
+        )
 
     def test_explicit_utc_is_respected(self):
         assert resolve_default_timezone(

--- a/egograph/backend/tests/unit/tools/timeline/test_daily.py
+++ b/egograph/backend/tests/unit/tools/timeline/test_daily.py
@@ -1,0 +1,218 @@
+"""``GetDailyTimelineTool`` のバリデーションと execute の単体テスト。
+
+REST と MCP で共有する validation ロジックを検証する。
+"""
+
+from datetime import date
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from backend.domain.tools.timeline.daily import (
+    GetDailyTimelineTool,
+    resolve_default_timezone,
+)
+
+JST = ZoneInfo("Asia/Tokyo")
+
+
+def _tool() -> GetDailyTimelineTool:
+    repository = MagicMock()
+    repository.build_daily_timeline.return_value = {"items": []}
+    return GetDailyTimelineTool(repository, default_timezone=JST)
+
+
+class TestExecuteValidation:
+    """execute が repository に正規化済みの入力を渡すことのテスト。"""
+
+    def test_passes_validated_inputs_to_repository(self):
+        tool = _tool()
+        tool.execute(
+            date="2026-06-28",
+            timezone="Asia/Tokyo",
+            sources=["spotify", "youtube"],
+            gap_minutes=90,
+            include_correlations=False,
+            include_raw_refs=True,
+            limit=10,
+        )
+        kwargs = tool.repository.build_daily_timeline.call_args.kwargs
+        assert kwargs["date_local"] == date(2026, 6, 28)
+        assert kwargs["timezone"] == JST
+        assert kwargs["sources"] == {"spotify", "youtube"}
+        assert kwargs["gap_minutes"] == 90
+        assert kwargs["include_correlations"] is False
+        assert kwargs["include_raw_refs"] is True
+        assert kwargs["limit"] == 10
+
+    def test_default_timezone_used_when_omitted(self):
+        tool = _tool()
+        tool.execute(date="2026-06-28")
+        kwargs = tool.repository.build_daily_timeline.call_args.kwargs
+        assert kwargs["timezone"] == JST
+        assert kwargs["sources"] == set()
+        assert kwargs["gap_minutes"] == 120
+        assert kwargs["include_correlations"] is True
+        assert kwargs["include_raw_refs"] is False
+        assert kwargs["limit"] == 500
+
+
+class TestDateValidation:
+    @pytest.mark.parametrize("value", ["2026-06-28", "2026-06-28"])
+    def test_accepts_valid_date(self, value):
+        tool = _tool()
+        tool.execute(date=value)
+        kwargs = tool.repository.build_daily_timeline.call_args.kwargs
+        assert kwargs["date_local"] == date(2026, 6, 28)
+
+    @pytest.mark.parametrize("value", ["2026/06/28", "not-a-date", "2026-13-01"])
+    def test_rejects_invalid_date(self, value):
+        tool = _tool()
+        with pytest.raises(ValueError, match="invalid_date"):
+            tool.execute(date=value)
+
+
+class TestTimezoneValidation:
+    def test_rejects_unknown_timezone(self):
+        tool = _tool()
+        with pytest.raises(ValueError, match="invalid_timezone"):
+            tool.execute(date="2026-06-28", timezone="Not/A/Zone")
+
+    def test_accepts_iana_timezone(self):
+        tool = _tool()
+        tool.execute(date="2026-06-28", timezone="America/New_York")
+        kwargs = tool.repository.build_daily_timeline.call_args.kwargs
+        assert kwargs["timezone"] == ZoneInfo("America/New_York")
+
+
+class TestSourcesValidation:
+    def test_rejects_unknown_source(self):
+        tool = _tool()
+        with pytest.raises(ValueError, match="invalid_sources"):
+            tool.execute(date="2026-06-28", sources=["spotify", "unknown"])
+
+    def test_accepts_all_known_sources(self):
+        tool = _tool()
+        tool.execute(
+            date="2026-06-28",
+            sources=[
+                "spotify",
+                "youtube",
+                "browser_history",
+                "github",
+                "google_health",
+            ],
+        )
+        kwargs = tool.repository.build_daily_timeline.call_args.kwargs
+        assert kwargs["sources"] == {
+            "spotify",
+            "youtube",
+            "browser_history",
+            "github",
+            "google_health",
+        }
+
+
+class TestGapMinutesValidation:
+    @pytest.mark.parametrize("value", [0, 1, 120, 1440])
+    def test_accepts_valid_gap_minutes(self, value):
+        tool = _tool()
+        tool.execute(date="2026-06-28", gap_minutes=value)
+
+    @pytest.mark.parametrize("value", [-1, 1441])
+    def test_rejects_out_of_range(self, value):
+        tool = _tool()
+        with pytest.raises(ValueError, match="invalid_gap_minutes"):
+            tool.execute(date="2026-06-28", gap_minutes=value)
+
+    def test_none_disables_gap(self):
+        tool = _tool()
+        tool.execute(date="2026-06-28", gap_minutes=None)
+        kwargs = tool.repository.build_daily_timeline.call_args.kwargs
+        assert kwargs["gap_minutes"] is None
+
+    def test_accepts_numeric_string_from_rest_query(self):
+        tool = _tool()
+        tool.execute(date="2026-06-28", gap_minutes="120")
+        kwargs = tool.repository.build_daily_timeline.call_args.kwargs
+        assert kwargs["gap_minutes"] == 120
+
+    def test_rejects_non_numeric_string(self):
+        tool = _tool()
+        with pytest.raises(ValueError, match="invalid_gap_minutes"):
+            tool.execute(date="2026-06-28", gap_minutes="abc")
+
+
+class TestLimitValidation:
+    @pytest.mark.parametrize("value", [1, 500, 2000])
+    def test_accepts_valid_limit(self, value):
+        tool = _tool()
+        tool.execute(date="2026-06-28", limit=value)
+
+    @pytest.mark.parametrize("value", [0, 2001])
+    def test_rejects_out_of_range(self, value):
+        tool = _tool()
+        with pytest.raises(ValueError, match="invalid_limit"):
+            tool.execute(date="2026-06-28", limit=value)
+
+    def test_accepts_numeric_string_from_rest_query(self):
+        tool = _tool()
+        tool.execute(date="2026-06-28", limit="100")
+        kwargs = tool.repository.build_daily_timeline.call_args.kwargs
+        assert kwargs["limit"] == 100
+
+    def test_rejects_non_numeric_string(self):
+        tool = _tool()
+        with pytest.raises(ValueError, match="invalid_limit"):
+            tool.execute(date="2026-06-28", limit="abc")
+
+
+class TestBooleanValidation:
+    def test_accepts_boolean_strings_from_rest_query(self):
+        tool = _tool()
+        tool.execute(
+            date="2026-06-28",
+            include_correlations="false",
+            include_raw_refs="true",
+        )
+        kwargs = tool.repository.build_daily_timeline.call_args.kwargs
+        assert kwargs["include_correlations"] is False
+        assert kwargs["include_raw_refs"] is True
+
+    def test_rejects_invalid_boolean_string(self):
+        tool = _tool()
+        with pytest.raises(ValueError, match="invalid_include_correlations"):
+            tool.execute(date="2026-06-28", include_correlations="maybe")
+
+
+class TestDefaultTimezoneResolution:
+    def test_unconfigured_timezone_defaults_to_jst(self):
+        assert resolve_default_timezone(
+            ZoneInfo("UTC"),
+            timezone_configured=False,
+        ) == JST
+
+    def test_explicit_utc_is_respected(self):
+        assert resolve_default_timezone(
+            ZoneInfo("UTC"),
+            timezone_configured=True,
+        ) == ZoneInfo("UTC")
+
+
+class TestInputSchemaContract:
+    def test_schema_requires_date_and_lists_optional_params(self):
+        schema = _tool().input_schema
+        assert schema["type"] == "object"
+        assert schema["required"] == ["date"]
+        properties = schema["properties"]
+        for field in [
+            "date",
+            "timezone",
+            "sources",
+            "gap_minutes",
+            "include_correlations",
+            "include_raw_refs",
+            "limit",
+        ]:
+            assert field in properties

--- a/egograph/backend/usecases/tools/factory.py
+++ b/egograph/backend/usecases/tools/factory.py
@@ -17,6 +17,10 @@ from backend.domain.tools.github.worklog import (
 )
 from backend.domain.tools.google_health.summary import GetGoogleHealthDailySummaryTool
 from backend.domain.tools.spotify.stats import GetListeningStatsTool, GetTopTracksTool
+from backend.domain.tools.timeline.daily import (
+    GetDailyTimelineTool,
+    resolve_default_timezone,
+)
 from backend.domain.tools.youtube.stats import (
     GetYouTubeTopChannelsTool,
     GetYouTubeTopVideosTool,
@@ -28,6 +32,7 @@ from backend.infrastructure.repositories import (
     GitHubRepository,
     GoogleHealthRepository,
     SpotifyRepository,
+    TimelineRepository,
     YouTubeRepository,
 )
 from backend.usecases.tools.registry import ToolRegistry
@@ -36,6 +41,7 @@ from backend.usecases.tools.registry import ToolRegistry
 def build_tool_registry(
     r2_config: R2Config | None,
     tz: ZoneInfo | None = None,
+    timezone_configured: bool = False,
 ) -> ToolRegistry:
     """R2設定に応じたツールレジストリを構築する。"""
     tool_registry = ToolRegistry()
@@ -74,5 +80,17 @@ def build_tool_registry(
 
     google_health_repository = GoogleHealthRepository(r2_config, tz=effective_tz)
     tool_registry.register(GetGoogleHealthDailySummaryTool(google_health_repository))
+
+    # Daily Timeline（複数 source 統合）
+    timeline_repository = TimelineRepository(r2_config)
+    tool_registry.register(
+        GetDailyTimelineTool(
+            timeline_repository,
+            default_timezone=resolve_default_timezone(
+                effective_tz,
+                timezone_configured=timezone_configured,
+            ),
+        )
+    )
 
     return tool_registry


### PR DESCRIPTION
## 概要

複数データソース（Spotify / YouTube / Browser History / GitHub / Google Health）の観測イベントを1日単位で時刻順に統合する Daily Timeline read model を追加する。REST API（`GET /v1/data/timeline/daily`）と MCP Tool（`get_daily_timeline`）の同一契約を提供する。

設計書: `docs/architecture/daily-timeline.md`

## 実装内容

- `infrastructure/database/timeline_queries.py`: 各 source の compacted Parquet から UTC range で raw event を取得するクエリ（`make_timestamp(epoch_us(col))` で TIMESTAMP/TIMESTAMPTZ を UTC naive に正規化）
- `infrastructure/repositories/timeline_repository.py`: 正規化・ソート（時刻→source priority→event_id）・correlation・gap・coverage・Google Health 日次サマリ構築
- `domain/tools/timeline/daily.py`: `get_daily_timeline` MCP ツール（バリデーション + Repository 呼び出しの唯一経路。REST/MCP で同一ロジックを共有）
- `api/timeline.py` / `api/schemas/timeline.py`: REST エンドポイントとレスポンススキーマ
- timezone デフォルト解決: `timezone_configured` で TIMEZONE 明示設定を判定し、未設定時は Asia/Tokyo を採用

## 主な仕様準拠

- Google Health は `items` に入らず `daily_summaries` / `coverage` に添付
- correlation は items の削除・統合を行わず注釈のみ（same youtube URL / youtube URL near watch の2ルール）
- gap は `started_at_utc` のみを使用し、前後両 event に挟まれた区間のみ
- validation: `invalid_date` / `invalid_timezone` / `invalid_sources` / `invalid_gap_minutes` / `invalid_limit`

## 検証

- `uv run pytest egograph/backend/tests` : 365 passed（既存300 + 新規65）
- 新規ファイルの ruff lint/format クリーン


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 日次タイムラインを取得する新しいRESTエンドポイントと連携ツールを追加しました（指定日・タイムゾーン・複数source対応）。
  * 観測イベントの統合、関連（相関）候補、未観測ギャップ、日次要約、カバレッジ情報の表示に対応しました。
* **Bug Fixes**
  * 日付/タイムゾーン/ギャップ/件数/フラグ等の入力検証を強化し、不正値は明確なエラーで返すようにしました。
* **Tests**
  * RESTとツールの契約一致、相関/ギャップ/欠損時挙動、無効入力時の400等の統合・単体テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->