### PR TITLE
feat(mcp): compact daily timeline responses

### DIFF
--- a/docs/architecture/daily-timeline.md
+++ b/docs/architecture/daily-timeline.md
@@ -2,7 +2,7 @@
 
 > 最終更新: 2026-07-04
 
-Daily Timeline は、複数データソースの観測イベントを1日単位で時刻順に統合し、REST API と MCP Tool の両方から同じ契約で提供する Backend read model である。
+Daily Timeline は、複数データソースの観測イベントを1日単位で時刻順に統合する Backend read model である。REST API は完全形を返し、MCP Tool は同じ意味のデータを AI エージェント向けの compact 表現で返す。
 
 ## 目的
 
@@ -26,7 +26,7 @@ Backend は「事実の整列」と「判断材料の付与」までを責務と
 | REST API | `GET /v1/data/timeline/daily` |
 | MCP Tool | `get_daily_timeline` |
 
-REST API と MCP Tool は同じ入力制約、同じ response shape、同じ validation を使う。どちらか一方だけに存在する項目を作らない。
+REST API と MCP Tool は同じ入力制約、同じ canonical builder、同じ validation を使う。REST API は完全形、MCP Tool は表示上の重複と source 固有 metadata を省いた compact 表現を返す。
 
 公開契約は1日単位に固定する。時間窓指定や週次レビューが必要になった場合でも、この endpoint / tool の意味を広げず、別契約として追加する。
 ただし実装内部は UTC range を入力にした builder として構成し、将来の別契約でも正規化、ソート、correlation、gap 生成のロジックを再利用できるようにする。
@@ -103,6 +103,46 @@ timezone=Asia/Tokyo
 
 ## 出力
 
