### PR TITLE
feat(mcp): hide timeline event ids from compact responses

### DIFF
--- a/docs/architecture/daily-timeline.md
+++ b/docs/architecture/daily-timeline.md
@@ -26,7 +26,7 @@ Backend は「事実の整列」と「判断材料の付与」までを責務と
 | REST API | `GET /v1/data/timeline/daily` |
 | MCP Tool | `get_daily_timeline` |
 
-REST API と MCP Tool は同じ入力制約、同じ canonical builder、同じ validation を使う。REST API は完全形、MCP Tool は表示上の重複と source 固有 metadata を省いた compact 表現を返す。
+REST API と MCP Tool は同じ入力制約、同じ canonical builder、同じ validation を使う。REST API は完全形、MCP Tool は表示上の重複と source 固有 metadata、event_id を省いた compact 表現を返す。
 
 公開契約は1日単位に固定する。時間窓指定や週次レビューが必要になった場合でも、この endpoint / tool の意味を広げず、別契約として追加する。
 ただし実装内部は UTC range を入力にした builder として構成し、将来の別契約でも正規化、ソート、correlation、gap 生成のロジックを再利用できるようにする。
@@ -105,16 +105,20 @@ timezone=Asia/Tokyo
 
 ### MCP compact 表現
 
-REST API の canonical response は以下の完全形を返す。MCP Tool はこの response を壊さずに構築したあと、呼び出し境界で次の compact 表現へ変換する。
+REST API の canonical response は完全形を返す。MCP Tool はこの response を構築したあと、呼び出し境界で次の compact 表現へ変換する。
 
+- `items[*].event_id` は返さない
+- `correlations[*].event_ids` は返さない
+- `gaps[*].preceded_by_event_id` / `followed_by_event_id` は返さない
 - `items[*].metadata` は返さない
 - `started_at_utc` / `started_at_local` は、要求された timezone の `started_at` に統合する
 - `ended_at_utc` / `ended_at_local` は、値がある場合だけ `ended_at` に統合する
 - `range` と `gaps` の時刻は要求された timezone の local 値だけを返す
 - `null`、空文字、空配列、空オブジェクトは省略する。`0` と `false` は保持する
 - `include_raw_refs=true` の場合の `raw_ref` は保持する
-- 空の配列・オブジェクトになったセクションは省略する
 - `meta.format` は `compact` になる
