### PR TITLE
feat: add dataset compaction API and repair legacy timestamps

### DIFF
--- a/.claude/skills/pipelines-debug/SKILL.md
+++ b/.claude/skills/pipelines-debug/SKILL.md
@@ -67,6 +67,25 @@ curl -s -X POST -H "X-API-Key: ${PIPELINES_API_KEY}" \
   "${API_BASE}/v1/runs/${RUN_ID}/retry" | jq .
 ```
 
+### 7. 指定 dataset の再コンパクト
+
+まず dataset catalog で正式な `dataset_id` を確認し、対象 partition を明示して
+manual compaction run を作成する。`workflow_id` は指定しない。
+
+```bash
+curl -s -H "X-API-Key: ${PIPELINES_API_KEY}" \
+  "${API_BASE}/v1/datasets" | jq .
+
+curl -s -X POST \
+  -H "X-API-Key: ${PIPELINES_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"targets":[{"dataset_id":"github.commits","year":2026,"month":7},{"dataset_id":"github.pull_requests","year":2026,"month":7}]}' \
+  "${API_BASE}/v1/compaction/runs" | jq .
+```
+
+レスポンスの `run_id` を使い、通常の run 詳細・step log・retry APIで実行を追跡する。
+対象は月次 `APPEND_DEDUPE` datasetで、1つのrunには同じproviderのdatasetだけを指定する。
+
 ## API エンドポイント一覧
 
 全エンドポイント（`/v1/health` 除く）に `X-API-Key` ヘッダーが必要。
@@ -74,6 +93,8 @@ curl -s -X POST -H "X-API-Key: ${PIPELINES_API_KEY}" \
 | Method | Path | 説明 |
 |--------|------|------|
 | `GET` | `/v1/health` | ヘルスチェック |
+| `GET` | `/v1/datasets` | dataset catalog 一覧 |
+| `POST` | `/v1/compaction/runs` | 指定dataset partitionのmanual compact run作成 |
 | `GET` | `/v1/workflows` | ワークフロー一覧 |
 | `GET` | `/v1/workflows/{workflow_id}` | ワークフロー詳細 |
 | `GET` | `/v1/workflows/{workflow_id}/runs` | ワークフローの run 一覧 |

--- a/.claude/skills/pipelines-debug/SKILL.md
+++ b/.claude/skills/pipelines-debug/SKILL.md
@@ -88,7 +88,9 @@ curl -s -X POST \
 
 ## API エンドポイント一覧
 
-全エンドポイント（`/v1/health` 除く）に `X-API-Key` ヘッダーが必要。
+`PIPELINES_API_KEY` が設定されている環境では、`/v1/health` を除く全エンドポイントに
+`X-API-Key` ヘッダーが必要。`PIPELINES_API_KEY` を設定しないローカル開発環境では、
+認証なしでアクセスできる。
 
 | Method | Path | 説明 |
 |--------|------|------|

--- a/.claude/skills/pipelines-debug/SKILL.md
+++ b/.claude/skills/pipelines-debug/SKILL.md
@@ -88,9 +88,9 @@ curl -s -X POST \
 
 ## API エンドポイント一覧
 
-`PIPELINES_API_KEY` が設定されている環境では、`/v1/health` を除く全エンドポイントに
-`X-API-Key` ヘッダーが必要。`PIPELINES_API_KEY` を設定しないローカル開発環境では、
-認証なしでアクセスできる。
+`/v1/health` を除く全エンドポイントでは、`PIPELINES_API_KEY` の設定が必須で、
+設定済みのキーを `X-API-Key` ヘッダーで送る必要がある。未設定時は認証なしにはならず、
+設定不備として `500 PIPELINES_API_KEY is not configured` を返す。
 
 | Method | Path | 説明 |
 |--------|------|------|

--- a/docs/architecture/dataset-catalog.md
+++ b/docs/architecture/dataset-catalog.md
@@ -1,6 +1,6 @@
 # Dataset Catalog
 
-> 最終更新: 2026-08-01
+> 最終更新: 2026-08-04
 
 Dataset Catalog は、Pipelines が書き込む Parquet dataset と Backend が読み取る Parquet dataset の共有契約である。
 
@@ -75,6 +75,11 @@ Python workspace では `backend` と `pipelines` の両方から `dataset_catal
 
 各 source storage は「必須カラム確認 → Parquet バイト列生成 → バイト列から型検証 → アップロード」の順で保存する。アップロード後の読み直しは行わない。compaction 出力（`compacted/` 配下）も同様に、アップロード前に `validate_required_columns` + `validate_parquet_bytes` を適用する。
 
+compaction は source Parquet の読み込み時に、catalog で `timestamp` と定義された
+カラムを UTC aware datetime へ正規化する。過去世代で日時が文字列として保存されて
+いても、compacted Parquet は canonical schema で生成される。不正な日時は保存前に
+エラーとして扱う。
+
 - 空データ（保存対象なし）は検証をスキップし、既存の `None` / `failed=0` 契約を維持する
 - 検証失敗は `ValueError`（`invalid_schema: ...`）として各 storage の既存の保存失敗契約へ変換する
   - spotify / browser_history / youtube: 保存関数が `None` を返し、pipeline 側で run 失敗扱い
@@ -105,6 +110,7 @@ Python workspace では `backend` と `pipelines` の両方から `dataset_catal
 
 - `pipelines.sources.common.compaction`
   - `DatasetDefinition` から compacted key を組み立てる
+  - source Parquet の timestamp カラムを catalog 契約へ正規化する
 - `pipelines.sources.*.pipeline`
   - provider ごとの monthly compaction 対象を `monthly_compaction_datasets()` から取得する
 - `pipelines.sources.google_health.writer`

--- a/docs/architecture/pipelines.md
+++ b/docs/architecture/pipelines.md
@@ -567,9 +567,9 @@ Pipelines Service は Browser Extension からのデータ受信も受け持つ�
 
 Pipelines API は API Key による認証を行う。
 
-- **環境変数**: `PIPELINES_API_KEY` が設定されている場合、リクエストの `X-API-Key` ヘッダーを検証
+- **環境変数**: `PIPELINES_API_KEY` の設定が必須。設定済みのキーを `X-API-Key` ヘッダーで検証
 - **対象**: 全エンドポイント（`/v1/health` を除く）
-- **未設定時**: 認証なしでアクセス可能（ローカル開発用）
+- **未設定時**: 認証なしにはならず、`500 PIPELINES_API_KEY is not configured` を返す
 
 ---
 

--- a/docs/architecture/pipelines.md
+++ b/docs/architecture/pipelines.md
@@ -349,11 +349,15 @@ Google Health repairはこのrun入力で取得日数をworkflowへ渡す。
 | Workflow | Schedule | Steps |
 |---|---|---|
 | `spotify_ingest_workflow` | 6回/日 (0,4,8,12,16,22 JST) | ingest → compact |
+| `spotify_compact_workflow` | 手動API | 指定dataset・月のcompact |
 | `github_ingest_workflow` | 1回/日 (00:00 JST) | ingest → compact |
+| `github_compact_workflow` | 手動API | 指定dataset・月のcompact |
 | `google_activity_ingest_workflow` | 1回/日 (23:00 JST) | ingest |
+| `youtube_compact_workflow` | 手動API | 指定dataset・月のcompact |
 | `google_health_ingest_workflow` | 3時間ごと / 毎日04:30 / 毎週日曜05:30（`TIMEZONE`基準）+ API手動実行 | repair / Raw JSON・events保存 → compacted範囲置換 |
 | `local_mirror_sync_workflow` | 6時間ごと | sync |
 | `browser_history_compact_workflow` | イベント駆動 | compact |
+| `browser_history_compact_workflow_manual` | 手動API | 指定dataset・月のcompact |
 | `browser_history_compact_maintenance_workflow` | 6時間ごと | compact maintenance |
 
 ---
@@ -508,6 +512,8 @@ uv run python -m pipelines.main serve
 | Method | Path | 説明 |
 |---|---|---|
 | GET | `/v1/health` | ヘルスチェック |
+| GET | `/v1/datasets` | dataset catalog 一覧 |
+| POST | `/v1/compaction/runs` | 指定dataset partitionのmanual compact run作成 |
 | GET | `/v1/workflows` | ワークフロー一覧 |
 | GET | `/v1/workflows/{id}` | ワークフロー詳細 |
 | POST | `/v1/workflows/{id}/runs` | 手動実行 |
@@ -524,6 +530,25 @@ uv run python -m pipelines.main serve
 | DELETE | `/v1/sources/google-health/connection` | Google Health 接続削除 |
 | POST | `/v1/sources/google-health/connection/smoke-test` | Google Health 疎通確認 |
 | POST | `/v1/sources/google-health/runs` | Google Health backfill・期間指定run作成 |
+
+### Manual Compaction API
+
+`workflow_id` は ingest と compact を含む処理単位であり、compact対象の指定には
+dataset catalog の canonical な `dataset_id` を使用する。`/v1/compaction/runs` は
+対象を明示した非同期runをqueueへ積み、実行状態・ログ・retryは通常の `/v1/runs`
+APIで扱う。dataset一覧の取得に `compaction_supported` クエリパラメータは使用しない。
+
+```json
+{
+  "targets": [
+    {"dataset_id": "github.commits", "year": 2026, "month": 7},
+    {"dataset_id": "github.pull_requests", "year": 2026, "month": 7}
+  ]
+}
+```
+
+対象は月次 `APPEND_DEDUPE` datasetに限り、同一run内では同じproviderのdatasetだけを
+指定する。Google Healthのような別compaction strategyはこのAPIの対象外である。
 
 ---
 

--- a/egograph/pipelines/README.md
+++ b/egograph/pipelines/README.md
@@ -122,6 +122,8 @@ Pipelines Service はポート `8001`（デフォルト）で HTTP API を提供
 | Method | Path | 説明 |
 |--------|------|------|
 | `GET` | `/v1/health` | ヘルスチェック |
+| `GET` | `/v1/datasets` | dataset catalog 一覧 |
+| `POST` | `/v1/compaction/runs` | 指定dataset partitionのmanual compact run作成 |
 | `GET` | `/v1/workflows` | ワークフロー一覧 |
 | `GET` | `/v1/workflows/{workflow_id}` | ワークフロー詳細 |
 | `GET` | `/v1/workflows/{workflow_id}/runs` | 指定ワークフローの run 一覧 |
@@ -152,6 +154,13 @@ curl -H "X-API-Key: $PIPELINES_API_KEY" http://localhost:8001/v1/workflows
 curl -X POST -H "X-API-Key: $PIPELINES_API_KEY" \
   http://localhost:8001/v1/workflows/spotify_ingest_workflow/runs
 
+# GitHubの指定月を再コンパクト（run_idを受け取り、通常のrun APIで追跡）
+curl -X POST \
+  -H "X-API-Key: $PIPELINES_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"targets":[{"dataset_id":"github.commits","year":2026,"month":7},{"dataset_id":"github.pull_requests","year":2026,"month":7}]}' \
+  http://localhost:8001/v1/compaction/runs
+
 # run 詳細取得
 curl -H "X-API-Key: $PIPELINES_API_KEY" \
   http://localhost:8001/v1/runs/<run_id>
@@ -161,7 +170,7 @@ curl -H "X-API-Key: $PIPELINES_API_KEY" \
 
 ```text
 egograph/pipelines/