+### MCP compact 表現
+
+REST API の canonical response は以下の完全形を返す。MCP Tool はこの response を壊さずに構築したあと、呼び出し境界で次の compact 表現へ変換する。
+
+- `items[*].metadata` は返さない
+- `started_at_utc` / `started_at_local` は、要求された timezone の `started_at` に統合する
+- `ended_at_utc` / `ended_at_local` は、値がある場合だけ `ended_at` に統合する
+- `range` と `gaps` の時刻は要求された timezone の local 値だけを返す
+- `null`、空文字、空配列、空オブジェクトは省略する。`0` と `false` は保持する
+- `include_raw_refs=true` の場合の `raw_ref` は保持する
+- 空の配列・オブジェクトになったセクションは省略する
+- `meta.format` は `compact` になる
+
+```json
+{
+  "date": "2026-06-28",
+  "timezone": "Asia/Tokyo",
+  "range": {
+    "start": "2026-06-28T00:00:00+09:00",
+    "end": "2026-06-29T00:00:00+09:00"
+  },
+  "items": [
+    {
+      "event_id": "spotify:play:abc123",
+      "started_at": "2026-06-28T09:12:03+09:00",
+      "source": "spotify",
+      "kind": "music_play",
+      "duration_seconds": 222,
+      "title": "ヨルシカ - だから僕は僕を辞めた"
+    }
+  ],
+  "meta": {
+    "item_count": 183,
+    "truncated": false,
+    "generated_at": "2026-06-28T23:58:10Z",
+    "format": "compact"
+  }
+}
+```
+
 ### トップレベル
 
 ```json
@@ -140,7 +180,7 @@ timezone=Asia/Tokyo
 | `coverage` | source ごとの取得状況 |
 | `meta` | 件数、truncate、生成時刻 |
 
-## Timeline Item
+## REST canonical Timeline Item
 
 ### 共通 shape
 
@@ -371,6 +411,7 @@ backend/
 | Database queries | DuckDB SQL と Parquet path 解決 |
 
 API と MCP で別ロジックを持たない。両方とも同じ Repository / UseCase を呼ぶ。
+ただし、MCP のみ呼び出し境界で compact projection を適用する。
 
 ## 非責務
 
@@ -393,6 +434,6 @@ Daily Timeline では以下を行わない。
 | Unit | Browser History と YouTube の correlation を生成できる |
 | Unit | `gap_minutes` 以上の `no_observed_events_gap` を生成できる |
 | Unit | Google Health を `daily_summaries` に置き、`items` に混ぜない |
-| Integration | REST API と MCP Tool が同じ response shape を返す |
+| Integration | REST API が完全形、MCP Tool が compact 表現を返す |
 | Integration | local parquet root 優先と R2 fallback が既存 path resolver と同じ規則で動く |
 | Contract | `items[*].raw_ref.dataset_id` が Dataset Catalog の `dataset_id` と一致する |

--- a/egograph/backend/api/schemas/timeline.py
+++ b/egograph/backend/api/schemas/timeline.py
@@ -1,8 +1,4 @@
-"""Daily Timeline API レスポンススキーマ。
-
-REST と MCP で同じ response shape を使うため、本スキーマは MCP 応答の
-契約とも一致する。Pydantic モデルは REST の OpenAPI / 直列化検証に使う。
-"""
+"""Daily Timeline REST API レスポンススキーマ。"""
 
 from datetime import datetime
 from typing import Any

--- a/egograph/backend/api/timeline.py
+++ b/egograph/backend/api/timeline.py
@@ -1,8 +1,9 @@
 """Daily Timeline REST API エンドポイント。
 
 REST も MCP も同じ ``GetDailyTimelineTool`` を呼び、同じ validation /
-response shape を共有する。本エンドポイントは query parameter の受け取りと
-HTTP レスポンス生成のみを担う。
+canonical response を共有する。本エンドポイントは query parameter の受け取りと
+完全形の HTTP レスポンス生成のみを担う。MCP の compact 化は
+MCP 呼び出し境界で行う。
 """
 
 import logging

--- a/egograph/backend/api/timeline.py
+++ b/egograph/backend/api/timeline.py
@@ -1,9 +1,7 @@
 """Daily Timeline REST API エンドポイント。
 
-REST も MCP も同じ ``GetDailyTimelineTool`` を呼び、同じ validation /
-canonical response を共有する。本エンドポイントは query parameter の受け取りと
-完全形の HTTP レスポンス生成のみを担う。MCP の compact 化は
-MCP 呼び出し境界で行う。
+``GetDailyTimelineTool`` の validation と canonical response を利用し、
+query parameter の受け取りと完全形の HTTP レスポンス生成を担う。
 """
 
 import logging

--- a/egograph/backend/domain/tools/timeline/compact.py
+++ b/egograph/backend/domain/tools/timeline/compact.py
@@ -1,0 +1,85 @@
+"""Daily Timeline の MCP 向け compact 表現。"""
+
+from typing import Any
+
+
+def compact_daily_timeline(response: dict[str, Any]) -> dict[str, Any]:
+    """Daily Timeline の完全形を MCP 向けの軽量な表現へ変換する。
+
+    REST API と内部の canonical response は変更せず、MCP の表示に必要な
+    情報だけを残す。``0`` や ``False`` は有効値のため削除しない。
+    """
+    compact: dict[str, Any] = dict(response)
+    compact["range"] = _compact_range(response.get("range"))
+    compact["items"] = [_compact_item(item) for item in response.get("items", [])]
+    compact["gaps"] = [_compact_gap(gap) for gap in response.get("gaps", [])]
+    compact["meta"] = {
+        **(response.get("meta") or {}),
+        "format": "compact",
+    }
+    return _drop_empty(compact)
+
+
+def _compact_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Timeline item の重複時刻・metadata・空値を省く。"""
+    return _drop_empty(
+        {
+            "event_id": item.get("event_id"),
+            "started_at": item.get("started_at_local"),
+            "ended_at": item.get("ended_at_local"),
+            "source": item.get("source"),
+            "kind": item.get("kind"),
+            "duration_seconds": item.get("duration_seconds"),
+            "title": item.get("title"),
+            "subtitle": item.get("subtitle"),
+            "url": item.get("url"),
+            "raw_ref": item.get("raw_ref"),
+        }
+    )
+
+
+def _compact_range(time_range: dict[str, Any] | None) -> dict[str, Any]:
+    """対象範囲を要求された timezone の local 時刻だけで表す。"""
+    if not time_range:
+        return {}
+    return _drop_empty(
+        {
+            "start": time_range.get("start_local"),
+            "end": time_range.get("end_local"),
+        }
+    )
+
+
+def _compact_gap(gap: dict[str, Any]) -> dict[str, Any]:
+    """Gap の UTC/local 重複を省き、local 時刻を返す。"""
+    return _drop_empty(
+        {
+            "gap_id": gap.get("gap_id"),
+            "kind": gap.get("kind"),
+            "start": gap.get("start_local"),
+            "end": gap.get("end_local"),
+            "duration_minutes": gap.get("duration_minutes"),
+            "preceded_by_event_id": gap.get("preceded_by_event_id"),
+            "followed_by_event_id": gap.get("followed_by_event_id"),
+        }
+    )
+
+
+def _drop_empty(value: Any) -> Any:
+    """JSON値から ``None`` と空コンテナだけを再帰的に除く。"""
+    if isinstance(value, dict):
+        compact = {key: _drop_empty(item) for key, item in value.items()}
+        return {key: item for key, item in compact.items() if not _is_empty(item)}
+    if isinstance(value, list):
+        compact = [_drop_empty(item) for item in value]
+        return [item for item in compact if not _is_empty(item)]
+    return value
+
+
+def _is_empty(value: Any) -> bool:
+    """``0`` と ``False`` を除き、JSON上の空値だけを判定する。"""
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict)):
+        return not value
+    return False

--- a/egograph/backend/domain/tools/timeline/daily.py
+++ b/egograph/backend/domain/tools/timeline/daily.py
@@ -1,8 +1,7 @@
-"""``get_daily_timeline`` MCP ツール。
+"""``get_daily_timeline`` の canonical tool。
 
-REST API と MCP Tool は同じ入力制約、同じ response shape、同じ validation を使う。
-本ツールの ``execute`` が唯一の validation + repository 呼び出しポイントであり、
-REST 側も本ツールを経由して同じロジックを実行する。
+REST API と MCP Tool は同じ入力制約、同じ validation、同じ canonical response を使う。
+MCP のレスポンス表示だけは、呼び出し境界で compact projection を適用する。
 """
 
 import logging
@@ -68,7 +67,8 @@ class GetDailyTimelineTool(ToolBase):
             "複数データソース（Spotify, YouTube, Browser History, GitHub, "
             "Google Health）の観測イベントを1日単位で時刻順に統合した"
             "タイムラインを取得します。Google Health は items には入らず"
-            "daily_summaries に添付されます。"
+            "daily_summaries に添付されます。MCPではmetadata、空値、"
+            "UTC/localの重複を省いたcompact形式で返します。"
         )
 
     @property

--- a/egograph/backend/mcp_server.py
+++ b/egograph/backend/mcp_server.py
@@ -9,6 +9,7 @@ from mcp.types import CallToolResult, TextContent
 from mcp.types import Tool as MCPTool
 
 from backend.config import BackendConfig
+from backend.domain.tools.timeline.compact import compact_daily_timeline
 from backend.infrastructure.logging.sanitizers import sanitize_exception
 from backend.usecases.tools.factory import build_tool_registry
 
@@ -76,10 +77,22 @@ def create_mcp_server(config: BackendConfig) -> FastMCP:
             content=[
                 TextContent(
                     type="text",
-                    text=json.dumps(result, ensure_ascii=False, default=str),
+                    text=_serialize_tool_result(name, result),
                 )
             ],
             isError=False,
         )
 
     return mcp
+
+
+def _serialize_tool_result(name: str, result: Any) -> str:
+    """ツールごとの MCP 表現を JSON テキストへ直列化する。"""
+    if name == "get_daily_timeline":
+        return json.dumps(
+            compact_daily_timeline(result),
+            ensure_ascii=False,
+            default=str,
+            separators=(",", ":"),
+        )
+    return json.dumps(result, ensure_ascii=False, default=str)

--- a/egograph/backend/tests/integration/test_timeline_api.py
+++ b/egograph/backend/tests/integration/test_timeline_api.py
@@ -441,14 +441,14 @@ class TestBuildDailyTimelineIntegration:
 
 
 # ============================================================
-# REST API と MCP Tool の契約一致
+# REST API と canonical tool の契約一致
 # ============================================================
 
 
 class TestRestAndMcpContract:
-    """REST API と MCP Tool が同じ response shape を返す。"""
+    """REST API と canonical tool が同じ完全形を返す。"""
 
-    def test_rest_and_tool_return_same_shape(self, tmp_path, test_client):
+    def test_rest_and_canonical_tool_return_same_shape(self, tmp_path, test_client):
         local_root = _write_all_sources(tmp_path)
         tool = _build_tool(local_root)
         test_client.app.dependency_overrides[get_daily_timeline_tool] = lambda: tool
@@ -581,3 +581,20 @@ class TestMcpServerRegistration:
         assert payload["date"] == "2026-06-28"
         assert len(payload["items"]) == 5
         assert "google_health" in payload["daily_summaries"]
+        assert payload["meta"]["format"] == "compact"
+        assert set(payload["range"]) == {"start", "end"}
+        for item in payload["items"]:
+            assert "metadata" not in item
+            assert "started_at" in item
+            assert "started_at_utc" not in item
+            assert "started_at_local" not in item
+            assert "raw_ref" in item
+        assert set(payload["gaps"][0]) == {
+            "gap_id",
+            "kind",
+            "start",
+            "end",
+            "duration_minutes",
+            "preceded_by_event_id",
+            "followed_by_event_id",
+        }

--- a/egograph/backend/tests/test_mcp_server.py
+++ b/egograph/backend/tests/test_mcp_server.py
@@ -213,6 +213,26 @@ def test_call_tool_returns_result(mock_backend_config):
     assert json.loads(result.content[0].text) == {"message": "ok", "count": 1}
 
 
+def test_call_tool_keeps_non_timeline_payload_unchanged(mock_backend_config):
+    """Daily Timeline 以外の MCP ツールには compact projection を適用しない。"""
+    tool = MockTool(
+        "other_tool",
+        "Other tool",
+        {"metadata": {"keep": True}, "value": None},
+    )
+    registry = _build_registry(tool)
+
+    with patch("backend.mcp_server.build_tool_registry", return_value=registry):
+        server = create_mcp_server(mock_backend_config)
+
+    result = _run_call_tool(server, "other_tool", {})
+
+    assert json.loads(result.content[0].text) == {
+        "metadata": {"keep": True},
+        "value": None,
+    }
+
+
 def test_call_tool_unknown_raises(mock_backend_config):
     """未知ツール呼び出しはエラー結果になる。"""
     # Arrange: 空のレジストリを準備

--- a/egograph/backend/tests/unit/tools/timeline/test_compact.py
+++ b/egograph/backend/tests/unit/tools/timeline/test_compact.py
@@ -1,0 +1,123 @@
+"""Daily Timeline の MCP compact 表現を検証する。"""
+
+from backend.domain.tools.timeline.compact import compact_daily_timeline
+
+
+def test_compact_daily_timeline_omits_metadata_empty_values_and_duplicate_times():
+    """metadata・空値・UTC/local重複を除き、有効なゼロ値を残す。"""
+    response = {
+        "date": "2026-06-28",
+        "timezone": "Asia/Tokyo",
+        "range": {
+            "start_local": "2026-06-28T00:00:00+09:00",
+            "end_local": "2026-06-29T00:00:00+09:00",
+            "start_utc": "2026-06-27T15:00:00Z",
+            "end_utc": "2026-06-28T15:00:00Z",
+        },
+        "items": [
+            {
+                "event_id": "spotify:play:p1",
+                "source": "spotify",
+                "kind": "music_play",
+                "started_at_utc": "2026-06-28T00:12:03Z",
+                "started_at_local": "2026-06-28T09:12:03+09:00",
+                "ended_at_utc": None,
+                "ended_at_local": None,
+                "duration_seconds": 0,
+                "title": "Song",
+                "subtitle": "",
+                "url": None,
+                "metadata": {"track_id": "t1"},
+            }
+        ],
+        "correlations": [],
+        "gaps": [
+            {
+                "gap_id": "gap_1",
+                "kind": "no_observed_events_gap",
+                "start_utc": "2026-06-28T01:00:00Z",
+                "end_utc": "2026-06-28T03:00:00Z",
+                "start_local": "2026-06-28T10:00:00+09:00",
+                "end_local": "2026-06-28T12:00:00+09:00",
+                "duration_minutes": 120,
+                "preceded_by_event_id": "spotify:play:p1",
+                "followed_by_event_id": "github:commit:c1",
+            }
+        ],
+        "daily_summaries": {},
+        "coverage": {
+            "spotify": {"included": True, "event_count": 1},
+            "youtube": {"included": False, "event_count": 0, "status": "excluded"},
+        },
+        "meta": {"item_count": 1, "truncated": False, "generated_at": "now"},
+    }
+
+    compact = compact_daily_timeline(response)
+
+    assert compact == {
+        "date": "2026-06-28",
+        "timezone": "Asia/Tokyo",
+        "range": {
+            "start": "2026-06-28T00:00:00+09:00",
+            "end": "2026-06-29T00:00:00+09:00",
+        },
+        "items": [
+            {
+                "event_id": "spotify:play:p1",
+                "started_at": "2026-06-28T09:12:03+09:00",
+                "source": "spotify",
+                "kind": "music_play",
+                "duration_seconds": 0,
+                "title": "Song",
+            }
+        ],
+        "gaps": [
+            {
+                "gap_id": "gap_1",
+                "kind": "no_observed_events_gap",
+                "start": "2026-06-28T10:00:00+09:00",
+                "end": "2026-06-28T12:00:00+09:00",
+                "duration_minutes": 120,
+                "preceded_by_event_id": "spotify:play:p1",
+                "followed_by_event_id": "github:commit:c1",
+            }
+        ],
+        "coverage": {
+            "spotify": {"included": True, "event_count": 1},
+            "youtube": {"included": False, "event_count": 0, "status": "excluded"},
+        },
+        "meta": {
+            "item_count": 1,
+            "truncated": False,
+            "generated_at": "now",
+            "format": "compact",
+        },
+    }
+
+
+def test_compact_daily_timeline_preserves_raw_ref_when_requested():
+    """明示的に要求された raw_ref は metadata と分けて保持する。"""
+    response = {
+        "items": [
+            {
+                "event_id": "spotify:play:p1",
+                "started_at_local": "2026-06-28T09:12:03+09:00",
+                "raw_ref": {
+                    "dataset_id": "spotify.plays",
+                    "record_id": "p1",
+                    "timestamp_column": "played_at_utc",
+                },
+                "metadata": {"track_id": "t1"},
+            }
+        ],
+        "meta": {},
+    }
+
+    compact = compact_daily_timeline(response)
+
+    assert compact["items"][0]["raw_ref"] == {
+        "dataset_id": "spotify.plays",
+        "record_id": "p1",
+        "timestamp_column": "played_at_utc",
+    }
+    assert "metadata" not in compact["items"][0]


### PR DESCRIPTION
## 概要

- get_daily_timeline の MCP 応答だけを compact 表現へ変換
- items の source 固有 metadata、null・空文字・空コンテナを省略
- UTC/local の重複時刻を timezone local の started_at / ended_at へ統合
- range と gaps も local 時刻だけに整理
- REST API は完全形のまま、他の MCP ツールは従来の直列化のまま維持

## 検証

- backend テスト: 432 passed
- 変更対象 Python ファイルの Ruff check: passed
- 変更対象 Python ファイルの Ruff format check: passed
- compact projection の unit / MCP integration / REST 完全形維持テストを追加

全体 Ruff には今回の変更と無関係な既存違反が残っています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * MCP の Daily Timeline 応答を、必要な情報に絞ったコンパクト形式で提供するようになりました。
  * コンパクト形式では、不要なメタデータや空値、重複する時刻情報を省略します。
  * REST API では完全な標準形式のレスポンスを引き続き利用できます。

* **改善**
  * Daily Timeline の REST API と MCP で、入力検証とレスポンス契約を統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->