### PR TITLE
fix: bound Google Health rollup query duration

### DIFF
--- a/docs/data-sources/google-health.md
+++ b/docs/data-sources/google-health.md
@@ -84,9 +84,11 @@ APIレスポンス原本をRaw JSONとして保持し、日次指標、サンプ
 
 rollup問い合わせには、Google Health APIのdata typeごとに最大期間の制約がある。
 `calories-in-heart-rate-zone`、`heart-rate`、`active-minutes`、`total-calories`は
-最大14日、それ以外は最大90日である。さらに、1ページで取得する期間は
-`windowSize × pageSize`以下でなければならない。そのため、Extractorは期間を14日または
-90日以下へ分割するだけでなく、同じ上限に収まるようrollupの`pageSize`を計算する。
+最大14日、それ以外は最大90日である。さらに、1ページで取得する期間は、daily rollupでは
+`windowSizeDays × pageSize`、interval rollupでは`windowSize × pageSize`がそれぞれ最大期間
+以下でなければならない。そのため、Extractorは期間を14日または90日以下へ分割するだけで
+なく、同じ上限に収まるようrollupの`pageSize`を計算する。interval rollupの期間分割は、
+DSTを含むタイムゾーンでもUTC経過時間が上限を超えないようにする。
 reconcileのページサイズはこの制約とは別に管理する。
 
 ### 3.2 取得対象data type

--- a/docs/data-sources/google-health.md
+++ b/docs/data-sources/google-health.md
@@ -82,6 +82,13 @@ APIレスポンス原本をRaw JSONとして保持し、日次指標、サンプ
 期間フィルタに`exercise.interval.civil_start_time`とローカル日付を使用する。
 `sleep`だけは終了時刻を対象にするため、`sleep.interval.end_time`と物理時刻を使用する。
 
+rollup問い合わせには、Google Health APIのdata typeごとに最大期間の制約がある。
+`calories-in-heart-rate-zone`、`heart-rate`、`active-minutes`、`total-calories`は
+最大14日、それ以外は最大90日である。さらに、1ページで取得する期間は
+`windowSize × pageSize`以下でなければならない。そのため、Extractorは期間を14日または
+90日以下へ分割するだけでなく、同じ上限に収まるようrollupの`pageSize`を計算する。
+reconcileのページサイズはこの制約とは別に管理する。
+
 ### 3.2 取得対象data type
 
 #### Activity / Fitness

--- a/egograph/pipelines/sources/google_health/client.py
+++ b/egograph/pipelines/sources/google_health/client.py
@@ -313,6 +313,7 @@ class GoogleHealthAPIClient:
         *,
         date_from: date,
         date_to: date,
+        page_size: int,
         page_token: str | None = None,
     ) -> dict[str, Any]:
         """指定civil date範囲の日次rollupを取得する。"""
@@ -324,7 +325,7 @@ class GoogleHealthAPIClient:
                 "end": _civil_midnight(date_to),
             },
             "windowSizeDays": 1,
-            "pageSize": 10_000,
+            "pageSize": page_size,
         }
         if page_token:
             body["pageToken"] = page_token
@@ -344,6 +345,7 @@ class GoogleHealthAPIClient:
         date_from: date,
         date_to: date,
         window_size_seconds: int,
+        page_size: int,
         page_token: str | None = None,
     ) -> dict[str, Any]:
         """指定物理時間範囲を固定windowでrollupする。"""
@@ -355,7 +357,7 @@ class GoogleHealthAPIClient:
                 "endTime": local_date_start_rfc3339(date_to, self._timezone),
             },
             "windowSize": f"{window_size_seconds}s",
-            "pageSize": 10_000,
+            "pageSize": page_size,
         }
         if page_token:
             body["pageToken"] = page_token

--- a/egograph/pipelines/sources/google_health/extractor.py
+++ b/egograph/pipelines/sources/google_health/extractor.py
@@ -15,8 +15,9 @@ from pipelines.sources.google_health.data_types import (
 )
 from pipelines.sources.google_health.timezone import local_date_start_rfc3339
 
-DEFAULT_PAGE_SIZE = 10_000
+MAX_PAGE_SIZE = 10_000
 SESSION_PAGE_SIZE = 25
+SECONDS_PER_DAY = 24 * 60 * 60
 INTERVAL_ROLLUP_WINDOW_SECONDS = 300
 SHORT_ROLLUP_DATA_TYPES = {
     "active-minutes",
@@ -135,7 +136,7 @@ class GoogleHealthExtractor:
                 page_size=(
                     SESSION_PAGE_SIZE
                     if data_type.record_kind is RecordKind.SESSION
-                    else DEFAULT_PAGE_SIZE
+                    else MAX_PAGE_SIZE
                 ),
                 page_token=page_token,
             )