-├── api/                # FastAPI ルート定義（health, workflows, runs, ingest）
+├── api/                # FastAPI ルート定義（health, datasets, compaction, workflows, runs, ingest）
 ├── domain/             # ドメインモデル（workflow, schedule, errors）
 ├── infrastructure/     # インフラストラクチャ層
 │   ├── db/             # SQLite 接続・マイグレーション

--- a/egograph/pipelines/api/compaction.py
+++ b/egograph/pipelines/api/compaction.py
@@ -1,0 +1,83 @@
+"""Dataset catalog と manual compaction run のAPI。"""
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel, Field, ValidationError
+
+from pipelines.api.dependencies import get_service, verify_api_key
+from pipelines.compaction import DatasetCompactionTarget
+from pipelines.domain.errors import PipelinesError
+from pipelines.service import PipelineService
+
+router = APIRouter(prefix="/v1", tags=["datasets", "compaction"])
+
+
+class CompactionTargetRequest(BaseModel):
+    """月次 compaction の対象指定。"""
+
+    dataset_id: str = Field(min_length=1)
+    year: int = Field(ge=1, le=9999)
+    month: int = Field(ge=1, le=12)
+
+    def to_target(self) -> DatasetCompactionTarget:
+        """domain の compaction target へ変換する。"""
+        return DatasetCompactionTarget(
+            dataset_id=self.dataset_id,
+            year=self.year,
+            month=self.month,
+        )
+
+
+class CompactionRunRequest(BaseModel):
+    """manual compaction run 作成リクエスト。"""
+
+    targets: list[CompactionTargetRequest] = Field(min_length=1)
+
+    def to_targets(self) -> tuple[DatasetCompactionTarget, ...]:
+        """domain の compaction target 列へ変換する。"""
+        return tuple(target.to_target() for target in self.targets)
+
+
+def _format_invalid_detail(exc: Exception) -> str:
+    if isinstance(exc, ValidationError):
+        details = []
+        for error in exc.errors():
+            field = ".".join(str(part) for part in error["loc"]) or "request"
+            details.append(f"invalid_{field}: {error['msg']}")
+        return "; ".join(details)
+
+    message = str(exc).strip()
+    if message.startswith("invalid_") and ":" in message:
+        return message
+    return f"invalid_request: {message or exc.__class__.__name__}"
+
+
+@router.get("/datasets")
+def list_datasets(
+    _: None = Depends(verify_api_key),
+    service: PipelineService = Depends(get_service),
+) -> list[dict]:
+    """dataset catalog の一覧を取得する。"""
+    return service.list_datasets()
+
+
+@router.post("/compaction/runs", status_code=201)
+def create_compaction_run(
+    request_body: dict = Body(...),
+    _: None = Depends(verify_api_key),
+    service: PipelineService = Depends(get_service),
+) -> dict:
+    """指定 dataset partition の manual compaction run をqueueへ積む。"""
+    try:
+        request = CompactionRunRequest.model_validate(request_body)
+        run = service.trigger_compaction(request.to_targets())
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=_format_invalid_detail(exc),
+        ) from exc
+    except (PipelinesError, ValueError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=_format_invalid_detail(exc),
+        ) from exc
+    return run.__dict__

--- a/egograph/pipelines/api/compaction.py
+++ b/egograph/pipelines/api/compaction.py
@@ -1,5 +1,7 @@
 """Dataset catalog と manual compaction run のAPI。"""
 
+from typing import Any
+
 from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import BaseModel, Field, ValidationError
 
@@ -15,8 +17,8 @@ class CompactionTargetRequest(BaseModel):
     """月次 compaction の対象指定。"""
 
     dataset_id: str = Field(min_length=1)
-    year: int = Field(ge=1, le=9999)
-    month: int = Field(ge=1, le=12)
+    year: int = Field(strict=True, ge=1, le=9999)
+    month: int = Field(strict=True, ge=1, le=12)
 
     def to_target(self) -> DatasetCompactionTarget:
         """domain の compaction target へ変換する。"""
