### PR TITLE
fix: enforce backend production safety and readiness

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -67,7 +67,13 @@ jobs:
             /root/.local/bin/uv sync --all-packages
             sudo systemctl restart egograph-backend
             for i in $(seq 1 10); do
-              if curl -fsS http://127.0.0.1:8000/health; then
+              if curl -fsS http://127.0.0.1:8000/health | python3 -c '
+                import json
+                import sys
+
+                payload = json.load(sys.stdin)
+                raise SystemExit(payload.get("status") != "ok")
+              '; then
                 echo "Health check passed"
                 exit 0
               fi

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -67,7 +67,8 @@ jobs:
             /root/.local/bin/uv sync --all-packages
             sudo systemctl restart egograph-backend
             for i in $(seq 1 10); do
-              if curl -fsS http://127.0.0.1:8000/health | python3 -c '
+              if curl -fsS --connect-timeout 2 --max-time 5 \
+                http://127.0.0.1:8000/health | python3 -c '
                 import json
                 import sys
 
@@ -79,6 +80,6 @@ jobs:
               fi
               sleep 2
             done
-            echo "=== Health check failed after 20s ==="
+            echo "=== Health check failed after 10 attempts (curl max 5s, 2s interval) ==="
             sudo journalctl -u egograph-backend --since "1 min ago" --no-pager
             exit 1

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -107,7 +107,7 @@ Daily Timeline の詳細は [daily-timeline.md](./daily-timeline.md) を参照�
 
 | メソッド | パス | 内容 |
 |---|---|---|
-| GET | `/health` `/v1/health` | DuckDB + R2 接続確認 |
+| GET | `/health` `/v1/health` | DuckDB + R2 readiness（正常: 200、依存障害: 503） |
 | GET | `/v1/data/spotify/stats/top-tracks` | トップトラック |
 | GET | `/v1/data/spotify/stats/listening` | 再生統計（日/週/月） |
 | GET | `/v1/data/browser-history/page-views` | ページビュー一覧 |
@@ -248,7 +248,7 @@ FastMCP を使用し、ToolRegistry のツールを MCP プロトコルで公開
 
 ### API Key 認証
 
-`BACKEND_API_KEY` 環境変数が設定されている場合、`_ApiKeyAuthMiddleware` が全リクエストで `X-API-Key` ヘッダーを検証する。
+`BACKEND_API_KEY` 環境変数が設定されている場合、`_ApiKeyAuthMiddleware` が全リクエストで `X-API-Key` ヘッダーを検証する。`BACKEND_ENV=production` では、アプリ生成時に API key が必須であることを検証する。
 
 - **対象**: REST API + MCP（共通）
 - **除外パス**: `/health`, `/v1/health`, `/docs`, `/redoc`, `/openapi.json`
@@ -256,7 +256,17 @@ FastMCP を使用し、ToolRegistry のツールを MCP プロトコルで公開
 
 ### CORS
 
-`CORS_ORIGINS` 環境変数（カンマ区切り）で許可オリジンを指定。ワイルドカード `*` は開発環境用。
+`CORS_ORIGINS` 環境変数（カンマ区切り）で許可オリジンを指定。ワイルドカード `*` は開発環境用で、`BACKEND_ENV=production` では拒否される。
+
+### 本番起動時の設定検証
+
+`BACKEND_ENV` のデフォルトは `development`。`production` を指定すると、FastAPI app の生成前に次を検証する。
+
+- `BACKEND_API_KEY` が空でないこと
+- `CORS_ORIGINS` が明示され、`*` を含まないこと
+- R2 設定が存在すること
+
+検証に失敗した場合は app を起動せず、設定エラーとして終了する。
 
 ### MCP Transport Security
 
@@ -271,7 +281,8 @@ FastMCP を使用し、ToolRegistry のツールを MCP プロトコルで公開
 | `host` | `BACKEND_HOST` | `127.0.0.1` | バインドホスト |
 | `port` | `BACKEND_PORT` | `8000` | バインドポート |
 | `reload` | `BACKEND_RELOAD` | `True` | ホットリロード |
-| `api_key` | `BACKEND_API_KEY` | `None` | API Key（オプション） |
+| `environment` | `BACKEND_ENV` | `development` | 実行環境（`development` / `production`） |
+| `api_key` | `BACKEND_API_KEY` | `None` | API Key（production では必須） |
 | `cors_origins` | `CORS_ORIGINS` | `*` | CORS 許可オリジン |
 | `log_level` | `LOG_LEVEL` | `INFO` | ログレベル |
 | `mcp_allowed_hosts` | `MCP_ALLOWED_HOSTS` | `[]` | MCP Host 許可リスト |
@@ -302,8 +313,8 @@ FastMCP を使用し、ToolRegistry のツールを MCP プロトコルで公開
 | エラー | HTTP ステータス | 内容 |
 |---|---|---|
 | `ValueError` (validation) | 400 | バリデーションエラー（日付範囲、limit 等） |