@@ -157,7 +158,11 @@ class GoogleHealthExtractor:
         date_to: date,
     ) -> list[dict[str, Any]]:
         responses: list[dict[str, Any]] = []
-        max_days = 14 if data_type.name in SHORT_ROLLUP_DATA_TYPES else 90
+        max_days = _max_rollup_days(data_type)
+        page_size = _rollup_page_size(
+            max_days=max_days,
+            window_size_seconds=SECONDS_PER_DAY,
+        )
         chunk_start = date_from
         while chunk_start < date_to:
             chunk_end = min(chunk_start + timedelta(days=max_days), date_to)
@@ -169,6 +174,7 @@ class GoogleHealthExtractor:
                     data_type.name,
                     date_from=chunk_start,
                     date_to=chunk_end,
+                    page_size=page_size,
                     page_token=page_token,
                 )
                 responses.append(response)
@@ -191,7 +197,11 @@ class GoogleHealthExtractor:
         date_to: date,
     ) -> list[dict[str, Any]]:
         responses: list[dict[str, Any]] = []
-        max_days = 14 if data_type.name in SHORT_ROLLUP_DATA_TYPES else 90
+        max_days = _max_rollup_days(data_type)
+        page_size = _rollup_page_size(
+            max_days=max_days,
+            window_size_seconds=INTERVAL_ROLLUP_WINDOW_SECONDS,
+        )
         chunk_start = date_from
         while chunk_start < date_to:
             chunk_end = min(chunk_start + timedelta(days=max_days), date_to)
@@ -204,6 +214,7 @@ class GoogleHealthExtractor:
                     date_from=chunk_start,
                     date_to=chunk_end,
                     window_size_seconds=INTERVAL_ROLLUP_WINDOW_SECONDS,
+                    page_size=page_size,
                     page_token=page_token,
                 )
                 responses.append(response)
@@ -216,6 +227,21 @@ class GoogleHealthExtractor:
                 page_token = next_page_token
             chunk_start = chunk_end
         return responses
+
+
+def _max_rollup_days(data_type: GoogleHealthDataType) -> int:
+    """data typeごとのrollup問い合わせ上限日数を返す。"""
+    return 14 if data_type.name in SHORT_ROLLUP_DATA_TYPES else 90
+
+
+def _rollup_page_size(*, max_days: int, window_size_seconds: int) -> int:
+    """APIの最大問い合わせ期間内に収まるrollup page sizeを返す。"""
+    if window_size_seconds <= 0:
+        raise ValueError("window_size_seconds must be positive")
+    max_windows = max_days * SECONDS_PER_DAY // window_size_seconds
+    if max_windows < 1:
+        raise ValueError("window_size_seconds exceeds rollup query duration")
+    return min(MAX_PAGE_SIZE, max_windows)
 
 
 def _build_filter(

--- a/egograph/pipelines/sources/google_health/extractor.py
+++ b/egograph/pipelines/sources/google_health/extractor.py
@@ -13,7 +13,10 @@ from pipelines.sources.google_health.data_types import (
     GoogleHealthDataType,
     RecordKind,
 )
-from pipelines.sources.google_health.timezone import local_date_start_rfc3339
+from pipelines.sources.google_health.timezone import (
+    local_date_start_rfc3339,
+    local_date_start_utc,
+)
 
 MAX_PAGE_SIZE = 10_000
 SESSION_PAGE_SIZE = 25
@@ -204,7 +207,12 @@ class GoogleHealthExtractor:
         )
         chunk_start = date_from
         while chunk_start < date_to:
-            chunk_end = min(chunk_start + timedelta(days=max_days), date_to)
+            chunk_end = _interval_rollup_chunk_end(
+                chunk_start=chunk_start,
+                date_to=date_to,
+                max_days=max_days,
+                timezone=self._timezone,
+            )
             page_token: str | None = None
             seen_page_tokens: set[str] = set()
             while True:
@@ -232,6 +240,27 @@ class GoogleHealthExtractor:
 def _max_rollup_days(data_type: GoogleHealthDataType) -> int:
     """data typeごとのrollup問い合わせ上限日数を返す。"""
     return 14 if data_type.name in SHORT_ROLLUP_DATA_TYPES else 90