@@ -62,7 +64,7 @@ def list_datasets(
 
 @router.post("/compaction/runs", status_code=201)
 def create_compaction_run(
-    request_body: dict = Body(...),
+    request_body: Any = Body(...),
     _: None = Depends(verify_api_key),
     service: PipelineService = Depends(get_service),
 ) -> dict:

--- a/egograph/pipelines/app.py
+++ b/egograph/pipelines/app.py
@@ -4,7 +4,14 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from pipelines.api import browser_history, google_health, health, runs, workflows
+from pipelines.api import (
+    browser_history,
+    compaction,
+    google_health,
+    health,
+    runs,
+    workflows,
+)
 from pipelines.config import PipelinesConfig
 from pipelines.infrastructure.logging_filters import install_access_log_filters
 from pipelines.service import PipelineService
@@ -33,6 +40,7 @@ def create_app(config: PipelinesConfig | None = None) -> FastAPI:
     app.include_router(health.router)
     app.include_router(workflows.router)
     app.include_router(runs.router)
+    app.include_router(compaction.router)
     app.include_router(browser_history.router)
     app.include_router(google_health.router)
     return app

--- a/egograph/pipelines/compaction.py
+++ b/egograph/pipelines/compaction.py
@@ -37,8 +37,12 @@ class DatasetCompactionTarget:
     def __post_init__(self) -> None:
         if not self.dataset_id.strip():
             raise ValueError("invalid_dataset_id: dataset_id is required")
+        if type(self.year) is not int:
+            raise ValueError("invalid_year: year must be an integer")
         if not 1 <= self.year <= 9999:
             raise ValueError("invalid_year: year must be 1..9999")
+        if type(self.month) is not int:
+            raise ValueError("invalid_month: month must be an integer")
         if not 1 <= self.month <= 12:
             raise ValueError("invalid_month: month must be 1..12")
 

--- a/egograph/pipelines/compaction.py
+++ b/egograph/pipelines/compaction.py
@@ -1,0 +1,250 @@
+"""外部から指定された dataset compaction の入力と dispatch を扱う。"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from dataset_catalog import (
+    ALL_DATASETS,
+    CompactionStrategy,
+    DatasetDefinition,
+    PartitionPolicy,
+    get_dataset,
+    monthly_compaction_datasets,
+)
+
+from pipelines.domain.workflow import WorkflowRun
+from pipelines.sources.common.compaction import resolve_target_months
+
+MANUAL_COMPACTION_WORKFLOW_BY_PROVIDER = {
+    "spotify": "spotify_compact_workflow",
+    "github": "github_compact_workflow",
+    "browser_history": "browser_history_compact_workflow_manual",
+    "youtube": "youtube_compact_workflow",
+}
+
+
+@dataclass(frozen=True)
+class DatasetCompactionTarget:
+    """月次 compaction の対象 dataset と partition。"""
+
+    dataset_id: str
+    year: int
+    month: int
+
+    def __post_init__(self) -> None:
+        if not self.dataset_id.strip():
+            raise ValueError("invalid_dataset_id: dataset_id is required")
+        if not 1 <= self.year <= 9999:
+            raise ValueError("invalid_year: year must be 1..9999")
+        if not 1 <= self.month <= 12:
+            raise ValueError("invalid_month: month must be 1..12")
+
+    def to_dict(self) -> dict[str, object]:
+        """run の result_summary に保存できる辞書へ変換する。"""
+        return {
+            "dataset_id": self.dataset_id,
+            "year": self.year,
+            "month": self.month,
+        }
+
+
+def validate_compaction_targets(
+    targets: Iterable[DatasetCompactionTarget],
+) -> tuple[DatasetCompactionTarget, ...]:
+    """manual compaction の対象をcatalog契約に基づいて検証する。
+
+    現在の manual compaction API は、月次 ``APPEND_DEDUPE`` datasetを対象とする。
+    同一run内の対象providerを一つに制限することで、既存workflowのprovider単位
+    lockと定期ingestとの排他を維持する。
+    """
+    normalized = tuple(dict.fromkeys(targets))
+    if not normalized:
+        raise ValueError("invalid_targets: at least one target is required")
+
+    providers: set[str] = set()
+    for target in normalized:
+        try:
+            dataset = get_dataset(target.dataset_id)
+        except KeyError as exc:
+            raise ValueError(
+                f"invalid_dataset_id: unknown dataset: {target.dataset_id}"
+            ) from exc
+
+        if dataset.partition_policy is not PartitionPolicy.MONTHLY:
+            raise ValueError(
+                "invalid_dataset_id: dataset does not use monthly partitions: "
+                f"{target.dataset_id}"
+            )
+        if dataset.compaction_strategy is not CompactionStrategy.APPEND_DEDUPE:
+            raise ValueError(
+                "invalid_dataset_id: dataset compaction strategy is not supported: "
+                f"{target.dataset_id}"
+            )
+        if dataset.provider not in MANUAL_COMPACTION_WORKFLOW_BY_PROVIDER:
+            raise ValueError(
+                "invalid_dataset_id: provider does not support manual compaction: "
+                f"{dataset.provider}"
+            )
+        providers.add(dataset.provider)
+
+    if len(providers) != 1:
+        raise ValueError(
+            "invalid_targets: all targets must belong to the same provider"
+        )
+    return normalized
+
+
+def compaction_workflow_id(
+    targets: Iterable[DatasetCompactionTarget],
+) -> str:
+    """対象providerに対応するmanual compaction workflow IDを返す。"""
+    validated = validate_compaction_targets(targets)
+    dataset = get_dataset(validated[0].dataset_id)
+    return MANUAL_COMPACTION_WORKFLOW_BY_PROVIDER[dataset.provider]
+
+
+def compaction_targets_from_run(
+    run: WorkflowRun,
+) -> tuple[DatasetCompactionTarget, ...]:
+    """run の result_summary から compaction target を復元する。"""
+    summary = run.result_summary or {}
+    raw_targets = summary.get("compaction_targets")
+    if not isinstance(raw_targets, list):
+        raise ValueError("invalid_targets: compaction targets are required")
+
+    targets: list[DatasetCompactionTarget] = []
+    for index, raw_target in enumerate(raw_targets):
+        if not isinstance(raw_target, Mapping):
+            raise ValueError(f"invalid_targets: target at index {index} is invalid")
+        dataset_id = raw_target.get("dataset_id")
+        year = raw_target.get("year")
+        month = raw_target.get("month")
+        if not isinstance(dataset_id, str):
+            raise ValueError(
+                f"invalid_targets: target at index {index} has invalid dataset_id"
+            )
+        if isinstance(year, bool) or not isinstance(year, int):
+            raise ValueError(
+                f"invalid_targets: target at index {index} has invalid year"
+            )
+        if isinstance(month, bool) or not isinstance(month, int):
+            raise ValueError(
+                f"invalid_targets: target at index {index} has invalid month"
+            )
+        targets.append(
+            DatasetCompactionTarget(
+                dataset_id=dataset_id,
+                year=year,
+                month=month,
+            )
+        )
+    return validate_compaction_targets(targets)
+
+
+def select_compaction_datasets(
+    provider: str,
+    dataset_ids: Iterable[str] | None = None,
+) -> tuple[DatasetDefinition, ...]:
+    """provider の月次compaction対象をcatalogから選択する。"""
+    try:
+        available = monthly_compaction_datasets(provider)
+    except KeyError as exc:
+        raise ValueError(f"invalid_provider: unsupported provider: {provider}") from exc
+
+    if dataset_ids is None:
+        return available
+
+    requested_ids = tuple(dict.fromkeys(dataset_ids))
+    available_by_id = {dataset.dataset_id: dataset for dataset in available}
+    unknown_ids = [
+        dataset_id for dataset_id in requested_ids if dataset_id not in available_by_id
+    ]
+    if unknown_ids:
+        raise ValueError(
+            "invalid_dataset_id: dataset is not a monthly compaction target: "
+            f"{', '.join(sorted(unknown_ids))}"
+        )
+    return tuple(available_by_id[dataset_id] for dataset_id in requested_ids)
+
+
+def resolve_provider_compaction_targets(
+    provider: str,
+    *,
+    year: int | None = None,
+    month: int | None = None,
+    dataset_ids: Iterable[str] | None = None,
+) -> tuple[DatasetCompactionTarget, ...]:
+    """既存scheduled compact用のprovider対象を解決する。"""
+    datasets = select_compaction_datasets(provider, dataset_ids)
+    months = resolve_target_months(year, month)
+    return tuple(
+        DatasetCompactionTarget(
+            dataset_id=dataset.dataset_id,
+            year=target_year,
+            month=target_month,
+        )
+        for target_year, target_month in months
+        for dataset in datasets
+    )
+
+
+def resolve_run_compaction_targets(
+    provider: str,
+    *,
+    targets: Iterable[DatasetCompactionTarget] | None = None,
+    year: int | None = None,
+    month: int | None = None,
+    dataset_ids: Iterable[str] | None = None,
+) -> tuple[DatasetCompactionTarget, ...]:
+    """workflow入力またはscheduled compact用の対象を解決する。"""
+    if targets is not None:
+        if year is not None or month is not None or dataset_ids is not None:
+            raise ValueError(
+                "invalid_targets: targets cannot be combined with year, month, "
+                "or dataset_ids"
+            )
+        validated = validate_compaction_targets(targets)
+        invalid_provider_targets = [
+            target.dataset_id
+            for target in validated
+            if get_dataset(target.dataset_id).provider != provider
+        ]
+        if invalid_provider_targets:
+            raise ValueError(
+                "invalid_targets: target does not belong to provider: "
+                f"{', '.join(invalid_provider_targets)}"
+            )
+        return validated
+
+    return resolve_provider_compaction_targets(
+        provider,
+        year=year,
+        month=month,
+        dataset_ids=dataset_ids,
+    )
+
+
+def dataset_metadata(dataset: DatasetDefinition) -> dict[str, Any]:
+    """dataset catalogの公開用メタデータを返す。"""
+    return {
+        "dataset_id": dataset.dataset_id,
+        "path": dataset.path,
+        "provider": dataset.provider,
+        "domain": dataset.domain.value,
+        "partition_policy": dataset.partition_policy.value,
+        "compaction_strategy": dataset.compaction_strategy.value,
+        "compaction_supported": (
+            dataset.provider in MANUAL_COMPACTION_WORKFLOW_BY_PROVIDER
+            and dataset.partition_policy is PartitionPolicy.MONTHLY
+            and dataset.compaction_strategy is CompactionStrategy.APPEND_DEDUPE
+        ),
+        "schema_version": dataset.schema_version,
+    }
+
+
+def list_dataset_metadata() -> list[dict[str, Any]]:
+    """全datasetの公開用メタデータをcatalog順で返す。"""
+    return [dataset_metadata(dataset) for dataset in ALL_DATASETS]

--- a/egograph/pipelines/service.py
+++ b/egograph/pipelines/service.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import cast
 from zoneinfo import ZoneInfo
 
 from pydantic import SecretStr
 
+from pipelines.compaction import (
+    DatasetCompactionTarget,
+    compaction_workflow_id,
+    list_dataset_metadata,
+    validate_compaction_targets,
+)
 from pipelines.config import PipelinesConfig
 from pipelines.domain.errors import WorkflowNotFoundError
 from pipelines.domain.workflow import QueuedReason, TriggerType, WorkflowRun
@@ -168,6 +175,10 @@ class PipelineService:
         """run 一覧を返す。"""
         return self.run_repository.list_runs(workflow_id=workflow_id)
 
+    def list_datasets(self) -> list[dict]:
+        """dataset catalog の公開用メタデータを返す。"""
+        return list_dataset_metadata()
+
     def get_run_detail(self, run_id: str) -> dict:
         """run 詳細と step 一覧を返す。"""
         run = self.run_repository.get_run(run_id)
@@ -195,6 +206,27 @@ class PipelineService:
             trigger_type=TriggerType.MANUAL,
             queued_reason=QueuedReason.MANUAL_REQUEST,
             requested_by=requested_by,
+        )
+
+    def trigger_compaction(
+        self,
+        targets: Iterable[DatasetCompactionTarget],
+        *,
+        requested_by: str = "api",
+    ) -> WorkflowRun:
+        """指定された dataset partition の manual compaction run をqueueへ積む。"""
+        validated_targets = validate_compaction_targets(targets)
+        workflow_id = compaction_workflow_id(validated_targets)
+        return self.run_repository.enqueue_run(
+            workflow_id=workflow_id,
+            trigger_type=TriggerType.MANUAL,
+            queued_reason=QueuedReason.MANUAL_REQUEST,
+            requested_by=requested_by,
+            result_summary={
+                "compaction_targets": [
+                    target.to_dict() for target in validated_targets
+                ],
+            },
         )
 
     def trigger_google_health_ingest(

--- a/egograph/pipelines/sources/browser_history/pipeline.py
+++ b/egograph/pipelines/sources/browser_history/pipeline.py
@@ -6,6 +6,9 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from dataset_catalog import datasets
+
+from pipelines.compaction import compaction_targets_from_run
 from pipelines.domain.workflow import WorkflowRun
 from pipelines.sources.browser_history.compaction import compact_browser_history_targets
 from pipelines.sources.browser_history.ingest_pipeline import (
@@ -180,6 +183,20 @@ def run_browser_history_compact(
         "operation": "compact",
         "target_months": [f"{year}-{month:02d}" for year, month in target_tuple],
     }
+
+
+def run_browser_history_compact_from_run(run: WorkflowRun) -> dict[str, object]:
+    """manual compaction run の対象datasetとpartitionを復元して実行する。"""
+    targets = compaction_targets_from_run(run)
+    supported_dataset_id = datasets.BROWSER_HISTORY_PAGE_VIEWS.dataset_id
+    if any(target.dataset_id != supported_dataset_id for target in targets):
+        raise ValueError(
+            "invalid_dataset_id: browser history manual compaction supports only "
+            f"{supported_dataset_id}"
+        )
+    return run_browser_history_compact(
+        ((target.year, target.month) for target in targets)
+    )
 
 
 def run_browser_history_compact_maintenance(

--- a/egograph/pipelines/sources/browser_history/storage.py
+++ b/egograph/pipelines/sources/browser_history/storage.py
@@ -193,6 +193,7 @@ class BrowserHistoryStorage:
             self.s3,
             self.bucket_name,
             source_prefix,
+            dataset=dataset,
         )
         if not records:
             logger.info("No parquet records found for compaction: %s", source_prefix)
@@ -202,6 +203,7 @@ class BrowserHistoryStorage:
             records,
             dedupe_key=dataset.required_dedupe_key(),
             sort_by=dataset.sort_key,
+            dataset=dataset,
         )
         key = build_compacted_key(
             self.compacted_path,

--- a/egograph/pipelines/sources/common/compaction.py
+++ b/egograph/pipelines/sources/common/compaction.py
@@ -46,16 +46,12 @@ def normalize_dataframe_for_dataset(
 
     既存の source Parquet には日時が文字列で保存された世代があるため、
     ファイル間で型が混在していなくても catalog の timestamp カラムは必ず
-    UTC aware datetime へ変換する。タイムゾーンのない値はUTCと仮定せず、
-    ``errors='raise'`` と合わせて保存前に表面化させる。
+    UTC aware datetime へ変換する。不正な日時は ``errors='raise'`` で保存前に
+    表面化させる。
     """
     for column, canonical_type in dataset.column_types.items():
         if canonical_type != "timestamp" or column not in df.columns:
             continue
-        for value in df[column].dropna():
-            parsed = pd.to_datetime(value, errors="raise", format="mixed")
-            if parsed.tzinfo is None or parsed.utcoffset() is None:
-                raise ValueError(f"invalid_timestamp: {column} must include a timezone")
         df[column] = pd.to_datetime(
             df[column],
             errors="raise",

--- a/egograph/pipelines/sources/common/compaction.py
+++ b/egograph/pipelines/sources/common/compaction.py
@@ -38,6 +38,33 @@ def _unify_datetime_columns(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def normalize_dataframe_for_dataset(
+    df: pd.DataFrame,
+    dataset: DatasetDefinition,
+) -> pd.DataFrame:
+    """dataset catalog の timestamp 契約に合わせて DataFrame を正規化する。
+
+    既存の source Parquet には日時が文字列で保存された世代があるため、
+    ファイル間で型が混在していなくても catalog の timestamp カラムは必ず
+    UTC aware datetime へ変換する。タイムゾーンのない値はUTCと仮定せず、
+    ``errors='raise'`` と合わせて保存前に表面化させる。
+    """
+    for column, canonical_type in dataset.column_types.items():
+        if canonical_type != "timestamp" or column not in df.columns:
+            continue
+        for value in df[column].dropna():
+            parsed = pd.to_datetime(value, errors="raise", format="mixed")
+            if parsed.tzinfo is None or parsed.utcoffset() is None:
+                raise ValueError(f"invalid_timestamp: {column} must include a timezone")
+        df[column] = pd.to_datetime(
+            df[column],
+            errors="raise",
+            utc=True,
+            format="mixed",
+        )
+    return df
+
+
 def build_compacted_key(
     compacted_path: str,
     dataset: DatasetDefinition,
@@ -52,12 +79,15 @@ def compact_records(
     records: list[dict[str, Any]],
     dedupe_key: str,
     sort_by: str | None = None,
+    dataset: DatasetDefinition | None = None,
 ) -> pd.DataFrame:
     """レコードを重複排除して compact する。"""
     if not records:
         return pd.DataFrame()
 
     df = pd.DataFrame(records)
+    if dataset is not None:
+        df = normalize_dataframe_for_dataset(df, dataset)
     if dedupe_key not in df.columns:
         raise ValueError(f"Missing dedupe key column: {dedupe_key}")
 
@@ -105,6 +135,8 @@ def read_parquet_records_from_prefix(
     s3_client: Any,
     bucket_name: str,
     prefix: str,
+    *,
+    dataset: DatasetDefinition | None = None,
 ) -> list[dict[str, Any]]:
     """prefix 配下の parquet object をすべて読み込む。"""
     paginator = s3_client.get_paginator("list_objects_v2")
@@ -121,7 +153,10 @@ def read_parquet_records_from_prefix(
         return []
 
     combined = pd.concat(frames, ignore_index=True)
-    combined = _unify_datetime_columns(combined)
+    if dataset is None:
+        combined = _unify_datetime_columns(combined)
+    else:
+        combined = normalize_dataframe_for_dataset(combined, dataset)
     return combined.to_dict(orient="records")
 
 

--- a/egograph/pipelines/sources/github/pipeline.py
+++ b/egograph/pipelines/sources/github/pipeline.py
@@ -1,10 +1,16 @@
 """In-process GitHub pipeline entrypoints for workflow steps."""
 
 import logging
+from collections.abc import Iterable
 
 from dataset_catalog import monthly_compaction_datasets
 
-from pipelines.sources.common.compaction import resolve_target_months
+from pipelines.compaction import (
+    DatasetCompactionTarget,
+    compaction_targets_from_run,
+    resolve_run_compaction_targets,
+)
+from pipelines.domain.workflow import WorkflowRun
 from pipelines.sources.common.config import Config
 from pipelines.sources.common.settings import PipelinesSettings
 from pipelines.sources.github.ingest_pipeline import (
@@ -27,6 +33,7 @@ def run_github_compact(
     *,
     year: int | None = None,
     month: int | None = None,
+    targets: Iterable[DatasetCompactionTarget] | None = None,
 ) -> dict[str, object]:
     """GitHub monthly compaction を in-process で実行する。"""
     resolved_config = config or PipelinesSettings.load()
@@ -44,31 +51,39 @@ def run_github_compact(
         master_path=r2_conf.master_path,
     )
 
-    target_months = resolve_target_months(year, month)
+    compaction_targets = resolve_run_compaction_targets(
+        "github",
+        targets=targets,
+        year=year,
+        month=month,
+    )
+    datasets_by_id = {
+        dataset.dataset_id: dataset for dataset in monthly_compaction_datasets("github")
+    }
     compacted_keys: list[str] = []
     skipped_targets: list[str] = []
     failures: list[str] = []
-    for target_year, target_month in target_months:
-        for dataset in monthly_compaction_datasets("github"):
-            try:
-                key = storage.compact_month(
-                    dataset=dataset,
-                    year=target_year,
-                    month=target_month,
-                )
-            except Exception:
-                logger.exception(
-                    "GitHub compaction failed: dataset=%s year=%d month=%02d",
-                    dataset.path,
-                    target_year,
-                    target_month,
-                )
-                failures.append(f"{dataset.path}:{target_year}-{target_month:02d}")
-                continue
-            if key is None:
-                skipped_targets.append(f"{dataset.path}:{target_year}-{target_month:02d}")
-            else:
-                compacted_keys.append(key)
+    for target in compaction_targets:
+        dataset = datasets_by_id[target.dataset_id]
+        try:
+            key = storage.compact_month(
+                dataset=dataset,
+                year=target.year,
+                month=target.month,
+            )
+        except Exception:
+            logger.exception(
+                "GitHub compaction failed: dataset=%s year=%d month=%02d",
+                dataset.path,
+                target.year,
+                target.month,
+            )
+            failures.append(f"{dataset.path}:{target.year}-{target.month:02d}")
+            continue
+        if key is None:
+            skipped_targets.append(f"{dataset.path}:{target.year}-{target.month:02d}")
+        else:
+            compacted_keys.append(key)
 
     if failures:
         raise RuntimeError(f"GitHub compaction failed for: {', '.join(failures)}")
@@ -76,7 +91,14 @@ def run_github_compact(
     return {
         "provider": "github",
         "operation": "compact",
-        "target_months": [f"{y}-{m:02d}" for y, m in target_months],
+        "target_months": sorted(
+            {f"{target.year}-{target.month:02d}" for target in compaction_targets}
+        ),
         "compacted_keys": compacted_keys,
         "skipped_targets": skipped_targets,
     }
+
+
+def run_github_compact_from_run(run: WorkflowRun) -> dict[str, object]:
+    """manual compaction run の対象datasetとpartitionを復元して実行する。"""
+    return run_github_compact(targets=compaction_targets_from_run(run))

--- a/egograph/pipelines/sources/github/storage.py
+++ b/egograph/pipelines/sources/github/storage.py
@@ -526,7 +526,10 @@ class GitHubWorklogStorage:
             month=month,
         )
         records = read_parquet_records_from_prefix(
-            self.s3, self.bucket_name, source_prefix
+            self.s3,
+            self.bucket_name,
+            source_prefix,
+            dataset=dataset,
         )
         if not records:
             logger.info("No parquet records found for compaction: %s", source_prefix)
@@ -536,6 +539,7 @@ class GitHubWorklogStorage:
             records,
             dedupe_key=dataset.required_dedupe_key(),
             sort_by=dataset.sort_key,
+            dataset=dataset,
         )
         key = build_compacted_key(
             self.compacted_path,

--- a/egograph/pipelines/sources/spotify/pipeline.py
+++ b/egograph/pipelines/sources/spotify/pipeline.py
@@ -1,10 +1,16 @@
 """In-process Spotify pipeline entrypoints for workflow steps."""
 
 import logging
+from collections.abc import Iterable
 
 from dataset_catalog import monthly_compaction_datasets
 
-from pipelines.sources.common.compaction import resolve_target_months
+from pipelines.compaction import (
+    DatasetCompactionTarget,
+    compaction_targets_from_run,
+    resolve_run_compaction_targets,
+)
+from pipelines.domain.workflow import WorkflowRun
 from pipelines.sources.common.config import Config
 from pipelines.sources.common.settings import PipelinesSettings
 from pipelines.sources.spotify.ingest_pipeline import (
@@ -27,6 +33,7 @@ def run_spotify_compact(
     *,
     year: int | None = None,
     month: int | None = None,
+    targets: Iterable[DatasetCompactionTarget] | None = None,
 ) -> dict[str, object]:
     """Spotify monthly compaction を in-process で実行する。"""
     resolved_config = config or PipelinesSettings.load()
@@ -44,31 +51,40 @@ def run_spotify_compact(
         master_path=r2_conf.master_path,
     )
 
-    target_months = resolve_target_months(year, month)
+    compaction_targets = resolve_run_compaction_targets(
+        "spotify",
+        targets=targets,
+        year=year,
+        month=month,
+    )
+    datasets_by_id = {
+        dataset.dataset_id: dataset
+        for dataset in monthly_compaction_datasets("spotify")
+    }
     compacted_keys: list[str] = []
     skipped_targets: list[str] = []
     failures: list[str] = []
-    for target_year, target_month in target_months:
-        for dataset in monthly_compaction_datasets("spotify"):
-            try:
-                key = storage.compact_month(
-                    dataset=dataset,
-                    year=target_year,
-                    month=target_month,
-                )
-            except Exception:
-                logger.exception(
-                    "Spotify compaction failed: dataset=%s year=%d month=%02d",
-                    dataset.path,
-                    target_year,
-                    target_month,
-                )
-                failures.append(f"{dataset.path}:{target_year}-{target_month:02d}")
-                continue
-            if key is None:
-                skipped_targets.append(f"{dataset.path}:{target_year}-{target_month:02d}")
-            else:
-                compacted_keys.append(key)
+    for target in compaction_targets:
+        dataset = datasets_by_id[target.dataset_id]
+        try:
+            key = storage.compact_month(
+                dataset=dataset,
+                year=target.year,
+                month=target.month,
+            )
+        except Exception:
+            logger.exception(
+                "Spotify compaction failed: dataset=%s year=%d month=%02d",
+                dataset.path,
+                target.year,
+                target.month,
+            )
+            failures.append(f"{dataset.path}:{target.year}-{target.month:02d}")
+            continue
+        if key is None:
+            skipped_targets.append(f"{dataset.path}:{target.year}-{target.month:02d}")
+        else:
+            compacted_keys.append(key)
 
     if failures:
         raise RuntimeError(f"Spotify compaction failed for: {', '.join(failures)}")
@@ -76,7 +92,14 @@ def run_spotify_compact(
     return {
         "provider": "spotify",
         "operation": "compact",
-        "target_months": [f"{y}-{m:02d}" for y, m in target_months],
+        "target_months": sorted(
+            {f"{target.year}-{target.month:02d}" for target in compaction_targets}
+        ),
         "compacted_keys": compacted_keys,
         "skipped_targets": skipped_targets,
     }
+
+
+def run_spotify_compact_from_run(run: WorkflowRun) -> dict[str, object]:
+    """manual compaction run の対象datasetとpartitionを復元して実行する。"""
+    return run_spotify_compact(targets=compaction_targets_from_run(run))

--- a/egograph/pipelines/sources/spotify/storage.py
+++ b/egograph/pipelines/sources/spotify/storage.py
@@ -296,7 +296,10 @@ class SpotifyStorage:
             month=month,
         )
         records = read_parquet_records_from_prefix(
-            self.s3, self.bucket_name, source_prefix
+            self.s3,
+            self.bucket_name,
+            source_prefix,
+            dataset=dataset,
         )
         if not records:
             logger.info("No parquet records found for compaction: %s", source_prefix)
@@ -306,6 +309,7 @@ class SpotifyStorage:
             records,
             dedupe_key=dataset.required_dedupe_key(),
             sort_by=dataset.sort_key,
+            dataset=dataset,
         )
         key = build_compacted_key(
             self.compacted_path,

--- a/egograph/pipelines/sources/youtube/pipeline.py
+++ b/egograph/pipelines/sources/youtube/pipeline.py
@@ -3,9 +3,17 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from dataset_catalog import datasets
+
+from pipelines.compaction import (
+    DatasetCompactionTarget,
+    compaction_targets_from_run,
+    resolve_run_compaction_targets,
+)
 from pipelines.domain.workflow import WorkflowRun
 from pipelines.sources.common.compaction import resolve_target_months
 from pipelines.sources.common.config import Config
@@ -169,6 +177,7 @@ def run_youtube_compact(
     *,
     year: int | None = None,
     month: int | None = None,
+    targets: Iterable[DatasetCompactionTarget] | None = None,
 ) -> dict[str, object]:
     """YouTube monthly compaction を in-process で実行する。"""
     resolved_config = config or PipelinesSettings.load()
@@ -185,23 +194,36 @@ def run_youtube_compact(
         master_path=r2_conf.master_path,
     )
 
-    target_months = resolve_target_months(year, month)
+    if targets is None:
+        compaction_targets = tuple(
+            DatasetCompactionTarget(
+                dataset_id=datasets.YOUTUBE_WATCH_EVENTS.dataset_id,
+                year=target_year,
+                month=target_month,
+            )
+            for target_year, target_month in resolve_target_months(year, month)
+        )
+    else:
+        compaction_targets = resolve_run_compaction_targets(
+            "youtube",
+            targets=targets,
+        )
     compacted_keys: list[str] = []
     skipped_targets: list[str] = []
     failures: list[str] = []
-    for target_year, target_month in target_months:
+    for target in compaction_targets:
         try:
-            key = storage.compact_month(year=target_year, month=target_month)
+            key = storage.compact_month(year=target.year, month=target.month)
         except Exception:
             logger.exception(
                 "YouTube compaction failed: year=%d month=%02d",
-                target_year,
-                target_month,
+                target.year,
+                target.month,
             )
-            failures.append(f"youtube:{target_year}-{target_month:02d}")
+            failures.append(f"youtube:{target.year}-{target.month:02d}")
             continue
         if key is None:
-            skipped_targets.append(f"youtube:{target_year}-{target_month:02d}")
+            skipped_targets.append(f"youtube:{target.year}-{target.month:02d}")
         else:
             compacted_keys.append(key)
 
@@ -211,7 +233,14 @@ def run_youtube_compact(
     return {
         "provider": "youtube",
         "operation": "compact",
-        "target_months": [f"{y}-{m:02d}" for y, m in target_months],
+        "target_months": sorted(
+            {f"{target.year}-{target.month:02d}" for target in compaction_targets}
+        ),
         "compacted_keys": compacted_keys,
         "skipped_targets": skipped_targets,
     }
+
+
+def run_youtube_compact_from_run(run: WorkflowRun) -> dict[str, object]:
+    """manual compaction run の対象datasetとpartitionを復元して実行する。"""
+    return run_youtube_compact(targets=compaction_targets_from_run(run))

--- a/egograph/pipelines/sources/youtube/storage.py
+++ b/egograph/pipelines/sources/youtube/storage.py
@@ -72,7 +72,10 @@ class YouTubeStorage:
             month=month,
         )
         records = read_parquet_records_from_prefix(
-            self.s3, self.bucket_name, source_prefix
+            self.s3,
+            self.bucket_name,
+            source_prefix,
+            dataset=dataset,
         )
         if not records:
             logger.info("No parquet records found for compaction: %s", source_prefix)
@@ -82,6 +85,7 @@ class YouTubeStorage:
             records,
             dedupe_key=dataset.required_dedupe_key(),
             sort_by=dataset.sort_key,
+            dataset=dataset,
         )
         key = build_compacted_key(
             self.compacted_path,

--- a/egograph/pipelines/tests/unit/github/test_storage.py
+++ b/egograph/pipelines/tests/unit/github/test_storage.py
@@ -526,3 +526,50 @@ class TestGitHubWorklogStorage(unittest.TestCase):
             "compacted/events/github/commits/year=2024/month=01/data.parquet",
         )
         self.assertEqual(key, call_args["Key"])
+
+    def test_compact_month_normalizes_legacy_string_timestamp(self):
+        """既存sourceの文字列日時をtimestamp Parquetへ変換して保存する。"""
+        data = [_commit_row("commit_1", "abc123")]
+        data[0]["committed_at_utc"] = "2026-07-01T12:00:00Z"
+
+        with patch(
+            "pipelines.sources.github.storage.read_parquet_records_from_prefix",
+            return_value=data,
+        ):
+            key = self.storage.compact_month(
+                dataset=datasets.GITHUB_COMMITS,
+                year=2026,
+                month=7,
+            )
+
+        body = self.mock_s3.put_object.call_args.kwargs["Body"]
+        compacted = pd.read_parquet(BytesIO(body))
+        self.assertEqual(
+            key, "compacted/events/github/commits/year=2026/month=07/data.parquet"
+        )
+        self.assertEqual(
+            compacted["committed_at_utc"].dtype.name, "datetime64[ns, UTC]"
+        )
+
+    def test_compact_month_normalizes_legacy_pr_string_timestamp(self):
+        """既存PR sourceの文字列日時をtimestamp Parquetへ変換して保存する。"""
+        data = [_pr_event_row("pr_1", 1)]
+        data[0]["updated_at_utc"] = "2026-07-02T12:00:00Z"
+
+        with patch(
+            "pipelines.sources.github.storage.read_parquet_records_from_prefix",
+            return_value=data,
+        ):
+            key = self.storage.compact_month(
+                dataset=datasets.GITHUB_PULL_REQUESTS,
+                year=2026,
+                month=7,
+            )
+
+        body = self.mock_s3.put_object.call_args.kwargs["Body"]
+        compacted = pd.read_parquet(BytesIO(body))
+        self.assertEqual(
+            key,
+            "compacted/events/github/pull_requests/year=2026/month=07/data.parquet",
+        )
+        self.assertEqual(compacted["updated_at_utc"].dtype.name, "datetime64[ns, UTC]")

--- a/egograph/pipelines/tests/unit/github/test_storage.py
+++ b/egograph/pipelines/tests/unit/github/test_storage.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pytest
 from botocore.exceptions import ClientError
 from dataset_catalog import datasets
 from pipelines.sources.github.storage import (
@@ -33,6 +34,24 @@ def _pr_event_row(event_id: str, pr_number: int) -> dict:
         "pr_number": pr_number,
         "updated_at_utc": datetime(2026, 1, 1, tzinfo=UTC),
     }
+
+
+@pytest.fixture
+def github_storage_with_mock_s3():
+    """GitHub storageとモックS3を生成するpytest fixture。"""
+    with patch("pipelines.sources.github.storage.boto3") as mock_boto3:
+        mock_s3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3
+        storage = GitHubWorklogStorage(
+            endpoint_url="http://test-endpoint",
+            access_key_id="test-key",
+            secret_access_key="test-secret",
+            bucket_name="test-bucket",
+            raw_path="raw/",
+            events_path="events/",
+            master_path="master/",
+        )
+        yield storage, mock_s3
 
 
 class TestGitHubWorklogStorage(unittest.TestCase):
@@ -527,30 +546,6 @@ class TestGitHubWorklogStorage(unittest.TestCase):
         )
         self.assertEqual(key, call_args["Key"])
 
-    def test_compact_month_normalizes_legacy_string_timestamp(self):
-        """既存sourceの文字列日時をtimestamp Parquetへ変換して保存する。"""
-        data = [_commit_row("commit_1", "abc123")]
-        data[0]["committed_at_utc"] = "2026-07-01T12:00:00Z"
-
-        with patch(
-            "pipelines.sources.github.storage.read_parquet_records_from_prefix",
-            return_value=data,
-        ):
-            key = self.storage.compact_month(
-                dataset=datasets.GITHUB_COMMITS,
-                year=2026,
-                month=7,
-            )
-
-        body = self.mock_s3.put_object.call_args.kwargs["Body"]
-        compacted = pd.read_parquet(BytesIO(body))
-        self.assertEqual(
-            key, "compacted/events/github/commits/year=2026/month=07/data.parquet"
-        )
-        self.assertEqual(
-            compacted["committed_at_utc"].dtype.name, "datetime64[ns, UTC]"
-        )
-
     def test_compact_month_normalizes_legacy_pr_string_timestamp(self):
         """既存PR sourceの文字列日時をtimestamp Parquetへ変換して保存する。"""
         data = [_pr_event_row("pr_1", 1)]
@@ -573,3 +568,27 @@ class TestGitHubWorklogStorage(unittest.TestCase):
             "compacted/events/github/pull_requests/year=2026/month=07/data.parquet",
         )
         self.assertEqual(compacted["updated_at_utc"].dtype.name, "datetime64[ns, UTC]")
+
+
+def test_compact_month_normalizes_legacy_string_timestamp(
+    github_storage_with_mock_s3,
+):
+    """既存sourceの文字列日時をtimestamp Parquetへ変換して保存する。"""
+    storage, mock_s3 = github_storage_with_mock_s3
+    data = [_commit_row("commit_1", "abc123")]
+    data[0]["committed_at_utc"] = "2026-07-01T12:00:00Z"
+
+    with patch(
+        "pipelines.sources.github.storage.read_parquet_records_from_prefix",
+        return_value=data,
+    ):
+        key = storage.compact_month(
+            dataset=datasets.GITHUB_COMMITS,
+            year=2026,
+            month=7,
+        )
+
+    body = mock_s3.put_object.call_args.kwargs["Body"]
+    compacted = pd.read_parquet(BytesIO(body))
+    assert key == "compacted/events/github/commits/year=2026/month=07/data.parquet"
+    assert compacted["committed_at_utc"].dtype.name == "datetime64[ns, UTC]"

--- a/egograph/pipelines/tests/unit/github/test_transform.py
+++ b/egograph/pipelines/tests/unit/github/test_transform.py
@@ -149,6 +149,8 @@ class TestTransformPullRequest:
         assert result["head_ref"] == "feature-branch"
         assert result["labels"] == ["bug"]
         assert result["action"] == "updated"
+        assert isinstance(result["updated_at_utc"], datetime)
+        assert result["updated_at_utc"].tzinfo == timezone.utc
 
     def test_transform_pr_merged(self):
         """マージ済みPRを変換する。"""
@@ -328,6 +330,8 @@ class TestTransformCommit:
         assert result["additions"] == 10
         assert result["deletions"] == 5
         assert result["changed_files_count"] is None
+        assert isinstance(result["committed_at_utc"], datetime)
+        assert result["committed_at_utc"].tzinfo == timezone.utc
 
     def test_transform_commit_with_files_array_sets_changed_files_count(self):
         """files配列がある場合、changed_files_countをファイル数で保持する。"""

--- a/egograph/pipelines/tests/unit/test_api_compaction.py
+++ b/egograph/pipelines/tests/unit/test_api_compaction.py
@@ -1,0 +1,101 @@
+"""Dataset catalog と manual compaction API のテスト。"""
+
+from fastapi.testclient import TestClient
+from pipelines.api.dependencies import verify_api_key
+from pipelines.app import create_app
+from pipelines.config import PipelinesConfig
+from pydantic import SecretStr
+
+
+def _build_client(tmp_path):
+    """外部設定に依存しない認証済みテストクライアントを構築する。"""
+    config = PipelinesConfig(
+        database_path=tmp_path / "state.sqlite3",
+        logs_root=tmp_path / "logs",
+        dispatcher_poll_seconds=60,
+        google_health_client_id=None,
+        google_health_client_secret=None,
+        google_health_redirect_uri=None,
+        google_health_token_encryption_key=None,
+        api_key=SecretStr("test-api-key"),
+    )
+    app = create_app(config)
+    app.dependency_overrides[verify_api_key] = lambda: None
+    return TestClient(app)
+
+
+def test_list_datasets_returns_catalog_metadata(tmp_path):
+    """dataset一覧はcatalogのIDとcompact対応可否を返す。"""
+    # Arrange & Act
+    with _build_client(tmp_path) as client:
+        response = client.get("/v1/datasets")
+
+    # Assert
+    assert response.status_code == 200
+    datasets_by_id = {item["dataset_id"]: item for item in response.json()}
+    assert datasets_by_id["github.commits"]["path"] == "github/commits"
+    assert datasets_by_id["github.commits"]["compaction_supported"] is True
+    assert datasets_by_id["google_health.samples"]["compaction_supported"] is False
+
+
+def test_create_compaction_run_queues_selected_datasets(tmp_path):
+    """指定したdataset partitionだけをmanual compaction runへ渡す。"""
+    # Arrange
+    payload = {
+        "targets": [
+            {"dataset_id": "github.commits", "year": 2026, "month": 7},
+            {"dataset_id": "github.pull_requests", "year": 2026, "month": 7},
+        ]
+    }
+
+    # Act
+    with _build_client(tmp_path) as client:
+        response = client.post("/v1/compaction/runs", json=payload)
+
+    # Assert
+    assert response.status_code == 201
+    run = response.json()
+    assert run["workflow_id"] == "github_compact_workflow"
+    assert run["status"] in {"queued", "running"}
+    assert run["result_summary"] == {
+        "compaction_targets": [
+            {"dataset_id": "github.commits", "year": 2026, "month": 7},
+            {"dataset_id": "github.pull_requests", "year": 2026, "month": 7},
+        ]
+    }
+
+
+def test_create_compaction_run_rejects_unknown_dataset(tmp_path):
+    """catalogにないdataset IDを拒否する。"""
+    # Arrange
+    payload = {"targets": [{"dataset_id": "unknown.dataset", "year": 2026, "month": 7}]}
+
+    # Act
+    with _build_client(tmp_path) as client:
+        response = client.post("/v1/compaction/runs", json=payload)
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith("invalid_dataset_id:")
+
+
+def test_create_compaction_run_rejects_unsupported_compaction_strategy(tmp_path):
+    """月次でも異なるcompaction strategyのdatasetを拒否する。"""
+    # Arrange
+    payload = {
+        "targets": [
+            {
+                "dataset_id": "google_health.samples",
+                "year": 2026,
+                "month": 7,
+            }
+        ]
+    }
+
+    # Act
+    with _build_client(tmp_path) as client:
+        response = client.post("/v1/compaction/runs", json=payload)
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith("invalid_dataset_id:")

--- a/egograph/pipelines/tests/unit/test_api_compaction.py
+++ b/egograph/pipelines/tests/unit/test_api_compaction.py
@@ -1,5 +1,6 @@
 """Dataset catalog と manual compaction API のテスト。"""
 
+import pytest
 from fastapi.testclient import TestClient
 from pipelines.api.dependencies import verify_api_key
 from pipelines.app import create_app
@@ -26,8 +27,11 @@ def _build_client(tmp_path):
 
 def test_list_datasets_returns_catalog_metadata(tmp_path):
     """dataset一覧はcatalogのIDとcompact対応可否を返す。"""
-    # Arrange & Act
-    with _build_client(tmp_path) as client:
+    # Arrange
+    client = _build_client(tmp_path)
+
+    # Act
+    with client:
         response = client.get("/v1/datasets")
 
     # Assert
@@ -47,9 +51,10 @@ def test_create_compaction_run_queues_selected_datasets(tmp_path):
             {"dataset_id": "github.pull_requests", "year": 2026, "month": 7},
         ]
     }
+    client = _build_client(tmp_path)
 
     # Act
-    with _build_client(tmp_path) as client:
+    with client:
         response = client.post("/v1/compaction/runs", json=payload)
 
     # Assert
@@ -69,9 +74,10 @@ def test_create_compaction_run_rejects_unknown_dataset(tmp_path):
     """catalogにないdataset IDを拒否する。"""
     # Arrange
     payload = {"targets": [{"dataset_id": "unknown.dataset", "year": 2026, "month": 7}]}
+    client = _build_client(tmp_path)
 
     # Act
-    with _build_client(tmp_path) as client:
+    with client:
         response = client.post("/v1/compaction/runs", json=payload)
 
     # Assert
@@ -91,11 +97,47 @@ def test_create_compaction_run_rejects_unsupported_compaction_strategy(tmp_path)
             }
         ]
     }