-| `FileNotFoundError` | - | Parquet ファイル未存在（health では `data_available=False`） |
-| `duckdb.IOException` | - | R2 接続エラー |
+| `FileNotFoundError` | 200 | Parquet ファイル未存在（`data_available=False`） |
+| DuckDB / R2 / 設定障害 | 503 | readiness failure（`status=error`、詳細はサニタイズ済み） |
 | 認証エラー | 401 | API Key 不正 |
 | MCP ツール不明 | - | `ValueError("Unknown tool")` |
 | MCP 実行エラー | - | `RuntimeError` でラップ |

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -107,7 +107,7 @@ Daily Timeline の詳細は [daily-timeline.md](./daily-timeline.md) を参照�
 
 | メソッド | パス | 内容 |
 |---|---|---|
-| GET | `/health` `/v1/health` | DuckDB + R2 readiness（正常: 200、依存障害: 503） |
+| GET | `/health` `/v1/health` | DuckDB + R2 readiness（正常: 200、起動後の依存障害: 503。本番設定不足は起動失敗） |
 | GET | `/v1/data/spotify/stats/top-tracks` | トップトラック |
 | GET | `/v1/data/spotify/stats/listening` | 再生統計（日/週/月） |
 | GET | `/v1/data/browser-history/page-views` | ページビュー一覧 |
@@ -248,7 +248,7 @@ FastMCP を使用し、ToolRegistry のツールを MCP プロトコルで公開
 
 ### API Key 認証
 
-`BACKEND_API_KEY` 環境変数が設定されている場合、`_ApiKeyAuthMiddleware` が全リクエストで `X-API-Key` ヘッダーを検証する。`BACKEND_ENV=production` では、アプリ生成時に API key が必須であることを検証する。
+`BACKEND_API_KEY` 環境変数が設定されている場合、`_ApiKeyAuthMiddleware` が除外パスを除く全リクエストで `X-API-Key` ヘッダーを検証する。`BACKEND_ENV=production` では、アプリ生成時に API key が必須であることを検証する。
 
 - **対象**: REST API + MCP（共通）
 - **除外パス**: `/health`, `/v1/health`, `/docs`, `/redoc`, `/openapi.json`
@@ -256,14 +256,14 @@ FastMCP を使用し、ToolRegistry のツールを MCP プロトコルで公開
 
 ### CORS
 
-`CORS_ORIGINS` 環境変数（カンマ区切り）で許可オリジンを指定。ワイルドカード `*` は開発環境用で、`BACKEND_ENV=production` では拒否される。
+`CORS_ORIGINS` 環境変数（カンマ区切り）で許可オリジンを指定。ワイルドカード `*` と空要素は開発環境用の設定ミスとして、`BACKEND_ENV=production` では拒否される。
 
 ### 本番起動時の設定検証
 
 `BACKEND_ENV` のデフォルトは `development`。`production` を指定すると、FastAPI app の生成前に次を検証する。
 
 - `BACKEND_API_KEY` が空でないこと
-- `CORS_ORIGINS` が明示され、`*` を含まないこと
+- `CORS_ORIGINS` が明示され、空要素や `*` を含まないこと
 - R2 設定が存在すること
 
 検証に失敗した場合は app を起動せず、設定エラーとして終了する。
@@ -314,7 +314,8 @@ FastMCP を使用し、ToolRegistry のツールを MCP プロトコルで公開
 |---|---|---|
 | `ValueError` (validation) | 400 | バリデーションエラー（日付範囲、limit 等） |
 | `FileNotFoundError` | 200 | Parquet ファイル未存在（`data_available=False`） |
-| DuckDB / R2 / 設定障害 | 503 | readiness failure（`status=error`、詳細はサニタイズ済み） |
+| 起動後の DuckDB / R2 障害 | 503 | readiness failure（`status=error`、`error=invalid_readiness: <sanitized reason>`） |
+| 本番起動時の設定障害 | HTTP 応答なし | app生成前にプロセス起動を失敗させる |
 | 認証エラー | 401 | API Key 不正 |
 | MCP ツール不明 | - | `ValueError("Unknown tool")` |
 | MCP 実行エラー | - | `RuntimeError` でラップ |

--- a/docs/deploy/backend.md
+++ b/docs/deploy/backend.md
@@ -85,13 +85,15 @@ source /root/.profile
 ## 3. デプロイ配置
 
 パスを固定することでsystemdやCIのスクリプトがシンプルになる。
-backend/pipelines のランタイム secrets は LXC 内の `.env` に置き、
-GitHub Secrets には載せない運用を想定。
+Backend のランタイム設定と secrets はリポジトリ配下の `.env` に保存せず、
+systemd の保護された `EnvironmentFile` またはデプロイ基盤の Secret 機能から
+サービスプロセスの環境変数として注入する。GitHub Secrets にはアプリ本体の
+ランタイム secrets を載せない運用を想定。
 
 推奨パス:
 
 - Repo: `/opt/egograph/repo`