+
+内部の canonical response と REST API の `event_id` は変更しない。
 
 ```json
 {
@@ -126,7 +130,6 @@ REST API の canonical response は以下の完全形を返す。MCP Tool はこ
   },
   "items": [
     {
-      "event_id": "spotify:play:abc123",
       "started_at": "2026-06-28T09:12:03+09:00",
       "source": "spotify",
       "kind": "music_play",
@@ -434,6 +437,6 @@ Daily Timeline では以下を行わない。
 | Unit | Browser History と YouTube の correlation を生成できる |
 | Unit | `gap_minutes` 以上の `no_observed_events_gap` を生成できる |
 | Unit | Google Health を `daily_summaries` に置き、`items` に混ぜない |
-| Integration | REST API が完全形、MCP Tool が compact 表現を返す |
+| Integration | REST API が完全形、MCP Tool が event_id を省いた compact 表現を返す |
 | Integration | local parquet root 優先と R2 fallback が既存 path resolver と同じ規則で動く |
 | Contract | `items[*].raw_ref.dataset_id` が Dataset Catalog の `dataset_id` と一致する |

--- a/docs/architecture/daily-timeline.md
+++ b/docs/architecture/daily-timeline.md
@@ -26,7 +26,7 @@ Backend は「事実の整列」と「判断材料の付与」までを責務と
 | REST API | `GET /v1/data/timeline/daily` |
 | MCP Tool | `get_daily_timeline` |
 
-REST API と MCP Tool は同じ入力制約、同じ canonical builder、同じ validation を使う。REST API は完全形、MCP Tool は表示上の重複と source 固有 metadata、event_id を省いた compact 表現を返す。
+REST API と MCP Tool は同じ入力制約、同じ canonical builder、同じ validation を使う。REST API は完全形、MCP Tool は表示上の重複と source 固有 metadata、`items[*].event_id`、`correlations[*].event_ids`、`gaps[*].preceded_by_event_id` / `followed_by_event_id` を省いた compact 表現を返す。
 
 公開契約は1日単位に固定する。時間窓指定や週次レビューが必要になった場合でも、この endpoint / tool の意味を広げず、別契約として追加する。
 ただし実装内部は UTC range を入力にした builder として構成し、将来の別契約でも正規化、ソート、correlation、gap 生成のロジックを再利用できるようにする。
@@ -118,7 +118,7 @@ REST API の canonical response は完全形を返す。MCP Tool はこの respo
 - `include_raw_refs=true` の場合の `raw_ref` は保持する
 - `meta.format` は `compact` になる
 
-内部の canonical response と REST API の `event_id` は変更しない。
+内部の canonical response と REST API は、`items[*].event_id`、`correlations[*].event_ids`、`gaps[*].preceded_by_event_id` / `followed_by_event_id` を保持し、変更しない。
 
 ```json
 {
@@ -437,6 +437,6 @@ Daily Timeline では以下を行わない。
 | Unit | Browser History と YouTube の correlation を生成できる |
 | Unit | `gap_minutes` 以上の `no_observed_events_gap` を生成できる |
 | Unit | Google Health を `daily_summaries` に置き、`items` に混ぜない |
-| Integration | REST API が完全形、MCP Tool が event_id を省いた compact 表現を返す |
+| Integration | REST API が完全形、MCP Tool が `items[*].event_id`、`correlations[*].event_ids`、`gaps[*].preceded_by_event_id` / `followed_by_event_id` を省いた compact 表現を返す |
 | Integration | local parquet root 優先と R2 fallback が既存 path resolver と同じ規則で動く |
 | Contract | `items[*].raw_ref.dataset_id` が Dataset Catalog の `dataset_id` と一致する |

--- a/egograph/backend/domain/tools/timeline/compact.py
+++ b/egograph/backend/domain/tools/timeline/compact.py
@@ -12,6 +12,10 @@ def compact_daily_timeline(response: dict[str, Any]) -> dict[str, Any]:
     compact: dict[str, Any] = dict(response)
     compact["range"] = _compact_range(response.get("range"))
     compact["items"] = [_compact_item(item) for item in response.get("items", [])]
+    compact["correlations"] = [
+        _compact_correlation(correlation)
+        for correlation in response.get("correlations", [])
+    ]
     compact["gaps"] = [_compact_gap(gap) for gap in response.get("gaps", [])]
     compact["meta"] = {
         **(response.get("meta") or {}),
@@ -21,10 +25,9 @@ def compact_daily_timeline(response: dict[str, Any]) -> dict[str, Any]:
 
 
 def _compact_item(item: dict[str, Any]) -> dict[str, Any]:
-    """Timeline item の重複時刻・metadata・空値を省く。"""
+    """Timeline item の重複時刻・metadata・event_id・空値を省く。"""
     return _drop_empty(
         {
-            "event_id": item.get("event_id"),
             "started_at": item.get("started_at_local"),
             "ended_at": item.get("ended_at_local"),
             "source": item.get("source"),
@@ -34,6 +37,18 @@ def _compact_item(item: dict[str, Any]) -> dict[str, Any]:
             "subtitle": item.get("subtitle"),
             "url": item.get("url"),
             "raw_ref": item.get("raw_ref"),
+        }
+    )
+
+
+def _compact_correlation(correlation: dict[str, Any]) -> dict[str, Any]:
+    """Correlation からイベントID参照を省く。"""
+    return _drop_empty(
+        {
+            "correlation_id": correlation.get("correlation_id"),
+            "kind": correlation.get("kind"),
+            "confidence": correlation.get("confidence"),
+            "reason": correlation.get("reason"),
         }
     )
 
@@ -51,7 +66,7 @@ def _compact_range(time_range: dict[str, Any] | None) -> dict[str, Any]:
 
 
 def _compact_gap(gap: dict[str, Any]) -> dict[str, Any]:
-    """Gap の UTC/local 重複を省き、local 時刻を返す。"""
+    """Gap の UTC/local 重複とイベントID参照を省き、local 時刻を返す。"""
     return _drop_empty(
         {
             "gap_id": gap.get("gap_id"),
@@ -59,8 +74,6 @@ def _compact_gap(gap: dict[str, Any]) -> dict[str, Any]:
             "start": gap.get("start_local"),
             "end": gap.get("end_local"),
             "duration_minutes": gap.get("duration_minutes"),
-            "preceded_by_event_id": gap.get("preceded_by_event_id"),
-            "followed_by_event_id": gap.get("followed_by_event_id"),
         }
     )
 

--- a/egograph/backend/domain/tools/timeline/daily.py
+++ b/egograph/backend/domain/tools/timeline/daily.py
@@ -68,7 +68,9 @@ class GetDailyTimelineTool(ToolBase):
             "Google Health）の観測イベントを1日単位で時刻順に統合した"
             "タイムラインを取得します。Google Health は items には入らず"
             "daily_summaries に添付されます。MCPではmetadata、空値、"
-            "UTC/localの重複、event_idを省いたcompact形式で返します。"
+            "UTC/localの重複、items[*].event_id、correlations[*].event_ids、"
+            "gaps[*].preceded_by_event_id / followed_by_event_idを省いた"
+            "compact形式で返します。"
         )
 
     @property

--- a/egograph/backend/domain/tools/timeline/daily.py
+++ b/egograph/backend/domain/tools/timeline/daily.py
@@ -68,7 +68,7 @@ class GetDailyTimelineTool(ToolBase):
             "Google Health）の観測イベントを1日単位で時刻順に統合した"
             "タイムラインを取得します。Google Health は items には入らず"
             "daily_summaries に添付されます。MCPではmetadata、空値、"
-            "UTC/localの重複を省いたcompact形式で返します。"
+            "UTC/localの重複、event_idを省いたcompact形式で返します。"
         )
 
     @property