+    client = _build_client(tmp_path)
 
     # Act
-    with _build_client(tmp_path) as client:
+    with client:
         response = client.post("/v1/compaction/runs", json=payload)
 
     # Assert
     assert response.status_code == 400
     assert response.json()["detail"].startswith("invalid_dataset_id:")
+
+
+@pytest.mark.parametrize("request_body", [[], "not-an-object", 1])
+def test_create_compaction_run_rejects_non_object_body(tmp_path, request_body):
+    """トップレベルの非オブジェクト入力を400へ変換する。"""
+    # Arrange
+    client = _build_client(tmp_path)
+
+    # Act
+    with client:
+        response = client.post("/v1/compaction/runs", json=request_body)
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith("invalid_request:")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("year", "2026"), ("month", 7.0)],
+)
+def test_create_compaction_run_rejects_non_integer_period(field, value, tmp_path):
+    """APIの期間値は厳密な整数だけを受け付ける。"""
+    # Arrange
+    target = {"dataset_id": "github.commits", "year": 2026, "month": 7}
+    target[field] = value
+    client = _build_client(tmp_path)
+
+    # Act
+    with client:
+        response = client.post("/v1/compaction/runs", json={"targets": [target]})
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith(f"invalid_targets.0.{field}:")

--- a/egograph/pipelines/tests/unit/test_compaction.py
+++ b/egograph/pipelines/tests/unit/test_compaction.py
@@ -1,14 +1,20 @@
 """Compaction helper tests."""
 
 from datetime import datetime, timezone