-- Backend env: `/opt/egograph/repo/egograph/backend/.env`
+- Backend environment file: `/etc/egograph/backend.env` (root のみ読み取り可)
 - Pipelines env: `/opt/egograph/repo/egograph/pipelines/.env`
 
 ```bash
@@ -135,7 +137,7 @@ uv run python -c "import duckdb; conn = duckdb.connect(); print(conn.execute(\"S
 ## 5. systemd 常駐
 
 systemdで `backend` を別プロセス常駐化し、障害時は自動復旧させる。
-`WorkingDirectory` と `.env` のパスは固定で運用する。
+`WorkingDirectory` と環境変数の注入元は固定で運用する。
 
 - `egograph-backend.service`
   - 読み取り / MCP API を提供する FastAPI 本体
@@ -158,8 +160,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/egograph/repo
-EnvironmentFile=/opt/egograph/repo/egograph/backend/.env
-Environment=USE_ENV_FILE=false
+EnvironmentFile=/etc/egograph/backend.env
 ExecStart=/root/.local/bin/uv run uvicorn backend.main:app --host 127.0.0.1 --port 8000
 Restart=always
 RestartSec=10
@@ -170,17 +171,15 @@ Group=root
 WantedBy=multi-user.target
 ```
 
-起動前に `egograph/backend/.env` を作成
+起動前に、systemd が読み込む環境変数ファイルを root 専用権限で作成する。
+リポジトリ配下の `.env` は使用しない。
 
 ```bash
-sudo cp /opt/egograph/repo/egograph/backend/.env.example /opt/egograph/repo/egograph/backend/.env
+sudo install -o root -g root -m 600 /dev/null /etc/egograph/backend.env
+sudoedit /etc/egograph/backend.env
 ```
 
-```bash
-sudo nano /opt/egograph/repo/egograph/backend/.env
-```
-
-本番用 `.env` では、少なくとも次を設定する。`BACKEND_ENV=production` にすると、API key・明示的な CORS・R2 設定が不足した状態では Backend は起動しない。
+`/etc/egograph/backend.env` には、デプロイ環境の Secret 管理機能から払い出した値を設定する。`BACKEND_ENV=production` にすると、API key・明示的な CORS・R2 設定が不足した状態では Backend は起動しない。
 
 ```dotenv
 BACKEND_ENV=production
@@ -321,10 +320,15 @@ docker build -t egograph-backend:latest .
 
 ### 8.2 起動
 
-backend 用の環境変数は `egograph/backend/.env` に置いて起動する。
+backend 用の環境変数は、デプロイ基盤の Secret Store からコンテナプロセスへ注入する。
+Docker の `--env-file` は Docker を実行するホスト上のファイルを読むため、
+リポジトリ外の root 専用ファイル（例: `/etc/egograph/backend.env`）を指定する。
+このファイルは root のみ読み取れるため、Docker も root 権限で実行する。
+コンテナ内へ Docker Secret をマウントするだけでは環境変数として注入されないため、
+Secret を使う場合は entrypoint 等で読み込む構成を別途用意する。
 
 ```bash
-docker run --env-file egograph/backend/.env -p 8000:8000 egograph-backend:latest
+sudo docker run --env-file /etc/egograph/backend.env -p 8000:8000 egograph-backend:latest
 ```
 
 ### 8.3 HTTPS

--- a/docs/deploy/backend.md
+++ b/docs/deploy/backend.md
@@ -180,6 +180,18 @@ sudo cp /opt/egograph/repo/egograph/backend/.env.example /opt/egograph/repo/egog
 sudo nano /opt/egograph/repo/egograph/backend/.env
 ```
 