--- a/egograph/backend/tests/integration/test_timeline_api.py
+++ b/egograph/backend/tests/integration/test_timeline_api.py
@@ -480,6 +480,9 @@ class TestRestAndMcpContract:
         # generated_at は呼び出しごとに変わるため除外して比較
         rest_body["meta"].pop("generated_at", None)
         tool_body["meta"].pop("generated_at", None)
+        assert "event_id" in rest_body["items"][0]
+        assert "event_ids" in rest_body["correlations"][0]
+        assert "preceded_by_event_id" in rest_body["gaps"][0]
         assert rest_body == tool_body
 
     def test_rest_returns_400_on_invalid_date(self, tmp_path, test_client):
@@ -584,17 +587,18 @@ class TestMcpServerRegistration:
         assert payload["meta"]["format"] == "compact"
         assert set(payload["range"]) == {"start", "end"}
         for item in payload["items"]:
+            assert "event_id" not in item
             assert "metadata" not in item
             assert "started_at" in item
             assert "started_at_utc" not in item
             assert "started_at_local" not in item
             assert "raw_ref" in item
+        for correlation in payload.get("correlations", []):
+            assert "event_ids" not in correlation
         assert set(payload["gaps"][0]) == {
             "gap_id",
             "kind",
             "start",
             "end",
             "duration_minutes",
-            "preceded_by_event_id",
-            "followed_by_event_id",
         }

--- a/egograph/backend/tests/integration/test_timeline_api.py
+++ b/egograph/backend/tests/integration/test_timeline_api.py
@@ -483,6 +483,8 @@ class TestRestAndMcpContract:
         assert "event_id" in rest_body["items"][0]
         assert "event_ids" in rest_body["correlations"][0]
         assert "preceded_by_event_id" in rest_body["gaps"][0]
+        assert "followed_by_event_id" in rest_body["gaps"][0]
+        assert "followed_by_event_id" in tool_body["gaps"][0]
         assert rest_body == tool_body
 
     def test_rest_returns_400_on_invalid_date(self, tmp_path, test_client):
@@ -593,7 +595,12 @@ class TestMcpServerRegistration:
             assert "started_at_utc" not in item
             assert "started_at_local" not in item
             assert "raw_ref" in item