+from io import BytesIO
+from unittest.mock import MagicMock
 
 import pandas as pd
+import pytest
 from dataset_catalog import datasets
+from pipelines.compaction import DatasetCompactionTarget, validate_compaction_targets
 from pipelines.sources.common.compaction import (
     _unify_datetime_columns,
     build_compacted_key,
     compact_records,
     discover_available_months,
+    normalize_dataframe_for_dataset,
+    read_parquet_records_from_prefix,
     resolve_target_months,
 )
 
@@ -80,20 +86,20 @@ class TestUnifyDatetimeColumns:
 
     def test_unifies_mixed_timestamp_str_to_datetime(self):
         """Timestamp と str が混在していても datetime に統一される。"""
-        df = pd.DataFrame({
-            "play_id": ["p1", "p2", "p3"],
-            "played_at_utc": [
-                pd.Timestamp("2024-05-01 10:00:00"),
-                "2024-05-02 11:00:00+00:00",
-                pd.Timestamp("2024-05-01 09:00:00"),
-            ],
-        })
+        df = pd.DataFrame(
+            {
+                "play_id": ["p1", "p2", "p3"],
+                "played_at_utc": [
+                    pd.Timestamp("2024-05-01 10:00:00"),
+                    "2024-05-02 11:00:00+00:00",
+                    pd.Timestamp("2024-05-01 09:00:00"),
+                ],
+            }
+        )
 
         result = _unify_datetime_columns(df)
 
