### PR TITLE
fix: stop workflow execution after lease loss

### DIFF
--- a/docs/architecture/pipelines.md
+++ b/docs/architecture/pipelines.md
@@ -160,16 +160,19 @@ sequenceDiagram
     Q-->>D: WorkflowRun
     D->>L: acquire(lock_key)
     L-->>D: Lease
-    loop Heartbeat
-        D->>L: heartbeat(lease)
-        L-->>D: true / false
-    end
-    loop Steps
-        D->>L: lease再確認
-        L-->>D: 有効 / 喪失
-        D->>X: execute(step)
-        X-->>D: StepResult
-        D->>R: update_step_result()
+    par 実行中
+        loop Heartbeat
+            D->>L: heartbeat(lease)
+            L-->>D: true / false
+        end
+    and Steps
+        loop Steps
+            D->>L: lease再確認
+            L-->>D: 有効 / 喪失
+            D->>X: execute(step)
+            X-->>D: StepResult
+            D->>R: update_step_result()
+        end
     end
     D->>L: 最終lease再確認
     D->>L: release(lease)
@@ -359,6 +362,7 @@ stateDiagram-v2
 stateDiagram-v2
     [*] --> QUEUED: create
     QUEUED --> RUNNING: start
+    QUEUED --> SKIPPED: lease lost
     RUNNING --> SUCCEEDED: success
     RUNNING --> FAILED: failure (retryable)
     RUNNING --> SKIPPED: prev step failed

--- a/docs/architecture/pipelines.md
+++ b/docs/architecture/pipelines.md
@@ -172,6 +172,8 @@ sequenceDiagram
             D->>X: execute(step)
             X-->>D: StepResult
             D->>R: update_step_result()
+            D->>L: lease再確認
+            L-->>D: 有効 / 喪失
         end
     end
     D->>L: 最終lease再確認
@@ -185,7 +187,7 @@ sequenceDiagram
 - `dispatch_once()`: キューから1件取得して実行
 - `run_forever()`: 停止要求まで poll を継続
 - Heartbeat: 実行中の lock を定期更新し、失敗時は lease 喪失を記録
-- Step 境界: 各 step 開始前と最終状態保存前に lease を再確認
+- Step 境界: 各 step の開始前と完了後、および最終状態保存前に lease を再確認
 
 #### 3.2 LockManager
 
@@ -200,7 +202,7 @@ sequenceDiagram
 **Lock のライフサイクル**:
 1. run 開始時に `acquire`
 2. 実行中に `heartbeat` を定期的に送信
-3. 各 step 境界と最終状態保存前に lease を再確認
+3. 各 step の開始前と完了後、および最終状態保存前に lease を再確認
 4. run 終了時に `release`（lease喪失後もbest-effort）
 
 #### 3.3 Lease 喪失時の動作

--- a/docs/architecture/pipelines.md
+++ b/docs/architecture/pipelines.md
@@ -162,12 +162,16 @@ sequenceDiagram
     L-->>D: Lease
     loop Heartbeat
         D->>L: heartbeat(lease)
+        L-->>D: true / false
     end
     loop Steps
+        D->>L: lease再確認
+        L-->>D: 有効 / 喪失
         D->>X: execute(step)
         X-->>D: StepResult
         D->>R: update_step_result()
     end
+    D->>L: 最終lease再確認
     D->>L: release(lease)
     D->>R: update_run_result(SUCCEEDED/FAILED)
 ```
@@ -177,7 +181,8 @@ sequenceDiagram
 **主要機能**:
 - `dispatch_once()`: キューから1件取得して実行
 - `run_forever()`: 停止要求まで poll を継続
-- Heartbeat: 実行中の lock を定期更新
+- Heartbeat: 実行中の lock を定期更新し、失敗時は lease 喪失を記録
+- Step 境界: 各 step 開始前と最終状態保存前に lease を再確認
 
 #### 3.2 LockManager
 
@@ -185,14 +190,19 @@ sequenceDiagram
 
 **機能**:
 - `acquire()`: lock 取得（失敗時は `WorkflowLockUnavailableError`）
-- `heartbeat()`: lock 更新
+- `heartbeat()`: lock 更新（対象leaseの更新行数が1のときだけ `True`）
 - `release()`: lock 解放
 - `cleanup_stale_locks()`: 古い lock のクリーンアップ
 
 **Lock のライフサイクル**:
 1. run 開始時に `acquire`
 2. 実行中に `heartbeat` を定期的に送信
-3. run 終了時に `release`
+3. 各 step 境界と最終状態保存前に lease を再確認
+4. run 終了時に `release`（lease喪失後もbest-effort）
+
+#### 3.3 Lease 喪失時の動作
+
+heartbeat のDB例外、または `heartbeat()` が `False` を返した場合は、run のエラー理由に `lease_lost:` を付けて `FAILED` を保存する。現在の step が完了するまでは強制停止せず、完了後に後続 step を開始しない。最後の step 完了後に喪失を検知した場合も `SUCCEEDED` を保存しない。
 
 ---
 
@@ -227,7 +237,7 @@ stateDiagram-v2
     [*] --> QUEUED: enqueue
     QUEUED --> RUNNING: dispatch
     RUNNING --> SUCCEEDED: all steps passed
-    RUNNING --> FAILED: step failed (after retries)
+    RUNNING --> FAILED: step failure or lease lost
     RUNNING --> CANCELED: cancel request
     SUCCEEDED --> [*]
     FAILED --> [*]
@@ -336,7 +346,7 @@ stateDiagram-v2
     QUEUED --> RUNNING: dispatch
     QUEUED --> CANCELED: cancel
     RUNNING --> SUCCEEDED: success
-    RUNNING --> FAILED: failure
+    RUNNING --> FAILED: failure or lease lost
     RUNNING --> CANCELED: cancel
     SUCCEEDED --> [*]
     FAILED --> [*]
@@ -371,6 +381,7 @@ stateDiagram-v2
 | Step timeout | FAILED として記録、再試行判定 |
 | Step exception | FAILED として記録、再試行判定 |
 | `AuthenticationError` | **即時** FAILED（リトライ対象外） |
+| lease heartbeat の例外 / 更新失敗 | `lease_lost:` を記録して FAILED、未開始 step は SKIPPED |
 
 ### 再試行ロジック
 

--- a/docs/deploy/pipelines.md
+++ b/docs/deploy/pipelines.md
@@ -119,6 +119,10 @@ main への push をトリガーに本番へデプロイする。
    - `systemctl restart egograph-pipelines` でサービス再起動
    - `/v1/health` でヘルスチェック（最大20秒）
 
+### 3.1 lease 喪失の確認
+
+実行中の workflow は `run show --json` または `GET /v1/runs/{run_id}` で確認する。heartbeat のDB障害や別workerによるlease置換が起きた場合、run は `failed` となり、`error_message` に `lease_lost:` を含む。後続 step は開始されず、失敗した run は通常の retry 操作で再実行できる。
+
 ### GitHub Secrets
 
 Backend で使用するものと同じ Secrets を使用する。追加の登録は不要。

--- a/egograph/pipelines/README.md
+++ b/egograph/pipelines/README.md
@@ -20,7 +20,7 @@ uv run python -m egograph.pipelines.main serve
 ```
 
 - **API Docs**: http://localhost:8001/docs