-        for correlation in payload.get("correlations", []):
+        assert payload["correlations"]
+        for correlation in payload["correlations"]:
+            assert "correlation_id" in correlation
+            assert "kind" in correlation
+            assert "confidence" in correlation
+            assert "reason" in correlation
             assert "event_ids" not in correlation
         assert set(payload["gaps"][0]) == {
             "gap_id",

--- a/egograph/backend/tests/unit/tools/timeline/test_compact.py
+++ b/egograph/backend/tests/unit/tools/timeline/test_compact.py
@@ -3,8 +3,8 @@
 from backend.domain.tools.timeline.compact import compact_daily_timeline
 
 
-def test_compact_daily_timeline_omits_metadata_empty_values_and_duplicate_times():
-    """metadata・空値・UTC/local重複を除き、有効なゼロ値を残す。"""
+def test_compact_daily_timeline_omits_metadata_ids_empty_values_and_duplicate_times():
+    """metadata・イベントID・空値・UTC/local重複を除き、有効なゼロ値を残す。"""
     response = {
         "date": "2026-06-28",
         "timezone": "Asia/Tokyo",
@@ -16,7 +16,7 @@ def test_compact_daily_timeline_omits_metadata_empty_values_and_duplicate_times(
         },
         "items": [
             {
-                "event_id": "spotify:play:p1",
+                "event_id": "spotify:play:sha256-64-chars",
                 "source": "spotify",
                 "kind": "music_play",
                 "started_at_utc": "2026-06-28T00:12:03Z",
@@ -30,7 +30,18 @@ def test_compact_daily_timeline_omits_metadata_empty_values_and_duplicate_times(
                 "metadata": {"track_id": "t1"},
             }
         ],
-        "correlations": [],
+        "correlations": [
+            {
+                "correlation_id": "corr_browser_history_youtube_001",
+                "kind": "same_activity_candidate",
+                "event_ids": [
+                    "browser_history:page_view:sha256-a",
+                    "youtube:watch_event:sha256-b",
+                ],
+                "confidence": 0.95,
+                "reason": "same_youtube_video_url_within_120_seconds",
+            }
+        ],
         "gaps": [
             {
                 "gap_id": "gap_1",
@@ -40,8 +51,8 @@ def test_compact_daily_timeline_omits_metadata_empty_values_and_duplicate_times(
                 "start_local": "2026-06-28T10:00:00+09:00",
                 "end_local": "2026-06-28T12:00:00+09:00",
                 "duration_minutes": 120,
-                "preceded_by_event_id": "spotify:play:p1",
-                "followed_by_event_id": "github:commit:c1",
+                "preceded_by_event_id": "spotify:play:sha256-a",
+                "followed_by_event_id": "github:commit:sha256-b",
             }
         ],
         "daily_summaries": {},
@@ -63,12 +74,19 @@ def test_compact_daily_timeline_omits_metadata_empty_values_and_duplicate_times(
         },
         "items": [
             {
-                "event_id": "spotify:play:p1",
                 "started_at": "2026-06-28T09:12:03+09:00",
                 "source": "spotify",
                 "kind": "music_play",
                 "duration_seconds": 0,
                 "title": "Song",
+            }
+        ],
+        "correlations": [
+            {
+                "correlation_id": "corr_browser_history_youtube_001",
+                "kind": "same_activity_candidate",
+                "confidence": 0.95,
+                "reason": "same_youtube_video_url_within_120_seconds",
             }
         ],
         "gaps": [
@@ -78,8 +96,6 @@ def test_compact_daily_timeline_omits_metadata_empty_values_and_duplicate_times(
                 "start": "2026-06-28T10:00:00+09:00",
                 "end": "2026-06-28T12:00:00+09:00",
                 "duration_minutes": 120,
-                "preceded_by_event_id": "spotify:play:p1",
-                "followed_by_event_id": "github:commit:c1",
             }
         ],
         "coverage": {
@@ -100,11 +116,11 @@ def test_compact_daily_timeline_preserves_raw_ref_when_requested():
     response = {
         "items": [
             {
-                "event_id": "spotify:play:p1",
+                "event_id": "spotify:play:sha256-64-chars",
                 "started_at_local": "2026-06-28T09:12:03+09:00",
                 "raw_ref": {
                     "dataset_id": "spotify.plays",
-                    "record_id": "p1",
+                    "record_id": "sha256-64-chars",
                     "timestamp_column": "played_at_utc",
                 },
                 "metadata": {"track_id": "t1"},
@@ -115,9 +131,10 @@ def test_compact_daily_timeline_preserves_raw_ref_when_requested():
 
     compact = compact_daily_timeline(response)
 
+    assert "event_id" not in compact["items"][0]
     assert compact["items"][0]["raw_ref"] == {
         "dataset_id": "spotify.plays",
-        "record_id": "p1",
+        "record_id": "sha256-64-chars",
         "timestamp_column": "played_at_utc",
     }
     assert "metadata" not in compact["items"][0]


### PR DESCRIPTION
## 概要

MCPの`get_daily_timeline` compactレスポンスから、内部イベントIDを表示しないようにします。

## 変更内容

- `items[*].event_id`をMCPレスポンスから除外
- `correlations[*].event_ids`を除外
- `gaps[*].preceded_by_event_id` / `followed_by_event_id`を除外
- canonical responseとREST APIの完全形、および内部イベントIDは変更しない
- 既存のmetadata・空値除外、TZごとの時刻compact化、`raw_ref`の明示要求時保持は維持
- 関連ドキュメントと単体・統合テストを更新

## 検証

- `432 passed`
- Ruff check / format check passed
- `git diff --check origin/main...HEAD` passed

前回のcompact化PR #185の後続変更です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Daily Timeline の MCP compact 表現で、関連情報（correlations）の概要を表示できるようになりました。
  - 出力を簡潔にするため、イベントやギャップに関する識別子を省略するようになりました。

- **ドキュメント**
  - REST API と MCP compact 表現における識別子の扱いを明確化しました。
  - REST API の標準レスポンス形式と内部データは変更ありません。

- **テスト**
  - REST API と MCP の出力内容、および識別子の表示ルールに関する検証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->