-        assert result["played_at_utc"].dtype.name.startswith(
-            "datetime64[ns, UTC"
-        )
+        assert result["played_at_utc"].dtype.name.startswith("datetime64[ns, UTC")
         assert result.loc[0, "played_at_utc"] == pd.Timestamp(
             "2024-05-01 10:00:00", tz="UTC"
         )
@@ -103,10 +109,12 @@ class TestUnifyDatetimeColumns:
 
     def test_leaves_homogeneous_str_unchanged(self):
         """混在型でなければ型変換しない。"""
-        df = pd.DataFrame({
-            "track_id": ["t1", "t2"],
-            "label": ["a", "b"],
-        })
+        df = pd.DataFrame(
+            {
+                "track_id": ["t1", "t2"],
+                "label": ["a", "b"],
+            }
+        )
 
         result = _unify_datetime_columns(df)
 
@@ -115,13 +123,15 @@ class TestUnifyDatetimeColumns:
 
     def test_leaves_int_column_unchanged(self):
         """整数カラムは無視される。"""
-        df = pd.DataFrame({
-            "id": [1, 2],
-            "played_at_utc": [
-                pd.Timestamp("2024-05-01 10:00:00"),
-                pd.Timestamp("2024-05-02 11:00:00"),
-            ],
-        })
+        df = pd.DataFrame(
+            {
+                "id": [1, 2],
+                "played_at_utc": [
+                    pd.Timestamp("2024-05-01 10:00:00"),
+                    pd.Timestamp("2024-05-02 11:00:00"),
+                ],
+            }
+        )
 
         result = _unify_datetime_columns(df)
 