+
+
+def _interval_rollup_chunk_end(
+    *,
+    chunk_start: date,
+    date_to: date,
+    max_days: int,
+    timezone: ZoneInfo,
+) -> date:
+    """物理時間rollupのUTC経過時間上限を超えない日付境界を返す。"""
+    chunk_end = min(chunk_start + timedelta(days=max_days), date_to)
+    start_utc = local_date_start_utc(chunk_start, timezone)
+    max_duration = timedelta(days=max_days)
+    while (
+        chunk_end > chunk_start
+        and local_date_start_utc(chunk_end, timezone) - start_utc > max_duration
+    ):
+        chunk_end -= timedelta(days=1)
+    if chunk_end == chunk_start:
+        raise ValueError("local date boundary exceeds rollup query duration")
+    return chunk_end
 
 
 def _rollup_page_size(*, max_days: int, window_size_seconds: int) -> int:

--- a/egograph/pipelines/tests/unit/google_health/test_client.py
+++ b/egograph/pipelines/tests/unit/google_health/test_client.py
@@ -124,6 +124,7 @@ def test_daily_rollup_sends_closed_open_civil_range(tmp_path):
         "steps",
         date_from=date(2026, 6, 1),
         date_to=date(2026, 6, 3),
+        page_size=14,
     )
 
     # Assert
@@ -134,6 +135,7 @@ def test_daily_rollup_sends_closed_open_civil_range(tmp_path):
         "day": 1,
     }
     assert body["range"]["end"]["date"]["day"] == 3
+    assert body["pageSize"] == 14
     assert "dataSourceFamily" not in body
 
 
@@ -151,6 +153,7 @@ def test_rollup_sends_physical_range_and_window(tmp_path):
         date_from=date(2026, 6, 1),
         date_to=date(2026, 6, 3),
         window_size_seconds=300,
+        page_size=4032,
     )
 
     # Assert
@@ -160,6 +163,7 @@ def test_rollup_sends_physical_range_and_window(tmp_path):
         "endTime": "2026-06-03T00:00:00Z",
     }
     assert body["windowSize"] == "300s"
+    assert body["pageSize"] == 4032
     assert "dataSourceFamily" not in body
 
 
@@ -182,6 +186,7 @@ def test_rollup_uses_configured_timezone_boundary(tmp_path):
         date_from=date(2026, 6, 1),
         date_to=date(2026, 6, 2),
         window_size_seconds=300,
+        page_size=4032,
     )
 
     # Assert

--- a/egograph/pipelines/tests/unit/google_health/test_extractor.py
+++ b/egograph/pipelines/tests/unit/google_health/test_extractor.py
@@ -1,15 +1,18 @@
 """Google Health extractorのテスト。"""
 
-from datetime import date
+from datetime import date, timedelta
 from zoneinfo import ZoneInfo
 
 import pytest
 from pipelines.sources.google_health.data_types import DATA_TYPE_BY_NAME
 from pipelines.sources.google_health.extractor import (
+    SECONDS_PER_DAY,
     GoogleHealthExtractor,
     _build_filter,
+    _max_rollup_days,
     _rollup_page_size,
 )
+from pipelines.sources.google_health.timezone import local_date_start_utc
 
 
 class FakeClient:
@@ -98,18 +101,23 @@ def test_short_daily_rollup_is_split_into_fourteen_day_ranges():
 
 
 @pytest.mark.parametrize(
-    ("max_days", "window_size_seconds", "expected_page_size"),
+    ("data_type_name", "expected_max_days"),
     [
-        (14, 86_400, 14),
-        (90, 86_400, 90),
-        (14, 300, 4_032),
-        (90, 300, 10_000),
+        ("active-minutes", 14),
+        ("calories-in-heart-rate-zone", 14),
+        ("heart-rate", 14),
+        ("total-calories", 14),
+        ("steps", 90),
     ],
 )
+@pytest.mark.parametrize("window_size_seconds", [SECONDS_PER_DAY, 300])
 def test_rollup_page_size_stays_within_google_query_duration(
-    max_days, window_size_seconds, expected_page_size
+    data_type_name, expected_max_days, window_size_seconds
 ):