+本番用 `.env` では、少なくとも次を設定する。`BACKEND_ENV=production` にすると、API key・明示的な CORS・R2 設定が不足した状態では Backend は起動しない。
+
+```dotenv
+BACKEND_ENV=production
+BACKEND_API_KEY=<random-long-secret>
+CORS_ORIGINS=https://<allowed-origin>
+R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+R2_ACCESS_KEY_ID=<access-key>
+R2_SECRET_ACCESS_KEY=<secret-key>
+R2_BUCKET_NAME=<bucket-name>
+```
+
 起動:
 
 ```bash
@@ -276,6 +288,10 @@ GitHub リポジトリの `Settings` → `Secrets and variables` → `Actions` �
 - `SSH_HOST`: 例 `egograph-prod.<tailnet>.ts.net`
 - `SSH_USER`: `root`
 - `SSH_KEY`: `egograph_deploy_key` の内容 (秘密鍵)
+
+### 6.3 デプロイ後の readiness 確認
+
+デプロイ workflow は `/health` の HTTP ステータスに加えて JSON の `status=ok` を確認する。Parquet が未投入の場合は `data_available=false` の HTTP 200 となり、R2・DuckDB・設定の障害は HTTP 503 となるため、障害をデプロイ成功として扱わない。
 
 ## 7. 変更フロー（手動）
 

--- a/docs/deploy/backend.md
+++ b/docs/deploy/backend.md
@@ -291,7 +291,7 @@ GitHub リポジトリの `Settings` → `Secrets and variables` → `Actions` �
 
 ### 6.3 デプロイ後の readiness 確認
 
-デプロイ workflow は `/health` の HTTP ステータスに加えて JSON の `status=ok` を確認する。Parquet が未投入の場合は `data_available=false` の HTTP 200 となり、R2・DuckDB・設定の障害は HTTP 503 となるため、障害をデプロイ成功として扱わない。
+デプロイ workflow は `/health` の HTTP ステータスに加えて JSON の `status=ok` を確認する。Parquet が未投入の場合は `data_available=false` の HTTP 200 となる。起動後の R2・DuckDB 障害は HTTP 503 となるため、障害をデプロイ成功として扱わない。本番設定の不足は起動時に app 生成前で検出され、systemd の起動失敗と journal で確認する。
 
 ## 7. 変更フロー（手動）
 

--- a/egograph/backend/.env.example
+++ b/egograph/backend/.env.example
@@ -6,6 +6,8 @@
 BACKEND_HOST=127.0.0.1
 BACKEND_PORT=8000
 BACKEND_RELOAD=true
+# development はAPIキーなしで起動可能。本番は production に変更する。
+BACKEND_ENV=development
 # BACKEND_API_KEY=your-secure-backend-api-key  # 未設定時は認証なし（開発用）
 
 # CORS設定 (カンマ区切り)

--- a/egograph/backend/README.md
+++ b/egograph/backend/README.md
@@ -23,7 +23,7 @@ uv run uvicorn egograph.backend.main:create_app --factory --reload --host 127.0.
 - **Health Check**: http://localhost:8000/health
 - **MCP Endpoint**: http://localhost:8000/mcp
 
-環境変数は `egograph/backend/.env.example` を参照。
+環境変数の一覧は `egograph/backend/.env.example` を参照。Backend は `.env` を自動読み込みしないため、シェル・IDE・systemd・デプロイ基盤からプロセス環境へ設定する。
 
 ## Configuration modes
 

--- a/egograph/backend/README.md
+++ b/egograph/backend/README.md
@@ -25,6 +25,14 @@ uv run uvicorn egograph.backend.main:create_app --factory --reload --host 127.0.
 
 環境変数は `egograph/backend/.env.example` を参照。
 
+## Configuration modes
+
+ローカル開発では `BACKEND_ENV=development`（デフォルト）を使用する。API key なしでも起動でき、`CORS_ORIGINS=*` を許可する。
+
+本番では `BACKEND_ENV=production` を設定する。起動時に `BACKEND_API_KEY`、ワイルドカードでない `CORS_ORIGINS`、R2 設定の存在を検証し、不足時は app を起動しない。
+
+`/health` と `/v1/health` は readiness endpoint であり、依存サービスが利用可能なら HTTP 200（データ未投入も含む）、DuckDB・R2・設定の障害なら HTTP 503 を返す。
+
 ## Development
 
 | 操作 | コマンド |

--- a/egograph/backend/README.md
+++ b/egograph/backend/README.md
@@ -29,9 +29,9 @@ uv run uvicorn egograph.backend.main:create_app --factory --reload --host 127.0.
 
 ローカル開発では `BACKEND_ENV=development`（デフォルト）を使用する。API key なしでも起動でき、`CORS_ORIGINS=*` を許可する。
 
-本番では `BACKEND_ENV=production` を設定する。起動時に `BACKEND_API_KEY`、ワイルドカードでない `CORS_ORIGINS`、R2 設定の存在を検証し、不足時は app を起動しない。
+本番では `BACKEND_ENV=production` を設定する。起動時に `BACKEND_API_KEY`、空要素やワイルドカードを含まない `CORS_ORIGINS`、R2 設定の存在を検証し、不足時は app を起動しない（HTTP 応答は返らない）。
 
-`/health` と `/v1/health` は readiness endpoint であり、依存サービスが利用可能なら HTTP 200（データ未投入も含む）、DuckDB・R2・設定の障害なら HTTP 503 を返す。
+`/health` と `/v1/health` は readiness endpoint であり、依存サービスが利用可能なら HTTP 200（データ未投入も含む）、起動後の DuckDB・R2 障害なら HTTP 503 を返す。本番設定の不足は起動時に検出されるため、503ではなくプロセス起動失敗として扱う。
 
 ## Development
 

--- a/egograph/backend/api/health.py
+++ b/egograph/backend/api/health.py
@@ -28,13 +28,13 @@ def _build_health_response(*, data_available: bool) -> dict[str, str | bool]:
     }
 
 
-def _build_health_error_response(error: Exception) -> JSONResponse:
+def _build_health_error_response(error_message: str) -> JSONResponse:
     """readiness failure の標準レスポンスを構築する。"""
     return JSONResponse(
         status_code=503,
         content={
             "status": "error",
-            "error": sanitize_infra_message(str(error)),
+            "error": f"invalid_readiness: {error_message}",
         },
     )
 
@@ -87,8 +87,13 @@ async def health_check(
         return _build_health_response(data_available=data_exists)
     except Exception as e:
         if _is_empty_dataset_error(e):
-            logger.info("Health check found no compacted parquet yet: %s", e)
+            sanitized_message = sanitize_infra_message(str(e))
+            logger.info(
+                "Health check found no compacted parquet yet: %s",
+                sanitized_message,
+            )
             return _build_health_response(data_available=False)
 
-        logger.exception("Health check failed")
-        return _build_health_error_response(e)
+        sanitized_message = sanitize_infra_message(str(e))
+        logger.error("Health check failed: %s", sanitized_message)
+        return _build_health_error_response(sanitized_message)

--- a/egograph/backend/api/health.py
+++ b/egograph/backend/api/health.py
@@ -5,6 +5,7 @@ import logging
 import duckdb
 from dataset_catalog import datasets
 from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
 
 from backend.config import BackendConfig
 from backend.constants import HEALTH_CHECK_LIMIT
@@ -25,6 +26,17 @@ def _build_health_response(*, data_available: bool) -> dict[str, str | bool]:
         "r2": "accessible",
         "data_available": data_available,
     }
+
+
+def _build_health_error_response(error: Exception) -> JSONResponse:
+    """readiness failure の標準レスポンスを構築する。"""
+    return JSONResponse(
+        status_code=503,
+        content={
+            "status": "error",
+            "error": sanitize_infra_message(str(error)),
+        },
+    )
 
 
 def _is_empty_dataset_error(error: Exception) -> bool:
@@ -79,4 +91,4 @@ async def health_check(
             return _build_health_response(data_available=False)
 
         logger.exception("Health check failed")
-        return {"status": "error", "error": sanitize_infra_message(str(e))}
+        return _build_health_error_response(e)

--- a/egograph/backend/config.py
+++ b/egograph/backend/config.py
@@ -40,6 +40,7 @@ class BackendConfig(BaseSettings):
     host: str = Field("127.0.0.1", alias="BACKEND_HOST")
     port: int = Field(8000, alias="BACKEND_PORT")
     reload: bool = Field(True, alias="BACKEND_RELOAD")
+    environment: str = Field("development", alias="BACKEND_ENV")
 
     # オプショナル認証
     api_key: SecretStr | None = Field(None, alias="BACKEND_API_KEY")
@@ -107,12 +108,15 @@ class BackendConfig(BaseSettings):
         Raises:
             ValueError: 本番環境で必須の設定が不足している場合
         """
-        if not self.api_key:
+        if self.api_key is None or not self.api_key.get_secret_value():
             raise ValueError("BACKEND_API_KEY is required for production")
-        if self.cors_origins == "*":
+        origins = [origin.strip() for origin in self.cors_origins.split(",")]
+        if not origins or any(origin == "*" for origin in origins):
             raise ValueError(
                 "CORS_ORIGINS must be explicitly configured for production (not '*')"
             )
+        if self.r2 is None:
+            raise ValueError("R2 configuration is required for production")
 
     @property
     def mcp_transport_security(self):

--- a/egograph/backend/config.py
+++ b/egograph/backend/config.py
@@ -10,10 +10,6 @@ from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel, Field, SecretStr, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# 環境変数で .env ファイルの使用を制御（デフォルトは使用）
-USE_ENV_FILE = os.getenv("USE_ENV_FILE", "true").lower() in ("true", "1", "yes")
-BACKEND_ENV_FILES = ["egograph/backend/.env"] if USE_ENV_FILE else []
-
 
 class R2Config(BaseModel):
     """Cloudflare R2設定 (S3互換)。"""
@@ -32,8 +28,7 @@ class BackendConfig(BaseSettings):
     """Backend APIサーバー設定。"""
 
     model_config = SettingsConfigDict(
-        env_file=BACKEND_ENV_FILES,
-        env_file_encoding="utf-8",
+        env_file=None,
         extra="ignore",
     )
 
@@ -111,7 +106,7 @@ class BackendConfig(BaseSettings):
         Raises:
             ValueError: 本番環境で必須の設定が不足している場合
         """
-        if self.api_key is None or not self.api_key.get_secret_value():
+        if self.api_key is None or not self.api_key.get_secret_value().strip():
             raise ValueError("BACKEND_API_KEY is required for production")
         origins = [origin.strip() for origin in self.cors_origins.split(",")]
         if any(not origin or origin == "*" for origin in origins):
@@ -145,8 +140,7 @@ class R2Settings(BaseSettings):
     """Cloudflare R2設定 (S3互換)。"""
 
     model_config = SettingsConfigDict(
-        env_file=BACKEND_ENV_FILES,
-        env_file_encoding="utf-8",
+        env_file=None,
         extra="ignore",
     )
 

--- a/egograph/backend/config.py
+++ b/egograph/backend/config.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from typing import Literal
 from zoneinfo import ZoneInfo
 
 from egograph_paths import PARQUET_DATA_DIR
@@ -40,7 +41,9 @@ class BackendConfig(BaseSettings):
     host: str = Field("127.0.0.1", alias="BACKEND_HOST")
     port: int = Field(8000, alias="BACKEND_PORT")
     reload: bool = Field(True, alias="BACKEND_RELOAD")
-    environment: str = Field("development", alias="BACKEND_ENV")
+    environment: Literal["development", "production"] = Field(
+        "development", alias="BACKEND_ENV"
+    )
 
     # オプショナル認証
     api_key: SecretStr | None = Field(None, alias="BACKEND_API_KEY")
@@ -111,9 +114,10 @@ class BackendConfig(BaseSettings):
         if self.api_key is None or not self.api_key.get_secret_value():
             raise ValueError("BACKEND_API_KEY is required for production")
         origins = [origin.strip() for origin in self.cors_origins.split(",")]
-        if not origins or any(origin == "*" for origin in origins):
+        if any(not origin or origin == "*" for origin in origins):
             raise ValueError(
-                "CORS_ORIGINS must be explicitly configured for production (not '*')"
+                "CORS_ORIGINS must be explicitly configured with non-empty origins "
+                "(not '*')"
             )
         if self.r2 is None:
             raise ValueError("R2 configuration is required for production")

--- a/egograph/backend/main.py
+++ b/egograph/backend/main.py
@@ -85,6 +85,8 @@ def create_app(config: BackendConfig | None = None) -> FastAPI:
     """
     if config is None:
         config = BackendConfig.from_env()
+    if config.environment == "production":
+        config.validate_for_production()
 
     # インフラ情報マスキングフィルターを全ロガーに適用（冪等）
     if not any(isinstance(f, InfraSanitizingFilter) for f in logging.root.filters):

--- a/egograph/backend/tests/conftest.py
+++ b/egograph/backend/tests/conftest.py
@@ -61,6 +61,7 @@ def mock_backend_config(mock_r2_config):
         host="127.0.0.1",
         port=8000,
         reload=False,
+        environment="development",
         api_key=SecretStr("test-backend-key"),  # SecretStrでラップ
         cors_origins="http://localhost:3000",  # ワイルドカードを避ける
         log_level="DEBUG",

--- a/egograph/backend/tests/conftest.py
+++ b/egograph/backend/tests/conftest.py
@@ -14,23 +14,6 @@ from backend.config import BackendConfig, R2Config
 from backend.main import create_app
 
 # ========================================
-# 環境変数クリア（テスト用）
-# ========================================
-
-
-@pytest.fixture(autouse=True)
-def disable_env_files():
-    """Pydantic Settingsの.env読み込みを無効化する。"""
-    original_backend_env_file = BackendConfig.model_config.get("env_file")
-
-    BackendConfig.model_config["env_file"] = []
-
-    yield
-
-    BackendConfig.model_config["env_file"] = original_backend_env_file
-
-
-# ========================================
 # 設定フィクスチャ
 # ========================================
 

--- a/egograph/backend/tests/integration/test_api_health.py
+++ b/egograph/backend/tests/integration/test_api_health.py
@@ -129,7 +129,7 @@ class TestHealthEndpoint:
         assert response.status_code == 503
         assert response.json() == {
             "status": "error",
-            "error": "invalid R2 path",
+            "error": "invalid_readiness: invalid R2 path",
         }
 
     def test_health_check_returns_ok_when_no_compacted_files_exist(
@@ -166,7 +166,7 @@ class TestHealthEndpoint:
             app.dependency_overrides[deps.get_config] = lambda: mock_backend_config
 
     def test_health_error_response_excludes_infra_info(
-        self, test_client, mock_backend_config
+        self, test_client, mock_backend_config, caplog
     ):
         """エラーレスポンスに R2 URL 等のインフラ情報が含まれない。"""
 
@@ -181,7 +181,8 @@ class TestHealthEndpoint:
 
         try:
             # Act: ヘルスチェックを実行
-            response = test_client.get("/health")
+            with caplog.at_level("ERROR", logger="backend.api.health"):
+                response = test_client.get("/health")
 
             # Assert: レスポンスに R2 ホスト名が含まれないことを検証
             assert response.status_code == 503
@@ -189,6 +190,8 @@ class TestHealthEndpoint:
             assert data["status"] == "error"
             assert "r2.cloudflarestorage.com" not in data["error"]
             assert "abc123" not in data["error"]
+            assert "r2.cloudflarestorage.com" not in caplog.text
+            assert "abc123" not in caplog.text
         finally:
             app.dependency_overrides.clear()
             app.dependency_overrides[deps.get_config] = lambda: mock_backend_config

--- a/egograph/backend/tests/integration/test_api_health.py
+++ b/egograph/backend/tests/integration/test_api_health.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import duckdb
 
@@ -77,7 +77,7 @@ class TestHealthEndpoint:
         try:
             response = test_client.get("/health")
 
-            assert response.status_code == 200  # エラーでも200を返す
+            assert response.status_code == 503
             data = response.json()
             assert data["status"] == "error"
             assert "error" in data
@@ -115,6 +115,22 @@ class TestHealthEndpoint:
         finally:
             app.dependency_overrides.clear()
             app.dependency_overrides[deps.get_config] = lambda: mock_backend_config
+
+    def test_health_check_handles_path_resolution_error(
+        self, test_client, mock_backend_config
+    ):
+        """R2 path 解決エラーを readiness failure として返す。"""
+        with patch(
+            "backend.api.health.build_dataset_glob",
+            side_effect=ValueError("invalid R2 path"),
+        ):
+            response = test_client.get("/health")
+
+        assert response.status_code == 503
+        assert response.json() == {
+            "status": "error",
+            "error": "invalid R2 path",
+        }
 
     def test_health_check_returns_ok_when_no_compacted_files_exist(
         self, test_client, mock_backend_config
@@ -168,7 +184,7 @@ class TestHealthEndpoint:
             response = test_client.get("/health")
 
             # Assert: レスポンスに R2 ホスト名が含まれないことを検証
-            assert response.status_code == 200
+            assert response.status_code == 503
             data = response.json()
             assert data["status"] == "error"
             assert "r2.cloudflarestorage.com" not in data["error"]

--- a/egograph/backend/tests/unit/test_config.py
+++ b/egograph/backend/tests/unit/test_config.py
@@ -7,6 +7,7 @@ from egograph_paths import PARQUET_DATA_DIR
 from pydantic import SecretStr, ValidationError
 
 from backend.config import BackendConfig, R2Settings
+from backend.main import create_app
 
 
 class TestBackendConfig:
@@ -19,6 +20,7 @@ class TestBackendConfig:
         assert config.host == "127.0.0.1"
         assert config.port == 8000
         assert config.reload is True
+        assert config.environment == "development"
         assert config.log_level == "INFO"
         assert config.api_key is None
         assert config.r2 is None
@@ -29,6 +31,7 @@ class TestBackendConfig:
             host="0.0.0.0",
             port=9000,
             reload=False,
+            environment="production",
             api_key=SecretStr("custom-key"),
             log_level="DEBUG",
         )
@@ -36,6 +39,7 @@ class TestBackendConfig:
         assert config.host == "0.0.0.0"
         assert config.port == 9000
         assert config.reload is False
+        assert config.environment == "production"
         assert config.api_key.get_secret_value() == "custom-key"
         assert config.log_level == "DEBUG"
         assert config.r2 is None
@@ -60,6 +64,7 @@ class TestBackendConfig:
 
     def test_from_env_with_r2_only(self, monkeypatch):
         """R2設定のみでロード可能。"""
+        monkeypatch.delenv("BACKEND_ENV", raising=False)
         monkeypatch.setenv("R2_ENDPOINT_URL", "https://test.r2.cloudflarestorage.com")
         monkeypatch.setenv("R2_ACCESS_KEY_ID", "test_key")
         monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test_secret")
@@ -70,6 +75,19 @@ class TestBackendConfig:
         assert config.r2 is not None
         assert config.r2.bucket_name == "test-bucket"
         assert config.r2.local_parquet_root == str(PARQUET_DATA_DIR)
+
+    def test_from_env_reads_backend_environment(self, monkeypatch):
+        """BACKEND_ENVを環境変数からロードする。"""
+        monkeypatch.setenv("BACKEND_ENV", "production")
+        monkeypatch.setenv("BACKEND_API_KEY", "production-key")
+        monkeypatch.setenv("CORS_ORIGINS", "https://app.example.com")
+        monkeypatch.setenv("R2_ENDPOINT_URL", "https://test.r2.cloudflarestorage.com")
+        monkeypatch.setenv("R2_ACCESS_KEY_ID", "test_key")
+        monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test_secret")
+
+        config = BackendConfig.from_env()
+
+        assert config.environment == "production"
 
     def test_validate_for_production_with_api_key(self, mock_backend_config):
         """API Keyがあれば本番環境検証成功。"""
@@ -91,6 +109,21 @@ class TestBackendConfig:
             match="CORS_ORIGINS must be explicitly configured",
         ):
             mock_backend_config.validate_for_production()
+
+    def test_validate_for_production_requires_r2(self, mock_backend_config):
+        """R2設定がなければ本番環境検証に失敗する。"""
+        mock_backend_config.r2 = None
+
+        with pytest.raises(ValueError, match="R2 configuration is required"):
+            mock_backend_config.validate_for_production()
+
+    def test_create_app_rejects_invalid_production_config(self, mock_backend_config):
+        """不正な本番設定ではFastAPIアプリを生成しない。"""
+        mock_backend_config.environment = "production"
+        mock_backend_config.api_key = None
+
+        with pytest.raises(ValueError, match="BACKEND_API_KEY is required"):
+            create_app(config=mock_backend_config)
 
 
 class TestR2Settings:

--- a/egograph/backend/tests/unit/test_config.py
+++ b/egograph/backend/tests/unit/test_config.py
@@ -89,6 +89,16 @@ class TestBackendConfig:
 
         assert config.environment == "production"
 
+    @pytest.mark.parametrize("environment", ["prod", "Production", "production "])
+    def test_from_env_rejects_unknown_backend_environment(
+        self, monkeypatch, environment
+    ):
+        """BACKEND_ENVの値域外を拒否する。"""
+        monkeypatch.setenv("BACKEND_ENV", environment)
+
+        with pytest.raises(ValidationError):
+            BackendConfig()
+
     def test_validate_for_production_with_api_key(self, mock_backend_config):
         """API Keyがあれば本番環境検証成功。"""
         mock_backend_config.validate_for_production()
@@ -107,6 +117,22 @@ class TestBackendConfig:
         with pytest.raises(
             ValueError,
             match="CORS_ORIGINS must be explicitly configured",
+        ):
+            mock_backend_config.validate_for_production()
+
+    @pytest.mark.parametrize(
+        "cors_origins",
+        ["", " ", "https://app.example.com,,https://admin.example.com"],
+    )
+    def test_validate_for_production_rejects_empty_cors_origin(
+        self, mock_backend_config, cors_origins
+    ):
+        """空要素を含むCORS設定を本番環境で拒否する。"""
+        mock_backend_config.cors_origins = cors_origins
+
+        with pytest.raises(
+            ValueError,
+            match="CORS_ORIGINS must be explicitly configured with non-empty origins",
         ):
             mock_backend_config.validate_for_production()
 

--- a/egograph/backend/tests/unit/test_config.py
+++ b/egograph/backend/tests/unit/test_config.py
@@ -89,6 +89,23 @@ class TestBackendConfig:
 
         assert config.environment == "production"
 
+    def test_does_not_load_local_env_file(self, monkeypatch, tmp_path):
+        """リポジトリ配下の.envを設定ソースとして使用しない。"""
+        env_file = tmp_path / "egograph/backend/.env"
+        env_file.parent.mkdir(parents=True)
+        env_file.write_text(
+            "BACKEND_ENV=production\nBACKEND_API_KEY=from-local-file\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("BACKEND_ENV", raising=False)
+        monkeypatch.delenv("BACKEND_API_KEY", raising=False)
+
+        config = BackendConfig()
+
+        assert config.environment == "development"
+        assert config.api_key is None
+
     @pytest.mark.parametrize("environment", ["prod", "Production", "production "])
     def test_from_env_rejects_unknown_backend_environment(
         self, monkeypatch, environment
@@ -109,6 +126,27 @@ class TestBackendConfig:
 
         with pytest.raises(ValueError, match="BACKEND_API_KEY is required"):
             mock_backend_config.validate_for_production()
+
+    @pytest.mark.parametrize("api_key", ["", " ", "\t\n"])
+    def test_validate_for_production_rejects_blank_api_key(
+        self, mock_backend_config, api_key
+    ):
+        """空白だけのAPI Keyを本番環境で拒否する。"""
+        mock_backend_config.api_key = SecretStr(api_key)
+
+        with pytest.raises(ValueError, match="BACKEND_API_KEY is required"):
+            mock_backend_config.validate_for_production()
+
+    def test_validate_for_production_preserves_non_blank_api_key(
+        self, mock_backend_config
+    ):
+        """空白を含んでも値のあるAPI Keyを有効として扱う。"""
+        api_key = "  test-backend-key  "
+        mock_backend_config.api_key = SecretStr(api_key)
+
+        mock_backend_config.validate_for_production()
+
+        assert mock_backend_config.api_key.get_secret_value() == api_key
 
     def test_validate_for_production_wildcard_cors(self, mock_backend_config):
         """ワイルドカードCORSは本番環境で禁止。"""


### PR DESCRIPTION
## 概要

Backend が本番設定の不足や R2/DuckDB 障害を正常状態として扱わないようにする。

## 変更内容

- `BACKEND_ENV` を `development` / `production` に限定（デフォルト: `development`）
- `production` では app 生成前に API key、空要素・wildcard のない CORS、R2 設定を検証
- `/health` と `/v1/health` を readiness endpoint として整理
  - データ未投入は HTTP 200 / `data_available=false`
  - 起動後の DuckDB・R2 障害は HTTP 503 / `status=error`
  - エラーは `invalid_readiness: ...` 形式かつ既存 sanitizer を通す
  - readiness の失敗ログに未加工の例外・tracebackを出さない
- deploy workflow が HTTP ステータスと JSON の `status=ok` を確認し、curl の接続・応答タイムアウトを設定
- Backend README、architecture、deploy docs を実装に合わせて更新

## 検証

- `USE_ENV_FILE=false R2_ENDPOINT_URL=... R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... R2_BUCKET_NAME=... uv run pytest egograph/backend/tests --cov=backend --cov-report=term-missing`
  - 391 passed、カバレッジ 97%
- 対象変更ファイルの `ruff check` / `ruff format --check`
  - pass

Pipelines の lease heartbeat 対応は別PRで提出する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ヘルスチェックでデータベースやストレージの準備状態を確認し、異常時は503エラーを返すようになりました。
  - 本番環境でAPIキー、CORS、ストレージ設定を検証し、不備がある場合は起動を रोक止します。
- **改善**
  - デプロイ後の確認で接続・応答タイムアウトと正常ステータスを検証するようになりました。
  - エラーレスポンスやログからインフラ情報を保護します。
- **ドキュメント**
  - 開発・本番環境の設定、ヘルスチェック、障害時の挙動を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->