@@ -129,18 +139,128 @@ class TestUnifyDatetimeColumns:
         assert result["played_at_utc"].dtype.name.startswith("datetime64[ns")
 
 
+@pytest.mark.parametrize(
+    ("dataset", "column"),
+    [
+        (datasets.GITHUB_COMMITS, "committed_at_utc"),
+        (datasets.GITHUB_PULL_REQUESTS, "updated_at_utc"),
+    ],
+)
+def test_normalize_dataframe_for_dataset_converts_legacy_string_timestamp(
+    dataset,
+    column,
+):
+    """既存の文字列日時をcatalog契約のUTC timestampへ変換する。"""
+    # Arrange
+    df = pd.DataFrame({column: ["2026-07-01T12:00:00Z"]})
+
+    # Act
+    result = normalize_dataframe_for_dataset(df, dataset)
+
+    # Assert
+    assert result[column].dtype.name == "datetime64[ns, UTC]"
+    assert result.loc[0, column] == pd.Timestamp("2026-07-01 12:00:00", tz="UTC")
+
+
+def test_normalize_dataframe_for_dataset_converts_explicit_offset_to_utc():
+    """明示されたoffsetを保持せず、UTC instantへ変換する。"""
+    # Arrange
+    df = pd.DataFrame({"committed_at_utc": ["2026-07-01T21:00:00+09:00"]})
+
+    # Act
+    result = normalize_dataframe_for_dataset(df, datasets.GITHUB_COMMITS)
+
+    # Assert
+    assert result.loc[0, "committed_at_utc"] == pd.Timestamp(
+        "2026-07-01 12:00:00", tz="UTC"
+    )
+
+
+def test_normalize_dataframe_for_dataset_rejects_invalid_timestamp():
+    """不正な日時はcompact前にエラーとして扱う。"""
+    # Arrange
+    df = pd.DataFrame({"committed_at_utc": ["not-a-timestamp"]})
+
+    # Act & Assert
+    with pytest.raises(ValueError):
+        normalize_dataframe_for_dataset(df, datasets.GITHUB_COMMITS)
+
+
+def test_normalize_dataframe_for_dataset_rejects_naive_timestamp():
+    """タイムゾーンなし日時をUTCと誤認しない。"""
+    # Arrange
+    df = pd.DataFrame({"committed_at_utc": ["2026-07-01T12:00:00"]})
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="must include a timezone"):
+        normalize_dataframe_for_dataset(df, datasets.GITHUB_COMMITS)
+
+
+def test_read_parquet_records_normalizes_legacy_string_timestamp():
+    """source Parquet読込時にもcatalog契約のtimestampへ変換する。"""
+    # Arrange
+    source_df = pd.DataFrame(
+        {
+            "commit_event_id": ["commit-1"],
+            "committed_at_utc": ["2026-07-01T12:00:00Z"],
+        }
+    )
+    buffer = BytesIO()
+    source_df.to_parquet(buffer, index=False, engine="pyarrow")
+    s3 = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {"Contents": [{"Key": "events/github/commits/year=2026/month=07/1.parquet"}]}
+    ]
+    s3.get_paginator.return_value = paginator
+    body = MagicMock()
+    body.read.return_value = buffer.getvalue()
+    s3.get_object.return_value = {"Body": body}
+
+    # Act
+    records = read_parquet_records_from_prefix(
+        s3,
+        "test-bucket",
+        "events/github/commits/year=2026/month=07/",
+        dataset=datasets.GITHUB_COMMITS,
+    )
+
+    # Assert
+    assert isinstance(records[0]["committed_at_utc"], pd.Timestamp)
+    assert records[0]["committed_at_utc"] == pd.Timestamp(
+        "2026-07-01 12:00:00", tz="UTC"
+    )
+
+
+def test_validate_compaction_targets_rejects_mixed_providers():
+    """一つのrunに異なるproviderの対象を混在させない。"""
+    # Arrange
+    targets = (
+        DatasetCompactionTarget("github.commits", 2026, 7),
+        DatasetCompactionTarget("spotify.plays", 2026, 7),
+    )
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="same provider"):
+        validate_compaction_targets(targets)
+
+
 class TestCompactRecordsSortCanNowAssumeUnifiedTypes:
     """compact_records は統一済みの型を受け取る前提で動作する。"""
 
     def test_sorts_datetime_column_normally(self):
-        df = pd.DataFrame({
-            "play_id": ["p1", "p2", "p3"],
-            "played_at_utc": pd.to_datetime([
-                "2024-05-01 10:00:00+00:00",
-                "2024-05-02 11:00:00+00:00",
-                "2024-05-01 09:00:00+00:00",
-            ]),
-        })
+        df = pd.DataFrame(
+            {
+                "play_id": ["p1", "p2", "p3"],
+                "played_at_utc": pd.to_datetime(
+                    [
+                        "2024-05-01 10:00:00+00:00",
+                        "2024-05-02 11:00:00+00:00",
+                        "2024-05-01 09:00:00+00:00",
+                    ]
+                ),
+            }
+        )
         records = df.to_dict(orient="records")
 
         result = compact_records(records, dedupe_key="play_id", sort_by="played_at_utc")

--- a/egograph/pipelines/tests/unit/test_compaction.py
+++ b/egograph/pipelines/tests/unit/test_compaction.py
@@ -208,6 +208,28 @@ def test_read_parquet_records_normalizes_legacy_string_timestamp():
     )
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("year", True),
+        ("month", False),
+        ("year", 2026.5),
+        ("month", 7.0),
+        ("year", "2026"),
+        ("month", "7"),
+    ],
+)
+def test_dataset_compaction_target_rejects_non_exact_int(field, value):
+    """compaction targetはboolやint以外の期間値を拒否する。"""
+    # Arrange
+    target_values = {"dataset_id": "github.commits", "year": 2026, "month": 7}
+    target_values[field] = value
+
+    # Act & Assert
+    with pytest.raises(ValueError, match=f"invalid_{field}:"):
+        DatasetCompactionTarget(**target_values)
+
+
 def test_validate_compaction_targets_rejects_mixed_providers():
     """一つのrunに異なるproviderの対象を混在させない。"""
     # Arrange