-    """rollupの1ページ期間がdata typeごとのAPI上限を超えない。"""
+    """全rollup対象data typeの1ページ期間がAPI上限を超えない。"""
+    # Arrange
+    max_days = _max_rollup_days(DATA_TYPE_BY_NAME[data_type_name])
+
     # Act
     page_size = _rollup_page_size(
         max_days=max_days,
@@ -117,8 +125,44 @@ def test_rollup_page_size_stays_within_google_query_duration(
     )
 
     # Assert
-    assert page_size == expected_page_size
-    assert page_size * window_size_seconds <= max_days * 86_400
+    assert max_days == expected_max_days
+    assert page_size == min(
+        10_000,
+        max_days * SECONDS_PER_DAY // window_size_seconds,
+    )
+    assert page_size * window_size_seconds <= max_days * SECONDS_PER_DAY
+
+
+def test_interval_rollup_chunk_respects_utc_duration_at_dst_fallback():
+    """DST終了日を含むinterval rollupはUTC経過時間で分割する。"""
+    # Arrange
+    client = FakeClient()
+    timezone = ZoneInfo("America/New_York")
+    chunk_start = date(2025, 10, 27)
+    date_to = date(2025, 11, 11)
+    extractor = GoogleHealthExtractor(client, timezone=timezone)
+
+    # Act
+    extractor.extract(
+        connection_id="connection-1",
+        data_type=DATA_TYPE_BY_NAME["calories-in-heart-rate-zone"],
+        date_from=chunk_start,
+        date_to=date_to,
+    )
+
+    # Assert
+    interval_ranges = [
+        (call[1]["date_from"], call[1]["date_to"])
+        for call in client.interval_rollup_calls
+    ]
+    assert interval_ranges == [
+        (date(2025, 10, 27), date(2025, 11, 9)),
+        (date(2025, 11, 9), date(2025, 11, 11)),
+    ]
+    for interval_start, interval_end in interval_ranges:
+        assert local_date_start_utc(interval_end, timezone) - local_date_start_utc(
+            interval_start, timezone
+        ) <= timedelta(days=14)
 
 
 def test_daily_filter_uses_proto_field_name():

--- a/egograph/pipelines/tests/unit/google_health/test_extractor.py
+++ b/egograph/pipelines/tests/unit/google_health/test_extractor.py
@@ -8,6 +8,7 @@ from pipelines.sources.google_health.data_types import DATA_TYPE_BY_NAME
 from pipelines.sources.google_health.extractor import (
     GoogleHealthExtractor,
     _build_filter,
+    _rollup_page_size,
 )
 
 
@@ -59,6 +60,7 @@ def test_extract_follows_pagination_and_collects_daily_rollup():
     )
     assert len(result.payload["reconcileResponses"]) == 2
     assert len(result.payload["dailyRollupResponses"]) == 1
+    assert client.rollup_calls[0][1]["page_size"] == 90
     assert result.record_count == 3
 
 
@@ -91,6 +93,32 @@ def test_short_daily_rollup_is_split_into_fourteen_day_ranges():
     assert [
         (call[1]["date_from"], call[1]["date_to"]) for call in client.rollup_calls
     ] == expected_ranges
+    assert {call[1]["page_size"] for call in client.interval_rollup_calls} == {4032}
+    assert {call[1]["page_size"] for call in client.rollup_calls} == {14}
+
+
+@pytest.mark.parametrize(
+    ("max_days", "window_size_seconds", "expected_page_size"),
+    [
+        (14, 86_400, 14),
+        (90, 86_400, 90),
+        (14, 300, 4_032),
+        (90, 300, 10_000),
+    ],
+)
+def test_rollup_page_size_stays_within_google_query_duration(
+    max_days, window_size_seconds, expected_page_size
+):
+    """rollupの1ページ期間がdata typeごとのAPI上限を超えない。"""
+    # Act
+    page_size = _rollup_page_size(
+        max_days=max_days,
+        window_size_seconds=window_size_seconds,
+    )
+
+    # Assert
+    assert page_size == expected_page_size
+    assert page_size * window_size_seconds <= max_days * 86_400
 
 
 def test_daily_filter_uses_proto_field_name():


### PR DESCRIPTION
## 概要

Google Health APIのrollup問い合わせで、`INVALID_ROLLUP_QUERY_DURATION`が発生する問題を修正しました。

## 原因

`dailyRollUp` / `rollUp` の`pageSize`が10,000件で固定されていました。

- daily rollup: 1日 × 10,000件
- 300秒間隔のrollup: 300秒 × 10,000件

Google Health APIのdata typeごとの最大問い合わせ期間を超えるため、HTTP 400が返されていました。

## 修正内容

- data typeごとの14日 / 90日制限に合わせてrollupの`pageSize`を計算
- daily rollupとinterval rollupの双方に適用
- reconcileのページサイズは変更しない
- 問い合わせ制約をドキュメント化
- 期間とページサイズの計算テストを追加

## 検証

- Google Health unit / integration tests: 84 passed
- ruff check: passed
- ruff format --check: passed

R2 / オブジェクトストレージ側の処理は今回のPRの対象外です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Google Healthのロールアップ取得で、データ種別に応じた期間上限を適用しました。
  * 長期間のデータは自動的に分割して取得します。
  * 取得期間と時間窓に応じてページサイズを調整し、安定したデータ取得を実現しました。
* **ドキュメント**
  * ロールアップの期間制約とページサイズ制約を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->