-- **Health Check**: http://localhost:8001/health
+- **Health Check**: http://localhost:8001/v1/health
 
 環境変数は `egograph/pipelines/.env.example` を参照。
 
@@ -95,6 +95,8 @@ uv run python -m pipelines.main run cancel 722e2f38-def8-4bba-9283-bfe07459935c 
 
 run の状態遷移: `queued` → `running` → `succeeded` / `failed` / `canceled`
 
+workflow lock は lease として管理される。heartbeat のDB例外や更新失敗を検知した場合、実行中のstep完了後に後続stepを開始せず、runを `failed` にして `error_message` へ `lease_lost:` から始まる理由を保存する。最後のstep完了後にleaseを失った場合も成功にはならない。
+
 **ログ取得時の注意点**: `run log` は step が実行され、log ファイルが生成された後にのみ利用可能。`queued` 状態の run に対して実行すると `WorkflowNotFoundError` になる。
 
 ```bash
@@ -140,8 +142,8 @@ Google Healthは`TIMEZONE`基準で3時間ごとの当日・前日repair、毎�
 # API ドキュメント（Swagger UI）
 http://localhost:8001/docs
 
-# ヘルスチェック
-curl http://localhost:8001/health
+# ヘルスチェック（データ収集前でも status=ok を返す）
+curl http://localhost:8001/v1/health
 
 # ワークフロー一覧
 curl -H "X-API-Key: $PIPELINES_API_KEY" http://localhost:8001/v1/workflows

--- a/egograph/pipelines/README.md
+++ b/egograph/pipelines/README.md
@@ -115,7 +115,7 @@ uv run python -m pipelines.main run log <run_id> <step_id>
 ## REST API リファレンス
 
 Pipelines Service はポート `8001`（デフォルト）で HTTP API を提供する。
-全エンドポイントは API キー認証が必要（環境変数 `PIPELINES_API_KEY` で設定）。
+`/v1/health` を除くエンドポイントは API キー認証が必要（環境変数 `PIPELINES_API_KEY` で設定）。
 
 ### エンドポイント一覧
 

--- a/egograph/pipelines/infrastructure/dispatching/lock_manager.py
+++ b/egograph/pipelines/infrastructure/dispatching/lock_manager.py
@@ -97,12 +97,12 @@ class WorkflowLockManager:
             lease_owner=self._lease_owner,
         )
 
-    def heartbeat(self, lease: WorkflowLease) -> None:
-        """lease の期限を延長する。"""
+    def heartbeat(self, lease: WorkflowLease) -> bool:
+        """lease の期限を延長し、現在の所有者なら成功を返す。"""
         now = _utc_now()
         expires_at = now + timedelta(seconds=self._lease_seconds)
         with self._mutex, self._conn:
-            self._conn.execute(
+            cursor = self._conn.execute(
                 """
                 UPDATE workflow_locks
                 SET heartbeat_at = ?,
@@ -119,6 +119,7 @@ class WorkflowLockManager:
                     lease.lease_owner,
                 ),
             )
+            return cursor.rowcount == 1
 
     def release(self, lease: WorkflowLease) -> None:
         """保持中 lease を解放する。"""

--- a/egograph/pipelines/infrastructure/dispatching/run_dispatcher.py
+++ b/egograph/pipelines/infrastructure/dispatching/run_dispatcher.py
@@ -35,6 +35,48 @@ logger = logging.getLogger(__name__)
 
 NOTIFICATION_SOURCE = "urn:egograph:pipelines"
 NOTIFICATION_TYPE = "egograph.pipelines.workflow_failed"
+LEASE_LOST_PREFIX = "lease_lost:"
+
+
+class _LeaseState:
+    """workerとheartbeat threadが共有するlease状態。"""
+
+    def __init__(self) -> None:
+        self._lost_event = threading.Event()
+        self._mutex = threading.Lock()
+        self._error_message: str | None = None
+        self._exception: Exception | None = None
+
+    @property
+    def is_lost(self) -> bool:
+        """leaseが失われたかどうかを返す。"""
+        return self._lost_event.is_set()
+
+    @property
+    def error_message(self) -> str:
+        """lease喪失理由を返す。"""
+        with self._mutex:
+            return self._error_message or f"{LEASE_LOST_PREFIX} workflow lease was lost"
+
+    @property
+    def exception(self) -> Exception | None:
+        """heartbeat失敗時の例外を返す。"""
+        with self._mutex:
+            return self._exception
+
+    def mark_lost(
+        self,
+        *,
+        error_message: str,
+        exception: Exception | None = None,
+    ) -> None:
+        """最初に検知したlease喪失理由を保存する。"""
+        with self._mutex:
+            if self._lost_event.is_set():
+                return
+            self._error_message = error_message
+            self._exception = exception
+            self._lost_event.set()
 
 
 class _DispatchOutcome:
@@ -229,34 +271,52 @@ class RunDispatcher:
         self,
         lease: WorkflowLease,
         stop_event: threading.Event,
+        lease_state: _LeaseState | None = None,
     ) -> None:
+        lease_state = lease_state or _LeaseState()
         while not stop_event.wait(self._heartbeat_seconds):
-            try:
-                # Heartbeat failure should not kill the background thread silently.
-                self._lock_manager.heartbeat(lease)
-            except Exception as exc:
-                logger.warning(
-                    "workflow heartbeat failed: lock_key=%s, run_id=%s, error=%s: %s",
-                    lease.lock_key,
-                    lease.run_id,
-                    type(exc).__name__,
-                    exc,
-                )
+            if not self._check_lease(lease, lease_state):
+                return
 
     def _execute_run(
         self,
         workflow: WorkflowDefinition,
         run: WorkflowRun,
+        lease_state: _LeaseState | None = None,
+        lease: WorkflowLease | None = None,
     ) -> None:
+        lease_state = lease_state or _LeaseState()
         last_summary: dict | None = None
         try:
             for sequence_no, step in enumerate(workflow.steps, start=1):
+                self._check_lease(lease, lease_state)
+                if lease_state.is_lost:
+                    self._mark_run_failed_due_to_lease_loss(
+                        workflow=workflow,
+                        run=run,
+                        lease_state=lease_state,
+                        remaining_steps=workflow.steps[sequence_no - 1 :],
+                        first_sequence_no=sequence_no,
+                        result_summary=last_summary,
+                    )
+                    return
                 success, last_summary, error_message, last_exc = self._execute_step(
                     workflow=workflow,
                     run=run,
                     step=step,
                     sequence_no=sequence_no,
                 )
+                self._check_lease(lease, lease_state)
+                if lease_state.is_lost:
+                    self._mark_run_failed_due_to_lease_loss(
+                        workflow=workflow,
+                        run=run,
+                        lease_state=lease_state,
+                        remaining_steps=workflow.steps[sequence_no:],
+                        first_sequence_no=sequence_no + 1,
+                        result_summary=last_summary,
+                    )
+                    return
                 if not success:
                     final_error = error_message or f"step failed: {step.step_id}"
                     self._skip_remaining_steps(
@@ -277,6 +337,17 @@ class RunDispatcher:
                         exc=last_exc,
                     )
                     return
+            self._check_lease(lease, lease_state)
+            if lease_state.is_lost:
+                self._mark_run_failed_due_to_lease_loss(
+                    workflow=workflow,
+                    run=run,
+                    lease_state=lease_state,
+                    remaining_steps=(),
+                    first_sequence_no=len(workflow.steps) + 1,
+                    result_summary=last_summary,
+                )
+                return
             final_status = _status_from_summary(last_summary)
             error_message = (
                 _error_from_summary(last_summary)
@@ -305,11 +376,21 @@ class RunDispatcher:
                 "run execution crashed unexpectedly: run_id=%s",
                 run.run_id,
             )
-            self._mark_run_failed_after_unexpected_exception(
-                workflow=workflow,
-                run=run,
-                exc=exc,
-            )
+            if lease_state.is_lost:
+                self._mark_run_failed_due_to_lease_loss(
+                    workflow=workflow,
+                    run=run,
+                    lease_state=lease_state,
+                    remaining_steps=(),
+                    first_sequence_no=len(workflow.steps) + 1,
+                    result_summary=last_summary,
+                )
+            else:
+                self._mark_run_failed_after_unexpected_exception(
+                    workflow=workflow,
+                    run=run,
+                    exc=exc,
+                )
 
     def _execute_step(
         self,
@@ -434,15 +515,16 @@ class RunDispatcher:
         run: WorkflowRun,
         lease: WorkflowLease,
     ) -> None:
+        lease_state = _LeaseState()
         heartbeat_stop = threading.Event()
         heartbeat_thread = threading.Thread(
             target=self._heartbeat_loop,
-            args=(lease, heartbeat_stop),
+            args=(lease, heartbeat_stop, lease_state),
             daemon=True,
         )
         heartbeat_thread.start()
         try:
-            self._execute_run(workflow, run)
+            self._execute_run(workflow, run, lease_state, lease)
         finally:
             heartbeat_stop.set()
             heartbeat_thread.join(timeout=max(1, self._heartbeat_seconds))
@@ -454,6 +536,73 @@ class RunDispatcher:
                     lease.lock_key,
                     lease.run_id,
                 )
+
+    def _check_lease(
+        self,
+        lease: WorkflowLease | None,
+        lease_state: _LeaseState,
+    ) -> bool:
+        """leaseを再確認し、失敗時は共有状態へ記録する。"""
+        if lease is None or lease_state.is_lost:
+            return not lease_state.is_lost
+        try:
+            if self._lock_manager.heartbeat(lease):
+                return True
+        except Exception as exc:
+            lease_state.mark_lost(
+                error_message=(
+                    f"{LEASE_LOST_PREFIX} heartbeat failed: {type(exc).__name__}: {exc}"
+                ),
+                exception=exc,
+            )
+            logger.warning(
+                "workflow heartbeat failed: lock_key=%s, run_id=%s, error=%s: %s",
+                lease.lock_key,
+                lease.run_id,
+                type(exc).__name__,
+                exc,
+            )
+            return False
+
+        lease_state.mark_lost(
+            error_message=f"{LEASE_LOST_PREFIX} workflow lease was lost"
+        )
+        logger.warning(
+            "workflow lease was lost: lock_key=%s, run_id=%s",
+            lease.lock_key,
+            lease.run_id,
+        )
+        return False
+
+    def _mark_run_failed_due_to_lease_loss(
+        self,
+        *,
+        workflow: WorkflowDefinition,
+        run: WorkflowRun,
+        lease_state: _LeaseState,
+        remaining_steps: tuple[StepDefinition, ...],
+        first_sequence_no: int,
+        result_summary: dict | None,
+    ) -> None:
+        """lease喪失を記録し、未開始stepをskipしてrunを失敗させる。"""
+        self._skip_remaining_steps(
+            run=run,
+            steps=remaining_steps,
+            first_sequence_no=first_sequence_no,
+        )
+        error_message = lease_state.error_message
+        self._run_repository.update_run_result(
+            run_id=run.run_id,
+            status=WorkflowRunStatus.FAILED,
+            error_message=error_message,
+            result_summary=result_summary,
+        )
+        self._notify_failure(
+            workflow=workflow,
+            run=run,
+            error_message=error_message,
+            exc=lease_state.exception,
+        )
 
     def _execute_run_in_worker(
         self,

--- a/egograph/pipelines/infrastructure/dispatching/run_dispatcher.py
+++ b/egograph/pipelines/infrastructure/dispatching/run_dispatcher.py
@@ -289,6 +289,7 @@ class RunDispatcher:
         last_summary: dict | None = None
         lease_loss_handled = False
         next_sequence_no = 1
+        step_started = False
         try:
             for sequence_no, step in enumerate(workflow.steps, start=1):
                 next_sequence_no = sequence_no
@@ -303,13 +304,16 @@ class RunDispatcher:
                         first_sequence_no=sequence_no,
                         result_summary=last_summary,
                     )
+                    lease_loss_handled = True
                     return
+                step_started = True
                 success, last_summary, error_message, last_exc = self._execute_step(
                     workflow=workflow,
                     run=run,
                     step=step,
                     sequence_no=sequence_no,
                 )
+                step_started = False
                 next_sequence_no = sequence_no + 1
                 self._check_lease(lease, lease_state)
                 if lease_state.is_lost:
@@ -322,6 +326,7 @@ class RunDispatcher:
                         first_sequence_no=sequence_no + 1,
                         result_summary=last_summary,
                     )
+                    lease_loss_handled = True
                     return
                 if not success:
                     final_error = error_message or f"step failed: {step.step_id}"
@@ -355,6 +360,7 @@ class RunDispatcher:
                     first_sequence_no=len(workflow.steps) + 1,
                     result_summary=last_summary,
                 )
+                lease_loss_handled = True
                 return
             final_status = _status_from_summary(last_summary)
             error_message = (
@@ -386,15 +392,19 @@ class RunDispatcher:
             )
             if lease_state.is_lost:
                 if not lease_loss_handled:
+                    first_unstarted_sequence_no = next_sequence_no + int(step_started)
                     self._mark_run_failed_due_to_lease_loss(
                         workflow=workflow,
                         run=run,
                         lease_state=lease_state,
-                        remaining_steps=workflow.steps[next_sequence_no - 1 :],
-                        first_sequence_no=next_sequence_no,
+                        remaining_steps=workflow.steps[
+                            first_unstarted_sequence_no - 1 :
+                        ],
+                        first_sequence_no=first_unstarted_sequence_no,
                         result_summary=last_summary,
                         exception=exc,
                     )
+                    lease_loss_handled = True
             else:
                 self._mark_run_failed_after_unexpected_exception(
                     workflow=workflow,
@@ -494,11 +504,29 @@ class RunDispatcher:
         first_sequence_no: int,
     ) -> None:
         for offset, step in enumerate(steps):
+            sequence_no = first_sequence_no + offset
+            existing_step_runs = {
+                existing.sequence_no: existing
+                for existing in self._step_run_repository.list_step_runs(run.run_id)
+            }
+            existing_step_run = existing_step_runs.get(sequence_no)
+            if existing_step_run is not None:
+                if existing_step_run.status != StepRunStatus.SKIPPED:
+                    self._step_run_repository.update_step_result(
+                        step_run_id=existing_step_run.step_run_id,
+                        status=StepRunStatus.SKIPPED,
+                        exit_code=None,
+                        stdout_tail="",
+                        stderr_tail="",
+                        log_path=None,
+                        result_summary=None,
+                    )
+                continue
             step_run = self._step_run_repository.insert_step_run(
                 run_id=run.run_id,
                 step_id=step.step_id,
                 step_name=step.step_name,
-                sequence_no=first_sequence_no + offset,
+                sequence_no=sequence_no,
                 attempt_no=1,
                 command=self._format_command(step),
                 status=StepRunStatus.SKIPPED,

--- a/egograph/pipelines/infrastructure/dispatching/run_dispatcher.py
+++ b/egograph/pipelines/infrastructure/dispatching/run_dispatcher.py
@@ -287,10 +287,14 @@ class RunDispatcher:
     ) -> None:
         lease_state = lease_state or _LeaseState()
         last_summary: dict | None = None
+        lease_loss_handled = False
+        next_sequence_no = 1
         try:
             for sequence_no, step in enumerate(workflow.steps, start=1):
+                next_sequence_no = sequence_no
                 self._check_lease(lease, lease_state)
                 if lease_state.is_lost:
+                    lease_loss_handled = True
                     self._mark_run_failed_due_to_lease_loss(
                         workflow=workflow,
                         run=run,
@@ -306,8 +310,10 @@ class RunDispatcher:
                     step=step,
                     sequence_no=sequence_no,
                 )
+                next_sequence_no = sequence_no + 1
                 self._check_lease(lease, lease_state)
                 if lease_state.is_lost:
+                    lease_loss_handled = True
                     self._mark_run_failed_due_to_lease_loss(
                         workflow=workflow,
                         run=run,
@@ -337,8 +343,10 @@ class RunDispatcher:
                         exc=last_exc,
                     )
                     return
+            next_sequence_no = len(workflow.steps) + 1
             self._check_lease(lease, lease_state)
             if lease_state.is_lost:
+                lease_loss_handled = True
                 self._mark_run_failed_due_to_lease_loss(
                     workflow=workflow,
                     run=run,
@@ -377,14 +385,16 @@ class RunDispatcher:
                 run.run_id,
             )
             if lease_state.is_lost:
-                self._mark_run_failed_due_to_lease_loss(
-                    workflow=workflow,
-                    run=run,
-                    lease_state=lease_state,
-                    remaining_steps=(),
-                    first_sequence_no=len(workflow.steps) + 1,
-                    result_summary=last_summary,
-                )
+                if not lease_loss_handled:
+                    self._mark_run_failed_due_to_lease_loss(
+                        workflow=workflow,
+                        run=run,
+                        lease_state=lease_state,
+                        remaining_steps=workflow.steps[next_sequence_no - 1 :],
+                        first_sequence_no=next_sequence_no,
+                        result_summary=last_summary,
+                        exception=exc,
+                    )
             else:
                 self._mark_run_failed_after_unexpected_exception(
                     workflow=workflow,
@@ -583,6 +593,7 @@ class RunDispatcher:
         remaining_steps: tuple[StepDefinition, ...],
         first_sequence_no: int,
         result_summary: dict | None,
+        exception: Exception | None = None,
     ) -> None:
         """lease喪失を記録し、未開始stepをskipしてrunを失敗させる。"""
         self._skip_remaining_steps(
@@ -591,6 +602,11 @@ class RunDispatcher:
             first_sequence_no=first_sequence_no,
         )
         error_message = lease_state.error_message
+        if exception is not None and exception is not lease_state.exception:
+            error_message = (
+                f"{error_message}; dispatcher failure: "
+                f"{type(exception).__name__}: {exception}"
+            )
         self._run_repository.update_run_result(
             run_id=run.run_id,
             status=WorkflowRunStatus.FAILED,
@@ -601,7 +617,7 @@ class RunDispatcher:
             workflow=workflow,
             run=run,
             error_message=error_message,
-            exc=lease_state.exception,
+            exc=exception or lease_state.exception,
         )
 
     def _execute_run_in_worker(

--- a/egograph/pipelines/tests/unit/test_dispatcher.py
+++ b/egograph/pipelines/tests/unit/test_dispatcher.py
@@ -26,6 +26,7 @@ from pipelines.infrastructure.db.workflow_repository import WorkflowRepository
 from pipelines.infrastructure.dispatching.lock_manager import WorkflowLockManager
 from pipelines.infrastructure.dispatching.run_dispatcher import (
     RunDispatcher,
+    _LeaseState,
     _status_from_summary,
 )
 from pipelines.infrastructure.execution.inprocess_executor import InProcessStepExecutor
@@ -1138,6 +1139,68 @@ def test_dispatch_once_does_not_mark_run_succeeded_after_last_step_lease_loss(
     updated_run = run_repository.get_run(run.run_id)
     assert updated_run.status == WorkflowRunStatus.FAILED
     assert "lease_lost:" in (updated_run.last_error_message or "")
+
+
+def test_lease_loss_exception_skips_only_unexecuted_steps_and_preserves_error(
+    tmp_path,
+):
+    """lease喪失後の例外処理が未実行stepと例外理由を保持する。"""
+    workflows = {
+        "lease_workflow": WorkflowDefinition(
+            workflow_id="lease_workflow",
+            name="Lease workflow",
+            description="Lease loss test workflow",
+            steps=(
+                StepDefinition(
+                    step_id="first",
+                    step_name="First",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+                StepDefinition(
+                    step_id="second",
+                    step_name="Second",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+            ),
+        )
+    }
+    run_repository, step_run_repository, dispatcher, _ = _build_dispatcher(
+        tmp_path, workflows
+    )
+    run = run_repository.enqueue_run(
+        workflow_id="lease_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+    )
+    lease = dispatcher._lock_manager.acquire(
+        lock_key="lease_workflow", run_id=run.run_id
+    )
+    lease_state = _LeaseState()
+
+    def execute_step(*, step, **_kwargs):
+        if step.step_id == "first":
+            return True, {"message": "first completed"}, None, None
+        lease_state.mark_lost(error_message="lease_lost: heartbeat unavailable")
+        raise RuntimeError("step persistence failed")
+
+    dispatcher._execute_step = execute_step
+
+    # Act
+    dispatcher._execute_run(workflows["lease_workflow"], run, lease_state, lease)
+
+    # Assert
+    updated_run = run_repository.get_run(run.run_id)
+    steps = step_run_repository.list_step_runs(run.run_id)
+    assert updated_run.status == WorkflowRunStatus.FAILED
+    assert updated_run.result_summary == {"message": "first completed"}
+    assert "lease_lost: heartbeat unavailable" in (updated_run.last_error_message or "")
+    assert "RuntimeError: step persistence failed" in (
+        updated_run.last_error_message or ""
+    )
+    assert [step.sequence_no for step in steps] == [2]
+    assert [step.status for step in steps] == [StepRunStatus.SKIPPED]
 
 
 def test_lease_loss_takes_precedence_over_step_failure(tmp_path):

--- a/egograph/pipelines/tests/unit/test_dispatcher.py
+++ b/egograph/pipelines/tests/unit/test_dispatcher.py
@@ -10,6 +10,7 @@ from pipelines.domain.errors import AuthenticationError
 from pipelines.domain.workflow import (
     QueuedReason,
     StepDefinition,
+    StepExecutionResult,
     StepExecutorType,
     StepRunStatus,
     TriggerType,
@@ -40,6 +41,7 @@ def _build_dispatcher(
     workflows,
     *,
     max_concurrent_runs=1,
+    heartbeat_seconds=60,
     notification_service=None,
 ):
     conn = connect(tmp_path / "state.sqlite3")
@@ -61,7 +63,7 @@ def _build_dispatcher(
         notification_service=notification_service
         or NotificationService(webhook_url=None),
         poll_seconds=0.01,
-        heartbeat_seconds=60,
+        heartbeat_seconds=heartbeat_seconds,
         max_concurrent_runs=max_concurrent_runs,
     )
     return run_repository, step_run_repository, dispatcher, lock_manager
@@ -982,8 +984,8 @@ def test_dispatch_available_runs_skips_blocked_run_within_same_cycle(tmp_path):
     assert run_repository.get_run(free_run.run_id).status == WorkflowRunStatus.SUCCEEDED
 
 
-def test_heartbeat_loop_logs_warning_and_continues_after_exception(tmp_path, caplog):
-    """heartbeat 失敗でスレッドが黙死しない。"""
+def test_heartbeat_loop_logs_warning_and_stops_after_exception(tmp_path, caplog):
+    """heartbeat例外をlease喪失として記録してループを終了する。"""
     _, _, dispatcher, _ = _build_dispatcher(tmp_path, {})
     lease = dispatcher._lock_manager.acquire(lock_key="dummy-lock", run_id="run-1")
     stop_event = Mock()
@@ -995,9 +997,205 @@ def test_heartbeat_loop_logs_warning_and_continues_after_exception(tmp_path, cap
     with caplog.at_level(logging.WARNING):
         dispatcher._heartbeat_loop(lease, stop_event)
 
-    assert dispatcher._lock_manager.heartbeat.call_count == 2
+    assert dispatcher._lock_manager.heartbeat.call_count == 1
     assert "workflow heartbeat failed" in caplog.text
     assert "db busy" in caplog.text
+
+
+def test_heartbeat_loop_stops_after_lease_is_lost(tmp_path, caplog):
+    """heartbeatがFalseを返したらlease喪失としてループを終了する。"""
+    _, _, dispatcher, _ = _build_dispatcher(tmp_path, {})
+    lease = dispatcher._lock_manager.acquire(lock_key="dummy-lock", run_id="run-1")
+    stop_event = Mock()
+    stop_event.wait = Mock(side_effect=[False, False, True])
+    dispatcher._lock_manager.heartbeat = Mock(return_value=False)
+
+    with caplog.at_level(logging.WARNING):
+        dispatcher._heartbeat_loop(lease, stop_event)
+
+    assert dispatcher._lock_manager.heartbeat.call_count == 1
+    assert "workflow lease was lost" in caplog.text
+
+
+def test_dispatch_once_does_not_start_next_step_after_lease_loss(tmp_path):
+    """lease喪失後は後続stepを開始せずrunをFAILEDにする。"""
+    workflows = {
+        "lease_workflow": WorkflowDefinition(
+            workflow_id="lease_workflow",
+            name="Lease workflow",
+            description="Lease loss test workflow",
+            steps=(
+                StepDefinition(
+                    step_id="first",
+                    step_name="First",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+                StepDefinition(
+                    step_id="second",
+                    step_name="Second",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+            ),
+        )
+    }
+    run_repository, step_run_repository, dispatcher, _ = _build_dispatcher(
+        tmp_path,
+        workflows,
+        heartbeat_seconds=60,
+    )
+    run = run_repository.enqueue_run(
+        workflow_id="lease_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+    )
+    started_steps: list[str] = []
+    heartbeat_available = True
+
+    def execute_step(**kwargs):
+        nonlocal heartbeat_available
+        started_steps.append(kwargs["step"].step_id)
+        if kwargs["step"].step_id == "first":
+            heartbeat_available = False
+        return StepExecutionResult(
+            status=StepRunStatus.SUCCEEDED,
+            exit_code=0,
+            stdout_tail="",
+            stderr_tail="",
+            log_path="",
+            result_summary=None,
+        )
+
+    dispatcher._inprocess_executor.execute = execute_step
+    dispatcher._lock_manager.heartbeat = Mock(
+        side_effect=lambda _lease: heartbeat_available
+    )
+
+    assert dispatcher.dispatch_once() is True
+
+    updated_run = run_repository.get_run(run.run_id)
+    steps = step_run_repository.list_step_runs(run.run_id)
+    assert started_steps == ["first"]
+    assert updated_run.status == WorkflowRunStatus.FAILED
+    assert "lease_lost:" in (updated_run.last_error_message or "")
+    assert [step.status for step in steps] == [
+        StepRunStatus.SUCCEEDED,
+        StepRunStatus.SKIPPED,
+    ]
+
+
+def test_dispatch_once_does_not_mark_run_succeeded_after_last_step_lease_loss(
+    tmp_path,
+):
+    """最後のstep後にleaseを失ったrunも成功として保存しない。"""
+    workflows = {
+        "lease_workflow": WorkflowDefinition(
+            workflow_id="lease_workflow",
+            name="Lease workflow",
+            description="Lease loss test workflow",
+            steps=(
+                StepDefinition(
+                    step_id="only",
+                    step_name="Only",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+            ),
+        )
+    }
+    run_repository, _, dispatcher, _ = _build_dispatcher(
+        tmp_path,
+        workflows,
+        heartbeat_seconds=60,
+    )
+    run = run_repository.enqueue_run(
+        workflow_id="lease_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+    )
+    heartbeat_available = True
+
+    def execute_step(**_kwargs):
+        nonlocal heartbeat_available
+        heartbeat_available = False
+        return StepExecutionResult(
+            status=StepRunStatus.SUCCEEDED,
+            exit_code=0,
+            stdout_tail="",
+            stderr_tail="",
+            log_path="",
+            result_summary=None,
+        )
+
+    dispatcher._inprocess_executor.execute = execute_step
+    dispatcher._lock_manager.heartbeat = Mock(
+        side_effect=lambda _lease: heartbeat_available
+    )
+
+    dispatcher.dispatch_once()
+
+    updated_run = run_repository.get_run(run.run_id)
+    assert updated_run.status == WorkflowRunStatus.FAILED
+    assert "lease_lost:" in (updated_run.last_error_message or "")
+
+
+def test_lease_loss_takes_precedence_over_step_failure(tmp_path):
+    """heartbeat失敗とstep失敗が重なった場合はlease喪失を記録する。"""
+    workflows = {
+        "lease_workflow": WorkflowDefinition(
+            workflow_id="lease_workflow",
+            name="Lease workflow",
+            description="Lease loss test workflow",
+            steps=(
+                StepDefinition(
+                    step_id="only",
+                    step_name="Only",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+            ),
+        )
+    }
+    run_repository, _, dispatcher, _ = _build_dispatcher(
+        tmp_path,
+        workflows,
+        heartbeat_seconds=60,
+    )
+    run = run_repository.enqueue_run(
+        workflow_id="lease_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+    )
+    heartbeat_available = True
+
+    def execute_step(**_kwargs):
+        nonlocal heartbeat_available
+        heartbeat_available = False
+        return StepExecutionResult(
+            status=StepRunStatus.FAILED,
+            exit_code=1,
+            stdout_tail="",
+            stderr_tail="step failed",
+            log_path="",
+            result_summary=None,
+            error_message="step failed",
+        )
+
+    dispatcher._inprocess_executor.execute = execute_step
+
+    def heartbeat(_lease):
+        if heartbeat_available:
+            return True
+        raise sqlite3.OperationalError("db busy")
+
+    dispatcher._lock_manager.heartbeat = heartbeat
+
+    dispatcher.dispatch_once()
+
+    updated_run = run_repository.get_run(run.run_id)
+    assert updated_run.status == WorkflowRunStatus.FAILED
+    assert (updated_run.last_error_message or "").startswith("lease_lost:")
 
 
 def test_invoke_does_not_pass_workflow_run_to_non_workflow_run_params():

--- a/egograph/pipelines/tests/unit/test_dispatcher.py
+++ b/egograph/pipelines/tests/unit/test_dispatcher.py
@@ -1115,30 +1115,28 @@ def test_dispatch_once_does_not_mark_run_succeeded_after_last_step_lease_loss(
         trigger_type=TriggerType.MANUAL,
         queued_reason=QueuedReason.MANUAL_REQUEST,
     )
-    heartbeat_available = True
-
-    def execute_step(**_kwargs):
-        nonlocal heartbeat_available
-        heartbeat_available = False
-        return StepExecutionResult(
-            status=StepRunStatus.SUCCEEDED,
-            exit_code=0,
-            stdout_tail="",
-            stderr_tail="",
-            log_path="",
-            result_summary=None,
-        )
-
-    dispatcher._inprocess_executor.execute = execute_step
-    dispatcher._lock_manager.heartbeat = Mock(
-        side_effect=lambda _lease: heartbeat_available
+    lease = dispatcher._lock_manager.acquire(
+        lock_key="lease_workflow", run_id=run.run_id
     )
+    lease_state = _LeaseState()
+    heartbeat_calls = 0
 
-    dispatcher.dispatch_once()
+    def heartbeat(_lease):
+        nonlocal heartbeat_calls
+        heartbeat_calls += 1
+        return heartbeat_calls < 3
 
+    dispatcher._lock_manager.heartbeat = heartbeat
+
+    # Act
+    dispatcher._execute_run(workflows["lease_workflow"], run, lease_state, lease)
+    dispatcher._lock_manager.release(lease)
+
+    # Assert
     updated_run = run_repository.get_run(run.run_id)
     assert updated_run.status == WorkflowRunStatus.FAILED
     assert "lease_lost:" in (updated_run.last_error_message or "")
+    assert heartbeat_calls == 3
 
 
 def test_lease_loss_exception_skips_only_unexecuted_steps_and_preserves_error(
@@ -1160,6 +1158,12 @@ def test_lease_loss_exception_skips_only_unexecuted_steps_and_preserves_error(
                 StepDefinition(
                     step_id="second",
                     step_name="Second",
+                    executor_type=StepExecutorType.INPROCESS,
+                    callable_ref="pipelines.tests.support.dummy_steps:succeed",
+                ),
+                StepDefinition(
+                    step_id="third",
+                    step_name="Third",
                     executor_type=StepExecutorType.INPROCESS,
                     callable_ref="pipelines.tests.support.dummy_steps:succeed",
                 ),
@@ -1199,7 +1203,7 @@ def test_lease_loss_exception_skips_only_unexecuted_steps_and_preserves_error(
     assert "RuntimeError: step persistence failed" in (
         updated_run.last_error_message or ""
     )
-    assert [step.sequence_no for step in steps] == [2]
+    assert [step.sequence_no for step in steps] == [3]
     assert [step.status for step in steps] == [StepRunStatus.SKIPPED]
 
 

--- a/egograph/pipelines/tests/unit/test_lock_manager.py
+++ b/egograph/pipelines/tests/unit/test_lock_manager.py
@@ -2,7 +2,10 @@ from datetime import UTC, datetime, timedelta
 
 from pipelines.infrastructure.db.connection import connect
 from pipelines.infrastructure.db.schema import initialize_schema
-from pipelines.infrastructure.dispatching.lock_manager import WorkflowLockManager
+from pipelines.infrastructure.dispatching.lock_manager import (
+    WorkflowLease,
+    WorkflowLockManager,
+)
 
 
 def test_acquire_blocks_active_lock_and_releases(tmp_path):
@@ -62,3 +65,55 @@ def test_cleanup_stale_locks_removes_expired_lease(tmp_path):
     assert deleted == 1
     lease = lock_manager.acquire(lock_key="dummy_workflow", run_id="run-2")
     assert lease.run_id == "run-2"
+
+
+def test_heartbeat_returns_true_for_current_lease(tmp_path):
+    """現在のrunとownerが保持するleaseだけheartbeatに成功する。"""
+    conn = connect(tmp_path / "state.sqlite3")
+    initialize_schema(conn)
+    lock_manager = WorkflowLockManager(conn, lease_seconds=60)
+    lease = lock_manager.acquire(lock_key="dummy_workflow", run_id="run-1")
+
+    assert lock_manager.heartbeat(lease) is True
+
+
+def test_heartbeat_returns_false_when_lock_is_missing(tmp_path):
+    """対象lockが削除済みならheartbeatに失敗する。"""
+    conn = connect(tmp_path / "state.sqlite3")
+    initialize_schema(conn)
+    lock_manager = WorkflowLockManager(conn, lease_seconds=60)
+    lease = lock_manager.acquire(lock_key="dummy_workflow", run_id="run-1")
+    conn.execute("DELETE FROM workflow_locks WHERE lock_key = ?", (lease.lock_key,))
+    conn.commit()
+
+    assert lock_manager.heartbeat(lease) is False
+
+
+def test_heartbeat_returns_false_for_different_run_id(tmp_path):
+    """run_idが異なるheartbeatは失敗する。"""
+    conn = connect(tmp_path / "state.sqlite3")
+    initialize_schema(conn)
+    lock_manager = WorkflowLockManager(conn, lease_seconds=60)
+    lease = lock_manager.acquire(lock_key="dummy_workflow", run_id="run-1")
+    wrong_run_lease = WorkflowLease(
+        lock_key=lease.lock_key,
+        run_id="run-2",
+        lease_owner=lease.lease_owner,
+    )
+
+    assert lock_manager.heartbeat(wrong_run_lease) is False
+
+
+def test_heartbeat_returns_false_for_different_lease_owner(tmp_path):
+    """lease_ownerが異なるheartbeatは失敗する。"""
+    conn = connect(tmp_path / "state.sqlite3")
+    initialize_schema(conn)
+    lock_manager = WorkflowLockManager(conn, lease_seconds=60)
+    lease = lock_manager.acquire(lock_key="dummy_workflow", run_id="run-1")
+    wrong_owner_lease = WorkflowLease(
+        lock_key=lease.lock_key,
+        run_id=lease.run_id,
+        lease_owner="other-owner",
+    )
+
+    assert lock_manager.heartbeat(wrong_owner_lease) is False

--- a/egograph/pipelines/tests/unit/test_lock_manager.py
+++ b/egograph/pipelines/tests/unit/test_lock_manager.py
@@ -74,7 +74,11 @@ def test_heartbeat_returns_true_for_current_lease(tmp_path):
     lock_manager = WorkflowLockManager(conn, lease_seconds=60)
     lease = lock_manager.acquire(lock_key="dummy_workflow", run_id="run-1")
 
-    assert lock_manager.heartbeat(lease) is True
+    # Act
+    heartbeat_succeeded = lock_manager.heartbeat(lease)
+
+    # Assert
+    assert heartbeat_succeeded is True
 
 
 def test_heartbeat_returns_false_when_lock_is_missing(tmp_path):
@@ -86,7 +90,11 @@ def test_heartbeat_returns_false_when_lock_is_missing(tmp_path):
     conn.execute("DELETE FROM workflow_locks WHERE lock_key = ?", (lease.lock_key,))
     conn.commit()
 
-    assert lock_manager.heartbeat(lease) is False
+    # Act
+    heartbeat_succeeded = lock_manager.heartbeat(lease)
+
+    # Assert
+    assert heartbeat_succeeded is False
 
 
 def test_heartbeat_returns_false_for_different_run_id(tmp_path):
@@ -101,7 +109,11 @@ def test_heartbeat_returns_false_for_different_run_id(tmp_path):
         lease_owner=lease.lease_owner,
     )
 
-    assert lock_manager.heartbeat(wrong_run_lease) is False
+    # Act
+    heartbeat_succeeded = lock_manager.heartbeat(wrong_run_lease)
+
+    # Assert
+    assert heartbeat_succeeded is False
 
 
 def test_heartbeat_returns_false_for_different_lease_owner(tmp_path):
@@ -116,4 +128,8 @@ def test_heartbeat_returns_false_for_different_lease_owner(tmp_path):
         lease_owner="other-owner",
     )
 
-    assert lock_manager.heartbeat(wrong_owner_lease) is False
+    # Act
+    heartbeat_succeeded = lock_manager.heartbeat(wrong_owner_lease)
+
+    # Assert
+    assert heartbeat_succeeded is False


### PR DESCRIPTION
## 概要

Pipelines の workflow lease を失った worker が、後続 step の実行や成功状態の保存を継続しないようにする。

## 変更内容

- `WorkflowLockManager.heartbeat()` が対象 lease の更新行数1件のときだけ `True` を返す
- heartbeat のDB例外と `False` を thread-safe な lease 喪失状態として記録
- 各 step 開始前、step 完了後、最終状態保存前に lease を再確認
- lease 喪失時は run を既存の `FAILED` に更新し、`lease_lost:` を含む理由を保存
- 未開始の後続 step は `SKIPPED` とし、最後の step 完了後の lease 喪失も `SUCCEEDED` にしない
- 例外経路でも未実行 step の sequence と元の例外理由を保持し、lease-loss処理を重複実行しない
- release は lease 喪失後も best-effort で実行
- Pipelines の architecture / deploy / README を実際の動作に合わせて更新

## 検証

- `USE_ENV_FILE=false uv run pytest egograph/pipelines/tests --cov=pipelines --cov-report=term-missing`
  - 516 passed, 2 skipped（外部Spotify liveテスト）
- `uv run pytest egograph/pipelines/tests/unit/test_lock_manager.py egograph/pipelines/tests/unit/test_dispatcher.py -q`
  - 36 passed
- 対象ファイルの `ruff check` / `ruff format --check`
  - pass

Backend の production 設定・readiness 対応は別PRで提出済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ワークフロー実行中のリース喪失を検知し、実行を安全に停止するようになりました。
  * リース喪失時は実行を失敗として記録し、未開始の後続ステップは実行されません。
  * heartbeat の障害や所有権変更も明確なエラー理由として表示されます。
  * リース喪失で失敗した実行は、通常の再試行操作で再実行できます。

* **ドキュメント**
  * 実行状態の確認方法とリース喪失時の対応手順を追加しました。
  * ヘルスチェックエンドポイントを `/v1/health` に変更し、認証なしで利用できるよう案内を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->