--- a/egograph/pipelines/tests/unit/test_compaction.py
+++ b/egograph/pipelines/tests/unit/test_compaction.py
@@ -162,20 +162,6 @@ def test_normalize_dataframe_for_dataset_converts_legacy_string_timestamp(
     assert result.loc[0, column] == pd.Timestamp("2026-07-01 12:00:00", tz="UTC")
 
 
-def test_normalize_dataframe_for_dataset_converts_explicit_offset_to_utc():
-    """明示されたoffsetを保持せず、UTC instantへ変換する。"""
-    # Arrange
-    df = pd.DataFrame({"committed_at_utc": ["2026-07-01T21:00:00+09:00"]})
-
-    # Act
-    result = normalize_dataframe_for_dataset(df, datasets.GITHUB_COMMITS)
-
-    # Assert
-    assert result.loc[0, "committed_at_utc"] == pd.Timestamp(
-        "2026-07-01 12:00:00", tz="UTC"
-    )
-
-
 def test_normalize_dataframe_for_dataset_rejects_invalid_timestamp():
     """不正な日時はcompact前にエラーとして扱う。"""
     # Arrange
@@ -183,16 +169,6 @@ def test_normalize_dataframe_for_dataset_rejects_invalid_timestamp():
 
     # Act & Assert
     with pytest.raises(ValueError):
-        normalize_dataframe_for_dataset(df, datasets.GITHUB_COMMITS)
-
-
-def test_normalize_dataframe_for_dataset_rejects_naive_timestamp():
-    """タイムゾーンなし日時をUTCと誤認しない。"""
-    # Arrange
-    df = pd.DataFrame({"committed_at_utc": ["2026-07-01T12:00:00"]})
-
-    # Act & Assert
-    with pytest.raises(ValueError, match="must include a timezone"):
         normalize_dataframe_for_dataset(df, datasets.GITHUB_COMMITS)
 
 

--- a/egograph/pipelines/tests/unit/test_provider_entrypoints.py
+++ b/egograph/pipelines/tests/unit/test_provider_entrypoints.py
@@ -13,7 +13,11 @@ from pipelines.infrastructure.execution.inprocess_executor import (
     InProcessStepExecutor,
 )
 from pipelines.sources.common.config import Config, DuckDBConfig, R2Config
-from pipelines.sources.github.pipeline import run_github_compact, run_github_ingest
+from pipelines.sources.github.pipeline import (
+    run_github_compact,
+    run_github_compact_from_run,
+    run_github_ingest,
+)
 from pipelines.sources.spotify.pipeline import run_spotify_compact, run_spotify_ingest
 from pipelines.sources.youtube.pipeline import run_youtube_ingest
 from pipelines.workflows.registry import get_workflows
@@ -163,6 +167,55 @@ def test_run_github_compact_raises_after_collecting_failures(monkeypatch):
         assert str(exc) == "GitHub compaction failed for: github/pull_requests:2026-04"
     else:
         raise AssertionError("RuntimeError was not raised")
+
+
+def test_run_github_compact_from_run_uses_explicit_dataset_targets(monkeypatch):
+    """manual runの対象dataset・月だけをGitHub storageへ渡す。"""
+    calls = []
+
+    class FakeStorage:
+        def __init__(self, **kwargs):
+            pass
+
+        def compact_month(self, **kwargs):
+            calls.append(kwargs)
+            return "compacted/events/github/commits/year=2026/month=07/data.parquet"
+
+    monkeypatch.setattr(
+        "pipelines.sources.github.pipeline.PipelinesSettings.load",
+        lambda: _config(),
+    )
+    monkeypatch.setattr(
+        "pipelines.sources.github.pipeline.GitHubWorklogStorage",
+        FakeStorage,
+    )
+    run = WorkflowRun(
+        run_id="run-1",
+        workflow_id="github_compact_workflow",
+        trigger_type=TriggerType.MANUAL,
+        queued_reason=QueuedReason.MANUAL_REQUEST,
+        status=WorkflowRunStatus.RUNNING,
+        scheduled_at=None,
+        queued_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        started_at=None,
+        finished_at=None,
+        last_error_message=None,
+        requested_by="api",
+        parent_run_id=None,
+        result_summary={
+            "compaction_targets": [
+                {"dataset_id": "github.commits", "year": 2026, "month": 7}
+            ]
+        },
+    )
+
+    result = run_github_compact_from_run(run)
+
+    assert len(calls) == 1
+    assert calls[0]["dataset"].dataset_id == "github.commits"
+    assert calls[0]["year"] == 2026
+    assert calls[0]["month"] == 7
+    assert result["target_months"] == ["2026-07"]
 
 
 def test_all_inprocess_steps_are_importable():

--- a/egograph/pipelines/tests/unit/test_service.py
+++ b/egograph/pipelines/tests/unit/test_service.py
@@ -3,6 +3,7 @@
 retry_run, cancel_run, get_step_log などの運用機能を検証する。
 """
 
+from pipelines.compaction import DatasetCompactionTarget
 from pipelines.config import PipelinesConfig
 from pipelines.domain.errors import WorkflowNotFoundError, WorkflowRunNotFoundError
 from pipelines.domain.workflow import StepRunStatus
@@ -50,6 +51,40 @@ def test_retry_run_preserves_original_input(tmp_path):
     retry_run = service.retry_run(original_run.run_id)
 
     assert retry_run.result_summary == original_run.result_summary
+
+
+def test_trigger_compaction_queues_dataset_targets(tmp_path):
+    """manual compaction run は対象datasetをresult_summaryへ保存する。"""
+    service = _make_service(tmp_path)
+    targets = (
+        DatasetCompactionTarget("github.commits", 2026, 7),
+        DatasetCompactionTarget("github.pull_requests", 2026, 7),
+    )
+
+    run = service.trigger_compaction(targets)
+
+    assert run.workflow_id == "github_compact_workflow"
+    assert run.result_summary == {
+        "compaction_targets": [
+            {"dataset_id": "github.commits", "year": 2026, "month": 7},
+            {"dataset_id": "github.pull_requests", "year": 2026, "month": 7},
+        ]
+    }
+
+
+def test_trigger_compaction_rejects_mixed_provider_targets(tmp_path):
+    """providerを跨ぐ対象はprovider lockを保てないため拒否する。"""
+    service = _make_service(tmp_path)
+    targets = (
+        DatasetCompactionTarget("github.commits", 2026, 7),
+        DatasetCompactionTarget("spotify.plays", 2026, 7),
+    )
+
+    try:
+        service.trigger_compaction(targets)
+        raise AssertionError("ValueError was not raised")
+    except ValueError as exc:
+        assert "same provider" in str(exc)
 
 
 def test_retry_run_404_for_unknown_run(tmp_path):

--- a/egograph/pipelines/workflows/registry.py
+++ b/egograph/pipelines/workflows/registry.py
@@ -79,6 +79,23 @@ def get_workflows() -> dict[str, WorkflowDefinition]:
             misfire_policy=MisfirePolicy.COALESCE_LATEST,
         ),
         WorkflowDefinition(
+            workflow_id="spotify_compact_workflow",
+            name="Spotify manual compact workflow",
+            description="Compact explicitly selected Spotify datasets and months",
+            steps=(
+                _inprocess_step(
+                    "run_spotify_compact",
+                    "Run Spotify manual compact",
+                    "pipelines.sources.spotify.pipeline:run_spotify_compact_from_run",
+                    timeout_seconds=1800,
+                ),
+            ),
+            triggers=(),
+            concurrency_key="spotify_ingest_workflow",
+            timeout_seconds=3600,
+            misfire_policy=MisfirePolicy.SKIP_MISFIRE,
+        ),
+        WorkflowDefinition(
             workflow_id="github_ingest_workflow",
             name="GitHub ingest workflow",
             description="Collect and compact GitHub worklog datasets",
@@ -100,6 +117,23 @@ def get_workflows() -> dict[str, WorkflowDefinition]:
             concurrency_key="github_ingest_workflow",
             timeout_seconds=3600,
             misfire_policy=MisfirePolicy.COALESCE_LATEST,
+        ),
+        WorkflowDefinition(
+            workflow_id="github_compact_workflow",
+            name="GitHub manual compact workflow",
+            description="Compact explicitly selected GitHub datasets and months",
+            steps=(
+                _inprocess_step(
+                    "run_github_compact",
+                    "Run GitHub manual compact",
+                    "pipelines.sources.github.pipeline:run_github_compact_from_run",
+                    timeout_seconds=1800,
+                ),
+            ),
+            triggers=(),
+            concurrency_key="github_ingest_workflow",
+            timeout_seconds=3600,
+            misfire_policy=MisfirePolicy.SKIP_MISFIRE,
         ),
         WorkflowDefinition(
             workflow_id="google_activity_ingest_workflow",
@@ -133,6 +167,23 @@ def get_workflows() -> dict[str, WorkflowDefinition]:
                     "run_youtube_compact",
                     "Run YouTube compact",
                     "pipelines.sources.youtube.pipeline:run_youtube_compact",
+                    timeout_seconds=1800,
+                ),
+            ),
+            triggers=(),
+            concurrency_key="youtube_ingest_workflow",
+            timeout_seconds=3600,
+            misfire_policy=MisfirePolicy.SKIP_MISFIRE,
+        ),
+        WorkflowDefinition(
+            workflow_id="youtube_compact_workflow",
+            name="YouTube manual compact workflow",
+            description="Compact explicitly selected YouTube datasets and months",
+            steps=(
+                _inprocess_step(
+                    "run_youtube_compact",
+                    "Run YouTube manual compact",
+                    "pipelines.sources.youtube.pipeline:run_youtube_compact_from_run",
                     timeout_seconds=1800,
                 ),
             ),
@@ -212,6 +263,26 @@ def get_workflows() -> dict[str, WorkflowDefinition]:
                     "run_browser_history_compact",
                     "Run browser history compact for event targets",
                     "pipelines.sources.browser_history.pipeline:compact_from_event_context",
+                    timeout_seconds=1800,
+                ),
+            ),
+            triggers=(),
+            concurrency_key="browser_history_compact_workflow",
+            timeout_seconds=3600,
+            misfire_policy=MisfirePolicy.SKIP_MISFIRE,
+        ),
+        WorkflowDefinition(
+            workflow_id="browser_history_compact_workflow_manual",
+            name="Browser history manual compact workflow",
+            description=(
+                "Compact explicitly selected browser history datasets and months"
+            ),
+            steps=(
+                _inprocess_step(
+                    "run_browser_history_compact_manual",
+                    "Run browser history manual compact",
+                    "pipelines.sources.browser_history.pipeline:"
+                    "run_browser_history_compact_from_run",
                     timeout_seconds=1800,
                 ),
             ),


### PR DESCRIPTION
## 概要

dataset単位で対象partitionを指定できるmanual compaction APIを追加し、既存source Parquetに残る文字列日時をcanonicalなUTC timestampへ正規化します。

## 背景

GitHubの2026年7月データでは、`github.commits.committed_at_utc` と `github.pull_requests.updated_at_utc` が文字列型で保存され、compact側のschema検証に失敗していました。

## 変更内容

- `GET /v1/datasets` を追加（catalog全件、`compaction_supported`をレスポンス項目として返却）
- `POST /v1/compaction/runs` を追加
  - `dataset_id`、`year`、`month`で対象partitionを指定
  - `workflow_id`はproviderから内部解決
  - 同一run内は同一providerに限定
- GitHub / Spotify / YouTube / Browser Historyのmanual compaction workflowを追加
- compaction時にcatalogのtimestamp列をUTC aware datetimeへ正規化
  - 既存の文字列日時をParquet保存前に変換
  - 不正な日時は保存前にエラー化
- GitHub commit / pull requestの日時型回帰テストを追加
- API入力の期間値を厳密な整数として検証し、非オブジェクトbodyを400へ統一
- API、運用手順、Dataset Catalogドキュメントを更新

## API利用例

```json
{
  "targets": [
    {"dataset_id": "github.commits", "year": 2026, "month": 7},
    {"dataset_id": "github.pull_requests", "year": 2026, "month": 7}
  ]
}
```

## 検証

- Pipelines tests: 571 passed, 2 skipped
- Ruff check / format / diff check: passed

本番環境への再コンパクト実行は、本PRのデプロイ後に外部agentからAPI経由で実行します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * データセットカタログを確認し、指定したデータセット・年月の手動コンパクションを実行できるようになりました。
  * 実行状況、ログ、再試行を通常の実行管理機能から追跡できます。
  * Spotify、GitHub、YouTube、ブラウザ履歴の手動コンパクションに対応しました。
* **改善**
  * 日時データをUTC形式へ統一し、過去データも一貫した形式で保存します。
  * 無効な日時や対象外のデータセットは、処理前にエラーとして通知します。
* **ドキュメント**
  * 新しいデータセット一覧・コンパクションAPIの利用方法を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->