### PR TITLE
fix: prevent partial GitHub cursors and mixed parquet sources

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -73,7 +73,8 @@ Google HealthはRepositoryが接続の生成・破棄をカプセル化し、RES
 特徴:
 - サーバー側に状態を保持しない（DB永続化なし）
 - DuckDB の httpfs 拡張で R2 に直接アクセス
-- ローカル Parquet が存在すればそちらを優先（`local_parquet_root` 設定時）
+- 期間指定クエリでLocal mirrorが完全な場合だけLocalを使用
+- 全件検索とdataset存在判定はR2を使用し、Local mirrorの部分状態で結果を隠さない
 
 ### Parquet パス解決
 
@@ -83,7 +84,9 @@ Google HealthはRepositoryが接続の生成・破棄をカプセル化し、RES
 - `build_partition_paths(config, dataset, utc_start, utc_end)`: 月次 dataset の指定期間に対応する compacted partition path を構築
 - `build_dataset_glob(config, dataset)`: dataset 全体の glob パターンを構築。GitHub repositories のような recursive dataset や、YouTube master のような snapshot dataset も catalog の path を基準に解決する
 
-ローカル優先ロジック: `local_parquet_root` が設定されており、catalog から導出した該当 local path に Parquet が存在すればローカルパスを使用。なければ同じ catalog 定義から導出した R2 (s3://) パスを使用する。
+データソース選択: `build_partition_paths` は対象期間のLocal partitionをすべて確認し、全て存在する場合だけLocal pathのリストを返す。1つでも欠けている場合は、クエリ内の全partitionをR2 (`s3://`) pathへ切り替える。これにより、同じクエリでLocalとR2を混在させない。
+
+`build_dataset_glob` と `dataset_has_parquet` はLocal mirrorの完全性を判定できないため、常にR2のglobを使用する。Local mirrorは期間指定クエリの利用補助であり、全件検索の完全な分析正本ではない。manifestやgenerationによる完全性情報を導入するまでは、このルールを適用する。
 
 Dataset Catalog の詳細は [dataset-catalog.md](./dataset-catalog.md) を参照。
 Daily Timeline の詳細は [daily-timeline.md](./daily-timeline.md) を参照。

--- a/egograph/backend/README.md
+++ b/egograph/backend/README.md
@@ -63,6 +63,12 @@ egograph/backend/
 日次指標の`date`はローカル日付として保存済みのため変換せず、欠損値は`null`として返す。
 絶対時刻を提供する場合は、他のデータソースと同様にUTC保存値を`TIMEZONE`へ変換して返す。
 
+## Parquet データソースの選択
+
+期間指定のクエリでは、対象期間のcompact ParquetがLocal mirrorにすべて存在する場合だけLocalを使用する。1つでも欠けている場合は、クエリ内の全partitionをR2から読み込み、LocalとR2を混在させない。
+
+期間を持たない全件検索とdataset存在判定はR2のglobを使用する。Local mirrorは期間指定クエリの読み取りを補助するものであり、全件検索の完全な分析正本ではない。manifestやgenerationによる完全性管理は別途導入する。
+
 ## See Also
 
 > 詳細な設計・仕様は docs/ を参照。

--- a/egograph/backend/infrastructure/database/google_health_queries.py
+++ b/egograph/backend/infrastructure/database/google_health_queries.py
@@ -1,45 +1,35 @@
 """Google Health日次サマリ用DuckDBクエリ。"""
 
-from datetime import date
 from typing import Any
 
 from dataset_catalog import datasets
 
-from backend.infrastructure.database.parquet_paths import build_dataset_glob
+from backend.infrastructure.database.parquet_paths import build_partition_paths
 from backend.infrastructure.database.query_params import QueryParams
 
 
 def _resolve_daily_metric_paths(params: QueryParams) -> list[str]:
-    """存在するdaily_metricsから対象月のParquetだけを解決する。"""
-    dataset_glob = build_dataset_glob(
+    """対象期間のdaily_metrics Parquetを単一sourceから解決する。"""
+    partition_paths = build_partition_paths(
         params.r2_config,
         datasets.GOOGLE_HEALTH_DAILY_METRICS,
+        params.utc_start,
+        params.utc_end,
     )
-    rows = params.conn.execute(
-        "SELECT file FROM glob(?) ORDER BY file",
-        (dataset_glob,),
-    ).fetchall()
-    target_months = set(_iter_months(params.start_date, params.end_date))
-    return [
-        str(row[0])
-        for row in rows
-        if any(
-            f"/year={year}/month={month:02d}/" in str(row[0])
-            for year, month in target_months
-        )
-    ]
 
+    resolved_paths: list[str] = []
+    for path in partition_paths:
+        if not path.startswith("s3://"):
+            resolved_paths.append(path)
+            continue
 
-def _iter_months(start_date: date, end_date: date):
-    current = date(start_date.year, start_date.month, 1)
-    limit = date(end_date.year, end_date.month, 1)
-    while current <= limit:
-        yield current.year, current.month
-        current = (
-            date(current.year + 1, 1, 1)
-            if current.month == 12
-            else date(current.year, current.month + 1, 1)
-        )
+        rows = params.conn.execute(
+            "SELECT file FROM glob(?) ORDER BY file",
+            (f"{path.rsplit('/', 1)[0]}/*.parquet",),
+        ).fetchall()
+        resolved_paths.extend(str(row[0]) for row in rows)
+
+    return resolved_paths
 
 
 def get_daily_summary(params: QueryParams) -> list[dict[str, Any]]:

--- a/egograph/backend/infrastructure/database/parquet_paths.py
+++ b/egograph/backend/infrastructure/database/parquet_paths.py
@@ -72,39 +72,34 @@ def build_partition_paths(
     utc_start: datetime,
     utc_end: datetime,
 ) -> list[str]:
-    """Build month-scoped parquet paths for compacted datasets."""
-    paths: list[str] = []
-    for partition in _iter_months(utc_start, utc_end):
-        local_path = (
-            _build_local_compacted_file(
-                config.local_parquet_root,
-                dataset,
-                partition,
-            )
-            if config.local_parquet_root
-            else None
-        )
-        if local_path and local_path.exists():
-            paths.append(str(local_path))
-            continue
+    """compacted datasetの月単位Parquet pathを構築する。
 
-        paths.append(_build_r2_compacted_file(config, dataset, partition))
+    Local mirrorは対象partitionがすべて存在する場合だけ使用する。1つでも欠けて
+    いる場合は、同一query内でsourceが混在しないよう全体をR2へ切り替える。
+    """
+    partitions = _iter_months(utc_start, utc_end)
+    if not config.local_parquet_root:
+        return [_build_r2_compacted_file(config, dataset, p) for p in partitions]
 
-    return paths
+    local_paths = [
+        _build_local_compacted_file(config.local_parquet_root, dataset, partition)
+        for partition in partitions
+    ]
+    if all(path.exists() for path in local_paths):
+        return [str(path) for path in local_paths]
+
+    return [_build_r2_compacted_file(config, dataset, p) for p in partitions]
 
 
 def build_dataset_glob(
     config: R2Config,
     dataset: DatasetDefinition,
 ) -> str:
-    """Build all-data glob for compacted datasets."""
-    if config.local_parquet_root:
-        local_root = Path(config.local_parquet_root) / dataset.compacted_prefix(
-            COMPACTED_ROOT
-        )
-        if any(local_root.rglob("*.parquet")):
-            return str(local_root / "**" / "*.parquet")
+    """compacted dataset全件用のR2 globを構築する。
 
+    dataset-wide globからLocal mirrorの完全性は判定できないため、全件queryは
+    単一のsourceとしてR2を使用する。
+    """
     return (
         f"s3://{config.bucket_name}/"
         f"{dataset.compacted_prefix(COMPACTED_ROOT)}**/*.parquet"

--- a/egograph/backend/infrastructure/database/timeline_queries.py
+++ b/egograph/backend/infrastructure/database/timeline_queries.py
@@ -9,13 +9,11 @@
 ``epoch_us`` は絶対 UTC エポックを返すためセッションタイムゾーンに依存しない。
 """
 
-from pathlib import Path
 from typing import Any
 
 from dataset_catalog import datasets
 
 from backend.infrastructure.database.parquet_paths import (
-    COMPACTED_ROOT,
     build_dataset_glob,
     build_partition_paths,
 )
@@ -32,16 +30,10 @@ _GITHUB_TS = "{col}::TIMESTAMP"
 def dataset_has_parquet(params: QueryParams, dataset) -> bool:
     """dataset の compacted Parquet が1件でも存在するか。
 
-    ``local_parquet_root`` 設定時はローカルミラーを優先して判定し、
-    ローカルに無い場合は R2 の glob へ fallback する。
+    dataset-wide availabilityではLocal mirrorの完全性を判定できないため、
+    共通path resolverが返すR2 globを常に使用する。
     coverage の ``not_available`` 判定のために使う。
     """
-    if params.r2_config.local_parquet_root:
-        local_root = Path(
-            params.r2_config.local_parquet_root
-        ) / dataset.compacted_prefix(COMPACTED_ROOT)
-        if any(local_root.rglob("*.parquet")):
-            return True
     pattern = build_dataset_glob(params.r2_config, dataset)
     rows = params.conn.execute("SELECT COUNT(*) FROM glob(?)", (pattern,)).fetchone()
     return bool(rows and rows[0] > 0)

--- a/egograph/backend/tests/integration/test_timeline_api.py
+++ b/egograph/backend/tests/integration/test_timeline_api.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import pandas as pd
+import pytest
 from dataset_catalog import DATASETS_BY_ID, datasets
 from mcp.types import (
     CallToolRequest,
@@ -32,6 +33,27 @@ JST = ZoneInfo("Asia/Tokyo")
 
 # テスト対象日: 2026-06-28 (JST) = UTC [2026-06-27T15:00, 2026-06-28T15:00)
 TARGET_DATE = date(2026, 6, 28)
+
+
+@pytest.fixture(autouse=True)
+def patch_dataset_availability_for_local_fixture(monkeypatch):
+    """Local-only integration fixtureのavailability判定を差し替える。
+
+    本番のdataset_has_parquetはR2の完全なdatasetを判定するため、Local-only
+    のテストデータでは、fixtureに存在するファイルだけを返す判定を使う。
+    """
+
+    def has_local_parquet(params, dataset):
+        local_root = params.r2_config.local_parquet_root
+        if not local_root:
+            return False
+        dataset_root = Path(local_root) / dataset.compacted_prefix("compacted/")
+        return any(dataset_root.rglob("*.parquet"))
+
+    monkeypatch.setattr(
+        "backend.infrastructure.database.timeline_queries.dataset_has_parquet",
+        has_local_parquet,
+    )
 
 
 def _utc(value: str) -> datetime:
@@ -514,8 +536,7 @@ class TestRestAndMcpContract:
         test_client.app.dependency_overrides[get_daily_timeline_tool] = lambda: tool
 
         response = test_client.get(
-            "/v1/data/timeline/daily"
-            "?date=2026-06-28&include_correlations=maybe",
+            "/v1/data/timeline/daily?date=2026-06-28&include_correlations=maybe",
             headers={"X-API-Key": "test-backend-key"},
         )
         assert response.status_code == 400

--- a/egograph/backend/tests/unit/database/test_parquet_paths.py
+++ b/egograph/backend/tests/unit/database/test_parquet_paths.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 
+import pytest
 from dataset_catalog import datasets
 from pydantic import SecretStr
 
@@ -30,7 +31,39 @@ def _build_r2_config(**overrides) -> R2Config:
 class TestBuildPartitionPaths:
     """build_partition_paths tests."""
 
-    def test_prefers_local_compacted_file_when_present(self, tmp_path):
+    def test_uses_local_for_all_partitions_when_every_partition_is_present(
+        self, tmp_path
+    ):
+        config = _build_r2_config(local_parquet_root=str(tmp_path))
+        local_january = (
+            tmp_path
+            / "compacted"
+            / "events"
+            / "spotify"
+            / "plays"
+            / "year=2024"
+            / "month=01"
+            / "data.parquet"
+        )
+        local_february = local_january.parent.parent / "month=02" / "data.parquet"
+        local_january.parent.mkdir(parents=True)
+        local_february.parent.mkdir(parents=True)
+        local_january.write_bytes(b"test")
+        local_february.write_bytes(b"test")
+
+        paths = build_partition_paths(
+            config,
+            datasets.SPOTIFY_PLAYS,
+            utc_start=datetime(2024, 1, 1),
+            utc_end=datetime(2024, 2, 1),
+        )
+
+        assert len(paths) == 2  # Jan + Feb (utc_end が次月)
+        assert paths == [str(local_january), str(local_february)]
+
+    def test_uses_r2_for_all_partitions_when_one_local_partition_is_missing(
+        self, tmp_path
+    ):
         config = _build_r2_config(local_parquet_root=str(tmp_path))
         local_file = (
             tmp_path
@@ -52,29 +85,31 @@ class TestBuildPartitionPaths:
             utc_end=datetime(2024, 2, 1),
         )
 
-        assert len(paths) == 2  # Jan + Feb (utc_end が次月)
-        assert paths[0] == str(local_file)
+        assert len(paths) == 2
+        assert paths == [
+            "s3://test-bucket/compacted/events/spotify/plays/year=2024/month=01/data.parquet",
+            "s3://test-bucket/compacted/events/spotify/plays/year=2024/month=02/data.parquet",
+        ]
 
-    def test_falls_back_to_r2_when_local_file_missing(self, tmp_path):
-        config = _build_r2_config(local_parquet_root=str(tmp_path))
+    def test_uses_r2_when_local_mirror_is_disabled(self):
+        config = _build_r2_config(local_parquet_root=None)
 
         paths = build_partition_paths(
             config,
             datasets.SPOTIFY_PLAYS,
             utc_start=datetime(2024, 1, 1),
-            utc_end=datetime(2024, 2, 1),
+            utc_end=datetime(2024, 1, 31),
         )
 
-        assert len(paths) == 2
-        assert paths[0] == (
+        assert paths == [
             "s3://test-bucket/compacted/events/spotify/plays/year=2024/month=01/data.parquet"
-        )
+        ]
 
 
 class TestBuildDatasetGlob:
     """build_dataset_glob tests."""
 
-    def test_prefers_local_glob_when_compacted_files_exist(self, tmp_path):
+    def test_uses_r2_glob_when_compacted_files_exist_locally(self, tmp_path):
         config = _build_r2_config(local_parquet_root=str(tmp_path))
         local_file = (
             tmp_path
@@ -94,15 +129,7 @@ class TestBuildDatasetGlob:
             datasets.SPOTIFY_TRACKS,
         )
 
-        assert path == str(
-            tmp_path
-            / "compacted"
-            / "master"
-            / "spotify"
-            / "tracks"
-            / "**"
-            / "*.parquet"
-        )
+        assert path == "s3://test-bucket/compacted/master/spotify/tracks/**/*.parquet"
 
     def test_uses_r2_glob_when_local_dataset_missing(self, tmp_path):
         config = _build_r2_config(local_parquet_root=str(tmp_path))
@@ -113,3 +140,19 @@ class TestBuildDatasetGlob:
         )
 
         assert path == "s3://test-bucket/compacted/master/spotify/tracks/**/*.parquet"
+
+    @pytest.mark.parametrize(
+        "dataset",
+        [datasets.GITHUB_REPOSITORIES, datasets.YOUTUBE_VIDEOS],
+    )
+    def test_uses_r2_glob_for_non_monthly_datasets(self, tmp_path, dataset):
+        config = _build_r2_config(local_parquet_root=str(tmp_path))
+        local_file = tmp_path / dataset.compacted_prefix("compacted/") / "data.parquet"
+        local_file.parent.mkdir(parents=True)
+        local_file.write_bytes(b"test")
+
+        path = build_dataset_glob(config, dataset)
+
+        assert path == (
+            f"s3://test-bucket/compacted/{dataset.domain.value}/{dataset.path}/**/*.parquet"
+        )

--- a/egograph/backend/tests/unit/repositories/test_google_health_queries.py
+++ b/egograph/backend/tests/unit/repositories/test_google_health_queries.py
@@ -1,10 +1,14 @@
 """Google Health DuckDBクエリのテスト。"""
 
-from datetime import date, timezone
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock
 
 import pandas as pd
 
-from backend.infrastructure.database.google_health_queries import get_daily_summary
+from backend.infrastructure.database.google_health_queries import (
+    _resolve_daily_metric_paths,
+    get_daily_summary,
+)
 from backend.infrastructure.database.query_params import QueryParams
 from backend.validators import to_utc_range
 
@@ -88,12 +92,59 @@ def test_get_daily_summary_pivots_metrics_and_preserves_missing_values(
     assert result[1]["daily_hrv"] == 42.0
 
 
+def test_daily_metric_paths_use_r2_for_all_partitions_when_local_is_partial(
+    mock_r2_config,
+    tmp_path,
+):
+    """Local partitionが欠ける場合は全partitionをR2から解決する。"""
+    local_root = tmp_path / "mirror"
+    local_partition = (
+        local_root
+        / "compacted"
+        / "events"
+        / "google_health"
+        / "daily_metrics"
+        / "year=2026"
+        / "month=06"
+    )
+    local_partition.mkdir(parents=True)
+    (local_partition / "data.parquet").write_bytes(b"local")
+    mock_r2_config.local_parquet_root = str(local_root)
+
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.side_effect = [
+        [
+            (
+                "s3://test-bucket/compacted/events/google_health/"
+                "daily_metrics/year=2026/month=06/data.parquet",
+            )
+        ],
+        [],
+    ]
+    params = QueryParams(
+        conn=conn,
+        r2_config=mock_r2_config,
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 6, 30),
+        utc_start=datetime(2026, 6, 1),
+        utc_end=datetime(2026, 7, 1),
+    )
+
+    result = _resolve_daily_metric_paths(params)
+
+    assert result == [
+        "s3://test-bucket/compacted/events/google_health/"
+        "daily_metrics/year=2026/month=06/data.parquet"
+    ]
+    assert conn.execute.call_count == 2
+
+
 def test_get_daily_summary_maps_compacted_metric_names(
     duckdb_conn,
     mock_r2_config,
     tmp_path,
 ):
-    """compacted parquetの実際のmetric_nameをdaily_hrv/daily_oxygen_saturationへ射影する。"""
+    """実際のmetric_nameをdaily_hrv/daily_oxygen_saturationへ射影する。"""
     local_root = tmp_path / "mirror"
     daily_dir = (
         local_root
@@ -152,7 +203,6 @@ def test_get_daily_summary_maps_compacted_metric_names(
 
 
 def test_get_daily_summary_returns_empty_when_partition_is_missing(
-    duckdb_conn,
     mock_r2_config,
     tmp_path,
 ):
@@ -176,13 +226,15 @@ def test_get_daily_summary_returns_empty_when_partition_is_missing(
         }
     ).to_parquet(other_month / "data.parquet")
     mock_r2_config.local_parquet_root = str(local_root)
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = []
     utc_start, utc_end = to_utc_range(
         date(2026, 6, 1),
         date(2026, 6, 30),
         timezone.utc,
     )
     params = QueryParams(
-        conn=duckdb_conn,
+        conn=conn,
         r2_config=mock_r2_config,
         start_date=date(2026, 6, 1),
         end_date=date(2026, 6, 30),
@@ -193,3 +245,4 @@ def test_get_daily_summary_returns_empty_when_partition_is_missing(
     result = get_daily_summary(params)
 
     assert result == []
+    assert conn.execute.call_count == 2

--- a/egograph/backend/tests/unit/repositories/test_timeline_repository.py
+++ b/egograph/backend/tests/unit/repositories/test_timeline_repository.py
@@ -426,9 +426,20 @@ class TestBuildRange:
 
 
 class TestDatasetHasParquet:
-    def test_falls_back_to_r2_when_local_dataset_missing(self, tmp_path):
+    def test_uses_r2_glob_even_when_local_dataset_exists(self, tmp_path):
         conn = MagicMock()
         conn.execute.return_value.fetchone.return_value = (1,)
+        local_dataset = (
+            tmp_path
+            / "compacted"
+            / "events"
+            / "spotify"
+            / "plays"
+            / "year=2026"
+            / "month=06"
+        )
+        local_dataset.mkdir(parents=True)
+        (local_dataset / "data.parquet").write_bytes(b"local-only")
         config = R2Config.model_construct(
             endpoint_url="https://test.r2.cloudflarestorage.com",
             access_key_id="test_key",
@@ -450,7 +461,10 @@ class TestDatasetHasParquet:
         )
 
         assert dataset_has_parquet(params, datasets.SPOTIFY_PLAYS) is True
-        conn.execute.assert_called_once()
+        conn.execute.assert_called_once_with(
+            "SELECT COUNT(*) FROM glob(?)",
+            ("s3://test-bucket/compacted/events/spotify/plays/**/*.parquet",),
+        )
 
 
 class TestComposeGoogleHealthSummary:

--- a/egograph/pipelines/sources/github/ingest_pipeline.py
+++ b/egograph/pipelines/sources/github/ingest_pipeline.py
@@ -81,9 +81,7 @@ def _resolve_since_iso(
     repo_cursor = repos_state.get(repo_full_name, {}).get("cursor_utc")
 
     if repo_cursor:
-        logger.info(
-            "Using incremental cursor for %s: %s", repo_full_name, repo_cursor
-        )
+        logger.info("Using incremental cursor for %s: %s", repo_full_name, repo_cursor)
         return repo_cursor
 
     # 旧形式からの移行cursor
@@ -98,6 +96,40 @@ def _resolve_since_iso(
     since = start.isoformat()
     logger.info("No cursor for %s. Backfill mode since=%s", repo_full_name, since)
     return since
+
+
+def _build_ingest_state(
+    state: dict[str, Any],
+    target_repos: list[str],
+    repo_cursors: dict[str, str],
+    failed_repos: set[str],
+    github_login: str,
+    updated_at: str,
+) -> dict[str, Any]:
+    """保存完了結果から次回実行用のstateを構築する。
+
+    失敗したリポジトリは新しいcursorを持たず、既存cursorだけを維持する。
+    これにより、未保存データを次回実行で再取得できる。
+    """
+    existing_repos = state.get("repos", {})
+    repos_state: dict[str, dict[str, str]] = {}
+
+    for repo_full_name in target_repos:
+        if repo_full_name in failed_repos:
+            existing_cursor = existing_repos.get(repo_full_name, {}).get("cursor_utc")
+            if existing_cursor:
+                repos_state[repo_full_name] = {"cursor_utc": existing_cursor}
+            continue
+
+        cursor = repo_cursors.get(repo_full_name)
+        if cursor:
+            repos_state[repo_full_name] = {"cursor_utc": cursor}
+
+    return {
+        "github_login": github_login,
+        "repos": repos_state,
+        "updated_at": updated_at,
+    }
 
 
 def run_pipeline(config: Config) -> None:
@@ -182,7 +214,6 @@ def run_pipeline(config: Config) -> None:
     total_failed_records = 0
     total_failed_fatal_api_calls = 0
     total_failed_enrichment_api_calls = 0
-    total_failed_repos = 0
 
     all_commits_data = []
     # リポジトリごとのcursorを追跡
@@ -209,6 +240,7 @@ def run_pipeline(config: Config) -> None:
                         "Failed to save repository master for %s", repo_full_name
                     )
                     total_failed_records += 1
+                    failed_repos.add(repo_full_name)
             else:
                 logger.info("Skipping non-personal repo: %s", repo_full_name)
                 continue
@@ -262,6 +294,7 @@ def run_pipeline(config: Config) -> None:
                                 month,
                             )
                             total_failed_records += stats["failed"]
+                            failed_repos.add(repo_full_name)
                         else:
                             logger.info(
                                 (
@@ -282,6 +315,7 @@ def run_pipeline(config: Config) -> None:
                 if raw_pr_saved is None:
                     logger.error("Failed to save raw PRs for %s", repo_full_name)
                     total_failed_records += len(prs)
+                    failed_repos.add(repo_full_name)
 
             # Repository Commitsを取得
             commits = collector.get_repository_commits(owner, repo, since=since_iso)
@@ -352,18 +386,19 @@ def run_pipeline(config: Config) -> None:
                 if raw_commits_saved is None:
                     logger.error("Failed to save raw commits for %s", repo_full_name)
                     total_failed_records += len(commits)
+                    failed_repos.add(repo_full_name)
 
             # リポジトリのcursorを記録
-            if max_cursor_candidate is not None:
-                repo_cursors[repo_full_name] = max_cursor_candidate.isoformat()
-            else:
-                now_utc = datetime.now(timezone.utc)
-                repo_cursors[repo_full_name] = now_utc.isoformat()
+            if repo_full_name not in failed_repos:
+                if max_cursor_candidate is not None:
+                    repo_cursors[repo_full_name] = max_cursor_candidate.isoformat()
+                else:
+                    now_utc = datetime.now(timezone.utc)
+                    repo_cursors[repo_full_name] = now_utc.isoformat()
 
         except Exception:
             logger.exception("Failed to process repository %s", repo_full_name)
             total_failed_fatal_api_calls += 1
-            total_failed_repos += 1
             failed_repos.add(repo_full_name)
             continue
 
@@ -372,12 +407,23 @@ def run_pipeline(config: Config) -> None:
     # Commitイベントを年月でグループ化して保存
     commits_by_month = _group_commits_by_month(all_commits_data)
 
-    all_saved = True
     for (year, month), commits in commits_by_month.items():
-        stats = storage.save_commits_parquet_with_stats(commits, year, month)
+        contributing_repos = {
+            commit["repo_full_name"]
+            for commit in commits
+            if commit.get("repo_full_name")
+        }
+        try:
+            stats = storage.save_commits_parquet_with_stats(commits, year, month)
+        except Exception:
+            logger.exception("Failed to save commits Parquet for %d-%02d", year, month)
+            failed_repos.update(contributing_repos)
+            total_failed_records += len(commits)
+            continue
+
         if stats["failed"] > 0:
             logger.error("Failed to save commits Parquet for %d-%02d", year, month)
-            all_saved = False
+            failed_repos.update(contributing_repos)
         else:
             logger.info(
                 "Saved commits for %d-%02d (fetched=%d new=%d duplicates=%d)",
@@ -405,44 +451,36 @@ def run_pipeline(config: Config) -> None:
         total_duplicate_commits,
         total_failed_records,
         total_failed_fatal_api_calls,
-        total_failed_repos,
+        len(failed_repos),
     )
     logger.info("Ingest enrichment API failures: %d", total_failed_enrichment_api_calls)
 
     # 状態を更新（失敗リポジトリのcursorは更新しない）
     now_utc = datetime.now(timezone.utc).isoformat()
-    repos_state: dict[str, dict[str, str]] = {}
+    new_state = _build_ingest_state(
+        state,
+        target_repos,
+        repo_cursors,
+        failed_repos,
+        github_conf.github_login,
+        now_utc,
+    )
 
-    for repo_full_name in target_repos:
-        if repo_full_name in failed_repos:
-            # 失敗リポジトリは旧cursorを維持
-            existing_cursor = (
-                state.get("repos", {})
-                .get(repo_full_name, {})
-                .get("cursor_utc")
-            )
-            if existing_cursor:
-                repos_state[repo_full_name] = {"cursor_utc": existing_cursor}
-            continue
-        if repo_full_name in repo_cursors:
-            repos_state[repo_full_name] = {
-                "cursor_utc": repo_cursors[repo_full_name]
-            }
-
-    new_state: dict[str, Any] = {
-        "github_login": github_conf.github_login,
-        "repos": repos_state,
-        "updated_at": now_utc,
-    }
-
-    if all_saved and total_failed_fatal_api_calls == 0 and total_failed_repos == 0:
+    try:
         storage.save_ingest_state(new_state)
-        logger.info("Pipeline completed successfully!")
-    else:
-        storage.save_ingest_state(new_state)
+    except Exception as exc:
+        logger.exception("Failed to save GitHub ingest state")
+        raise RuntimeError("Failed to save GitHub ingest state") from exc
+
+    if failed_repos:
         logger.warning(
             "Pipeline had failures. State partially updated (failed repos excluded)."
         )
+        raise RuntimeError(
+            f"GitHub ingest failed for repositories: {', '.join(sorted(failed_repos))}"
+        )
+
+    logger.info("Pipeline completed successfully!")
 
 
 def _group_commits_by_month(

--- a/egograph/pipelines/tests/integration/github/test_enrichment.py
+++ b/egograph/pipelines/tests/integration/github/test_enrichment.py
@@ -3,6 +3,8 @@
 PR review 件数補完と commit detail 補完のフローを検証する。
 """
 
+from datetime import datetime, timezone
+
 import responses
 from pipelines.sources.common.config import (
     Config,
@@ -35,7 +37,8 @@ def _build_config(memory_s3, **kwargs) -> Config:
         "token": SecretStr("test-github-token"),
         "github_login": "test-user",
         "target_repos": ["test-user/test-repo"],
-        "backfill_days": 30,
+        # 固定fixtureの日付を現在日時の境界で取りこぼさない。
+        "backfill_days": 3650,
         "fetch_commit_details": True,
         "max_commit_detail_requests_per_repo": 10,
     }
@@ -48,8 +51,6 @@ def _build_config(memory_s3, **kwargs) -> Config:
 
 def _current_month_pr():
     """現在月の日付で PR モックデータを生成する。"""
-    from datetime import datetime, timezone
-
     now = datetime.now(timezone.utc)
     return {
         **MOCK_PULL_REQUEST_RESPONSE,
@@ -67,8 +68,6 @@ def _current_month_pr():
 
 def _current_month_commit():
     """現在月の日付でコミットモックデータを生成する。"""
-    from datetime import datetime, timezone
-
     now = datetime.now(timezone.utc)
     return {
         "sha": "abc123def456",

--- a/egograph/pipelines/tests/integration/github/test_ingest.py
+++ b/egograph/pipelines/tests/integration/github/test_ingest.py
@@ -4,6 +4,8 @@ MemoryS3 + responses モックを使用し、Collector → Transform → S3 Stor
 全データフローを検証する。
 """
 
+from datetime import datetime, timezone
+
 import responses
 from pipelines.sources.common.config import (
     Config,
@@ -40,7 +42,8 @@ def _build_config(memory_s3) -> Config:
             token=SecretStr("test-github-token"),
             github_login="test-user",
             target_repos=["test-user/test-repo"],
-            backfill_days=30,
+            # 固定fixtureの日付を現在日時の境界で取りこぼさない。
+            backfill_days=3650,
             fetch_commit_details=True,
             max_commit_detail_requests_per_repo=10,
         ),
@@ -112,8 +115,6 @@ def _mock_github_api(
 @responses.activate
 def test_ingest_saves_raw_events_and_state():
     """Ingest が raw JSON, events Parquet, ingest state を S3 に保存する。"""
-    from datetime import datetime, timezone
-
     now = datetime.now(timezone.utc)
     current_month = f"{now.year}-{now.month:02d}"
     pr = {

--- a/egograph/pipelines/tests/unit/github/test_pipeline.py
+++ b/egograph/pipelines/tests/unit/github/test_pipeline.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
+import pytest
 from pipelines.sources.common.config import (
     Config,
     DuckDBConfig,
@@ -95,6 +96,53 @@ def _build_commit_detail() -> dict:
         "stats": {"additions": 2, "deletions": 1, "total": 3},
         "files": [{"filename": "a.py"}],
     }
+
+
+def _configure_successful_pipeline_mocks(
+    storage: MagicMock,
+    collector: MagicMock,
+    state: dict | None = None,
+) -> None:
+    """単一リポジトリの正常系mockを構築する。"""
+    storage.get_ingest_state.return_value = state or {
+        "github_login": "test-user",
+        "repos": {
+            "test-user/test-repo": {"cursor_utc": "2026-01-01T00:00:00+00:00"},
+        },
+    }
+    storage.save_repo_master.return_value = "repo.parquet"
+    storage.save_pr_events_parquet_with_stats.return_value = {
+        "fetched": 1,
+        "new": 1,
+        "duplicates": 0,
+        "failed": 0,
+    }
+    storage.save_raw_prs.return_value = "pr.json"
+    storage.save_raw_commits.return_value = "commits.json"
+    storage.save_commits_parquet_with_stats.return_value = {
+        "fetched": 1,
+        "new": 1,
+        "duplicates": 0,
+        "failed": 0,
+    }
+
+    collector.get_repository.return_value = _build_personal_repo()
+    collector.get_pull_requests.return_value = [_build_pr()]
+    collector.get_pr_reviews.return_value = []
+    collector.get_repository_commits.return_value = [_build_commit()]
+    collector.get_commit_detail.return_value = _build_commit_detail()
+
+
+def _patch_pipeline_dependencies(monkeypatch, storage, collector):
+    """run_pipelineの外部依存をテストdoubleへ差し替える。"""
+    monkeypatch.setattr(
+        "pipelines.sources.github.ingest_pipeline.GitHubWorklogStorage",
+        lambda **_: storage,
+    )
+    monkeypatch.setattr(
+        "pipelines.sources.github.ingest_pipeline.GitHubWorklogCollector",
+        lambda **_: collector,
+    )
 
 
 class TestMigrateState:
@@ -234,7 +282,8 @@ def test_run_pipeline_does_not_update_state_on_fatal_repo_failure(monkeypatch):
         lambda **_: collector,
     )
 
-    run_pipeline(config)
+    with pytest.raises(RuntimeError, match="GitHub ingest failed"):
+        run_pipeline(config)
 
     # 致命的エラー時は state は保存されるが、失敗リポジトリのcursorは更新されない
     storage.save_ingest_state.assert_called_once()
@@ -243,6 +292,182 @@ def test_run_pipeline_does_not_update_state_on_fatal_repo_failure(monkeypatch):
     assert state_arg["repos"]["test-user/test-repo"]["cursor_utc"] == (
         "2026-01-01T00:00:00+00:00"
     )
+
+
+@pytest.mark.parametrize(
+    "failure_kind",
+    ["repo_master", "pr_events", "raw_prs", "raw_commits", "commit_events"],
+)
+def test_run_pipeline_does_not_advance_cursor_when_required_save_fails(
+    monkeypatch,
+    failure_kind,
+):
+    """必須データの保存失敗時は既存cursorを維持する。"""
+    config = _build_config()
+    storage = MagicMock()
+    collector = MagicMock()
+    _configure_successful_pipeline_mocks(storage, collector)
+
+    if failure_kind == "repo_master":
+        storage.save_repo_master.return_value = None
+    elif failure_kind == "pr_events":
+        storage.save_pr_events_parquet_with_stats.return_value = {
+            "fetched": 1,
+            "new": 0,
+            "duplicates": 0,
+            "failed": 1,
+        }
+    elif failure_kind == "raw_prs":
+        storage.save_raw_prs.return_value = None
+    elif failure_kind == "raw_commits":
+        storage.save_raw_commits.return_value = None
+    else:
+        storage.save_commits_parquet_with_stats.return_value = {
+            "fetched": 1,
+            "new": 0,
+            "duplicates": 0,
+            "failed": 1,
+        }
+
+    _patch_pipeline_dependencies(monkeypatch, storage, collector)
+
+    with pytest.raises(RuntimeError, match="GitHub ingest failed"):
+        run_pipeline(config)
+
+    storage.save_ingest_state.assert_called_once()
+    state_arg = storage.save_ingest_state.call_args[0][0]
+    assert state_arg["repos"]["test-user/test-repo"]["cursor_utc"] == (
+        "2026-01-01T00:00:00+00:00"
+    )
+
+
+def test_run_pipeline_does_not_add_cursor_for_failed_new_repo(monkeypatch):
+    """新規リポジトリの必須保存失敗時はcursorをstateへ追加しない。"""
+    config = _build_config()
+    storage = MagicMock()
+    collector = MagicMock()
+    _configure_successful_pipeline_mocks(
+        storage,
+        collector,
+        state={"github_login": "test-user", "repos": {}},
+    )
+    storage.save_repo_master.return_value = None
+    _patch_pipeline_dependencies(monkeypatch, storage, collector)
+
+    with pytest.raises(RuntimeError, match="GitHub ingest failed"):
+        run_pipeline(config)
+
+    state_arg = storage.save_ingest_state.call_args[0][0]
+    assert "test-user/test-repo" not in state_arg["repos"]
+
+
+def test_run_pipeline_shared_commit_failure_blocks_all_contributing_repos(monkeypatch):
+    """共有月partitionの保存失敗時は寄与した全repoのcursorを止める。"""
+    config = _build_config()
+    config.github_worklog.target_repos = [
+        "test-user/first-repo",
+        "test-user/second-repo",
+    ]
+    storage = MagicMock()
+    collector = MagicMock()
+    _configure_successful_pipeline_mocks(
+        storage,
+        collector,
+        state={
+            "github_login": "test-user",
+            "repos": {
+                "test-user/first-repo": {"cursor_utc": "2026-01-01T00:00:00+00:00"},
+                "test-user/second-repo": {"cursor_utc": "2026-01-02T00:00:00+00:00"},
+            },
+        },
+    )
+    storage.save_commits_parquet_with_stats.return_value = {
+        "fetched": 2,
+        "new": 0,
+        "duplicates": 0,
+        "failed": 2,
+    }
+    _patch_pipeline_dependencies(monkeypatch, storage, collector)
+
+    with pytest.raises(RuntimeError, match="first-repo.*second-repo"):
+        run_pipeline(config)
+
+    state_arg = storage.save_ingest_state.call_args[0][0]
+    assert state_arg["repos"] == {
+        "test-user/first-repo": {"cursor_utc": "2026-01-01T00:00:00+00:00"},
+        "test-user/second-repo": {"cursor_utc": "2026-01-02T00:00:00+00:00"},
+    }
+
+
+def test_run_pipeline_saves_state_when_shared_commit_save_raises(monkeypatch):
+    """共有partitionの保存例外時もstate保存後に失敗を通知する。"""
+    config = _build_config()
+    storage = MagicMock()
+    collector = MagicMock()
+    _configure_successful_pipeline_mocks(storage, collector)
+    storage.save_commits_parquet_with_stats.side_effect = RuntimeError(
+        "commit parquet write failed"
+    )
+    _patch_pipeline_dependencies(monkeypatch, storage, collector)
+
+    with pytest.raises(RuntimeError, match="GitHub ingest failed"):
+        run_pipeline(config)
+
+    storage.save_ingest_state.assert_called_once()
+    state_arg = storage.save_ingest_state.call_args[0][0]
+    assert state_arg["repos"]["test-user/test-repo"]["cursor_utc"] == (
+        "2026-01-01T00:00:00+00:00"
+    )
+
+
+def test_run_pipeline_updates_only_successful_repo_cursor(monkeypatch):
+    """複数repoの一部失敗時は成功repoだけcursorを更新する。"""
+    config = _build_config()
+    config.github_worklog.target_repos = [
+        "test-user/first-repo",
+        "test-user/second-repo",
+    ]
+    storage = MagicMock()
+    collector = MagicMock()
+    _configure_successful_pipeline_mocks(
+        storage,
+        collector,
+        state={
+            "github_login": "test-user",
+            "repos": {
+                "test-user/first-repo": {"cursor_utc": "2026-01-01T00:00:00+00:00"},
+                "test-user/second-repo": {"cursor_utc": "2026-01-02T00:00:00+00:00"},
+            },
+        },
+    )
+    storage.save_repo_master.side_effect = ["repo.parquet", None]
+    _patch_pipeline_dependencies(monkeypatch, storage, collector)
+
+    with pytest.raises(RuntimeError, match="second-repo"):
+        run_pipeline(config)
+
+    state_arg = storage.save_ingest_state.call_args[0][0]
+    assert state_arg["repos"]["test-user/first-repo"]["cursor_utc"] == (
+        "2026-01-03T00:00:00+00:00"
+    )
+    assert state_arg["repos"]["test-user/second-repo"]["cursor_utc"] == (
+        "2026-01-02T00:00:00+00:00"
+    )
+
+
+def test_run_pipeline_state_save_failure_is_not_success(monkeypatch):
+    """state保存失敗時はstate保存を一度試行し、成功扱いにしない。"""
+    config = _build_config()
+    storage = MagicMock()
+    collector = MagicMock()
+    _configure_successful_pipeline_mocks(storage, collector)
+    storage.save_ingest_state.side_effect = RuntimeError("state write failed")
+    _patch_pipeline_dependencies(monkeypatch, storage, collector)
+
+    with pytest.raises(RuntimeError, match="Failed to save GitHub ingest state"):
+        run_pipeline(config)
+
+    storage.save_ingest_state.assert_called_once()
 
 
 def test_run_pipeline_uses_cursor_and_updates_state_on_success(monkeypatch):


### PR DESCRIPTION
## 概要

GitHub ingestで保存に失敗したデータのcursorが進む問題と、BackendのLocal mirror/R2混在によるデータ欠損を修正します。

## 変更内容

### GitHub ingest

- Repository master、PR event、raw PR、raw commit、commit event partitionの保存成功後だけcursor候補をstateへ反映
- 月単位のcommit event保存失敗を、その月に寄与した全リポジトリへ伝播
- 失敗リポジトリは既存cursorを維持し、新規リポジトリにはcursorを追加しない
- state保存を最後に一度だけ実行し、保存後に必要な保存/API失敗が残る場合はRuntimeErrorで上位へ通知
- state保存自体の失敗も成功扱いにしない
- 必須保存の失敗注入、共有partition、部分成功、state保存失敗のテストを追加

### Backend

- 期間指定queryは、対象Local partitionがすべて存在する場合だけLocalを使用
- Local partitionが1つでも欠ける場合は、query全体をR2へ切り替え、sourceを混在させない
- 全件globとdataset存在判定は常にR2を使用
- Google Health daily summaryも期間用path resolverを使用し、欠損R2 partitionを除外
- Backend READMEとarchitecture docsを実装仕様に更新

## 検証

- `USE_ENV_FILE=false uv run pytest egograph/pipelines/tests -q` — 507 passed, 2 skipped
- `USE_ENV_FILE=false R2_ENDPOINT_URL=... R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... R2_BUCKET_NAME=... uv run pytest egograph/backend/tests -q` — 381 passed
- 変更対象Pythonファイルの `ruff check` — passed
- 変更対象Pythonファイルの `ruff format --check` — passed
- `git diff --check` — passed

リポジトリ全体のruffには今回と無関係な既存違反が残っています。

## コミット

- `fix: commit github cursors after successful writes`
- `fix: make local parquet source selection deterministic`

## 対象外

- R2 multi-object transaction
- compactionのストリーミング化
- generation manifest
- 全sourceのcursor処理の全面共通化
- Backendのconnection pooling / query cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 期間指定の分析では、必要なローカルデータがすべて揃っている場合のみローカルミラーを使用するようになりました。不足がある場合は自動的に共有ストレージへ切り替わり、結果の一貫性が向上します。
  - 全件検索やデータセットの存在確認では、常に共有ストレージを参照するようになりました。
  - GitHubデータ取り込みで一部のリポジトリに失敗が発生しても、成功分の状態を保持し、失敗状況を適切に通知できるようになりました。

- **テスト**
  - データ欠損時の切り替えや取り込み失敗時の動作を追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->